### PR TITLE
Mantis 04: evidence-first observation and analog pipeline (#19)

### DIFF
--- a/projects/biomemetics/labs/mantis/analogs/README.md
+++ b/projects/biomemetics/labs/mantis/analogs/README.md
@@ -6,3 +6,9 @@ An analog is a relationship with provenance, not identity. A terrarium latch,
 rail carriage, robotic joint, or sensing system may cite a biological mechanism
 without claiming that the engineered implementation reproduces the organism.
 
+Schema: `analog.schema.json`. Committed catalog: `catalog.json` (empty until a
+Function exists). Direction is biology-to-engineering; `equivalent` is always
+false. Governed projection (`src/projection.ts`) plans SpecimenDB Attach tags
+from PR 33 as read-only (`executable: false`, `storeWrite: false`) and does
+not call a store.
+

--- a/projects/biomemetics/labs/mantis/analogs/analog.schema.json
+++ b/projects/biomemetics/labs/mantis/analogs/analog.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:specimendb:biomemetics:mantis:analogs:analog-catalog:v1",
+  "title": "Mantis analog catalog",
+  "description": "Directional biology-to-engineering mappings. Empty unless a Function exists. An analog is a relationship with limits, not identity.",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "kind",
+    "workspaceRef",
+    "catalogSpecimen",
+    "records"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "kind": {
+      "const": "AnalogCatalog"
+    },
+    "workspaceRef": {
+      "const": "biomemetics.mantis"
+    },
+    "catalogSpecimen": {
+      "const": false
+    },
+    "records": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/analog"
+      }
+    }
+  },
+  "unevaluatedProperties": false,
+  "$defs": {
+    "review": {
+      "$ref": "../observations/observation.schema.json#/$defs/review"
+    },
+    "analog": {
+      "type": "object",
+      "required": [
+        "schemaVersion",
+        "kind",
+        "analogId",
+        "functionRef",
+        "workspaceRef",
+        "target",
+        "direction",
+        "equivalent",
+        "limit",
+        "nonEquivalence",
+        "review"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "1.0.0"
+        },
+        "kind": {
+          "const": "AnalogLink"
+        },
+        "analogId": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9.-]*$"
+        },
+        "functionRef": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9.-]*$"
+        },
+        "workspaceRef": {
+          "const": "biomemetics.mantis"
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "direction": {
+          "const": "biology-to-engineering"
+        },
+        "equivalent": {
+          "const": false
+        },
+        "limit": {
+          "type": "string",
+          "minLength": 1
+        },
+        "nonEquivalence": {
+          "type": "string",
+          "minLength": 1
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1
+        },
+        "review": {
+          "$ref": "#/$defs/review"
+        }
+      },
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/analogs/catalog.json
+++ b/projects/biomemetics/labs/mantis/analogs/catalog.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./analog.schema.json",
+  "schemaVersion": "1.0.0",
+  "kind": "AnalogCatalog",
+  "workspaceRef": "biomemetics.mantis",
+  "catalogSpecimen": false,
+  "records": []
+}

--- a/projects/biomemetics/labs/mantis/analogs/package.json
+++ b/projects/biomemetics/labs/mantis/analogs/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@tmnl/mantis-analogs",
+  "private": true,
+  "type": "module"
+}

--- a/projects/biomemetics/labs/mantis/analogs/src/analog.ts
+++ b/projects/biomemetics/labs/mantis/analogs/src/analog.ts
@@ -1,0 +1,42 @@
+import {
+  SCHEMA_VERSION,
+  WORKSPACE_REF,
+  type AnalogLink,
+  type BiologicalFunction,
+} from '../../observations/src/types.ts';
+import { PipelineRefused } from '../../observations/src/types.ts';
+import { validateAnalog } from '../../observations/src/validate.ts';
+
+export interface AnalogDraft {
+  readonly analogId: string;
+  readonly target: string;
+  readonly limit: string;
+  readonly nonEquivalence: string;
+  readonly note?: string;
+  readonly review: AnalogLink['review'];
+}
+
+export const deriveAnalog = (
+  fn: BiologicalFunction | undefined,
+  draft: AnalogDraft,
+): AnalogLink => {
+  const record = {
+    schemaVersion: SCHEMA_VERSION,
+    kind: 'AnalogLink' as const,
+    analogId: draft.analogId,
+    functionRef: fn?.functionId ?? '',
+    workspaceRef: WORKSPACE_REF,
+    target: draft.target,
+    direction: 'biology-to-engineering' as const,
+    equivalent: false as const,
+    limit: draft.limit,
+    nonEquivalence: draft.nonEquivalence,
+    ...(draft.note === undefined ? {} : { note: draft.note }),
+    review: draft.review,
+  };
+  const validated = validateAnalog(record, fn);
+  if (!validated.valid || validated.value === undefined) {
+    throw new PipelineRefused(validated.reasons);
+  }
+  return validated.value;
+};

--- a/projects/biomemetics/labs/mantis/analogs/src/projection.ts
+++ b/projects/biomemetics/labs/mantis/analogs/src/projection.ts
@@ -1,0 +1,150 @@
+import {
+  AttachRpcContract,
+  LOCAL_EVIDENCE_RECORD_REF,
+  localEvidenceRef,
+  type AnalogLink,
+  type BiologicalFunction,
+  type ComponentProjection,
+  type GovernedProjectionPlan,
+  type Mechanism,
+  type Observation,
+  type ProjectionProvenance,
+  type RefusalReason,
+  type Structure,
+} from '../../observations/src/types.ts';
+import { PipelineRefused } from '../../observations/src/types.ts';
+import {
+  refuseLabAsSpecimen,
+  reviewIsAccepted as reviewOk,
+} from '../../observations/src/validate.ts';
+
+export { AttachRpcContract, localEvidenceRef };
+
+export interface ProjectionInput {
+  readonly observation: Observation;
+  readonly structure?: Structure;
+  readonly mechanism?: Mechanism;
+  readonly fn?: BiologicalFunction;
+  readonly analog?: AnalogLink;
+  readonly gitSha: string;
+  readonly runId: string;
+  readonly specimenId?: string;
+  readonly caller?: unknown;
+}
+
+const sourceClassFor = (
+  observation: Observation,
+): 'observed' | 'measured' =>
+  (observation.measurements?.length ?? 0) > 0 ? 'measured' : 'observed';
+
+const provenanceFor = (
+  observation: Observation,
+  evidenceRef: string,
+  claimRef: string,
+): ProjectionProvenance => {
+  const review = observation.review;
+  return {
+    evidenceId: observation.observationId,
+    evidenceRef,
+    claimRefs: [claimRef],
+    sourceClass: sourceClassFor(observation),
+    recordedAt: observation.recordedAt,
+    inputRefs: [
+      {
+        ref: observation.media.path,
+        role: 'source-media',
+        sha256: observation.media.sha256,
+      },
+    ],
+    observationSourceRefs: observation.statements
+      .map((statement) => statement.sourceRef)
+      .filter((ref): ref is string => ref !== undefined && ref.trim() !== ''),
+    artifactRefs: [
+      {
+        path: observation.media.path,
+        mediaType: observation.media.mediaType,
+        sha256: observation.media.sha256,
+      },
+    ],
+    review: {
+      reviewer: review.reviewer as string,
+      reviewedAt: review.reviewedAt as string,
+    },
+  };
+};
+
+/**
+ * Thin governed projection. Mirrors PR 33 Attach payload tags. Never writes a
+ * store, never inserts a Specimen, never mutates locality or taxon.
+ */
+export const planGovernedProjection = (
+  input: ProjectionInput,
+): GovernedProjectionPlan => {
+  const reasons: RefusalReason[] = refuseLabAsSpecimen(input.specimenId);
+  const evidenceRef = localEvidenceRef(input.gitSha, input.runId);
+  if (!LOCAL_EVIDENCE_RECORD_REF.test(evidenceRef)) {
+    reasons.push('evidence-not-local-run');
+  }
+
+  const observationReview = reviewOk(input.observation.review);
+  if (!observationReview) reasons.push('unverified-evidence');
+
+  if (reasons.length > 0) throw new PipelineRefused([...new Set(reasons)]);
+
+  const projections: ComponentProjection[] = [];
+  const claim = `claim:${input.observation.observationId}`;
+  const provenance = provenanceFor(input.observation, evidenceRef, claim);
+  const observedText = input.observation.statements.find(
+    (statement) => statement.status === 'observed',
+  )?.text;
+  if (observedText !== undefined) {
+    projections.push({
+      component: { _tag: 'Observation', text: observedText },
+      provenance,
+    });
+  }
+  if (input.structure !== undefined && reviewOk(input.structure.review)) {
+    projections.push({
+      component: { _tag: 'Structure', text: input.structure.description },
+      provenance: { ...provenance, claimRefs: [`${claim}:structure`] },
+    });
+  }
+  if (input.mechanism !== undefined && reviewOk(input.mechanism.review)) {
+    projections.push({
+      component: { _tag: 'Mechanism', text: input.mechanism.hypothesis },
+      provenance: { ...provenance, claimRefs: [`${claim}:mechanism`] },
+    });
+  }
+  if (input.fn !== undefined && reviewOk(input.fn.review)) {
+    projections.push({
+      component: { _tag: 'Function', text: input.fn.statement },
+      provenance: { ...provenance, claimRefs: [`${claim}:function`] },
+    });
+  }
+  if (input.analog !== undefined && reviewOk(input.analog.review)) {
+    projections.push({
+      component: {
+        _tag: 'AnalogLink',
+        target: input.analog.target,
+        ...(input.analog.note === undefined ? {} : { note: input.analog.note }),
+      },
+      provenance: { ...provenance, claimRefs: [`${claim}:analog`] },
+    });
+  }
+
+  const blockers: GovernedProjectionPlan['blockers'] =
+    projections.length === 0
+      ? ['specimendb-attach-unavailable', 'no-admissible-evidence']
+      : ['specimendb-attach-unavailable'];
+
+  return {
+    projections,
+    executable: false,
+    storeWrite: false,
+    localityMutated: false,
+    taxonMutated: false,
+    blocker: 'specimendb-attach-unavailable',
+    blockers,
+    evidenceRef,
+  };
+};

--- a/projects/biomemetics/labs/mantis/mechanisms/README.md
+++ b/projects/biomemetics/labs/mantis/mechanisms/README.md
@@ -7,3 +7,7 @@ cited support. Engineered hypotheses stay separate from biological findings.
 Each mechanism should include states, moving and grounded members, forces or
 travel where known, failure modes, and a verification plan.
 
+Schemas: `mechanism.schema.json`, `function.schema.json`. Committed catalogs:
+`catalog.json` and `functions.json` (empty until a Structure exists). Mechanism
+and function stay `interpreted` or `unverified`; they are not observed facts.
+

--- a/projects/biomemetics/labs/mantis/mechanisms/catalog.json
+++ b/projects/biomemetics/labs/mantis/mechanisms/catalog.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./mechanism.schema.json",
+  "schemaVersion": "1.0.0",
+  "kind": "MechanismCatalog",
+  "workspaceRef": "biomemetics.mantis",
+  "catalogSpecimen": false,
+  "records": []
+}

--- a/projects/biomemetics/labs/mantis/mechanisms/function.schema.json
+++ b/projects/biomemetics/labs/mantis/mechanisms/function.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:specimendb:biomemetics:mantis:mechanisms:function-catalog:v1",
+  "title": "Mantis function catalog",
+  "description": "Interpreted functions bound to mechanism hypotheses. Empty unless a Mechanism exists. Function is not observed structure.",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "kind",
+    "workspaceRef",
+    "catalogSpecimen",
+    "records"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "kind": {
+      "const": "FunctionCatalog"
+    },
+    "workspaceRef": {
+      "const": "biomemetics.mantis"
+    },
+    "catalogSpecimen": {
+      "const": false
+    },
+    "records": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/function"
+      }
+    }
+  },
+  "unevaluatedProperties": false,
+  "$defs": {
+    "review": {
+      "$ref": "../observations/observation.schema.json#/$defs/review"
+    },
+    "function": {
+      "type": "object",
+      "required": [
+        "schemaVersion",
+        "kind",
+        "functionId",
+        "mechanismRef",
+        "workspaceRef",
+        "statement",
+        "status",
+        "limits",
+        "review"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "1.0.0"
+        },
+        "kind": {
+          "const": "Function"
+        },
+        "functionId": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9.-]*$"
+        },
+        "mechanismRef": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9.-]*$"
+        },
+        "workspaceRef": {
+          "const": "biomemetics.mantis"
+        },
+        "statement": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "enum": ["interpreted", "unverified"]
+        },
+        "limits": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "review": {
+          "$ref": "#/$defs/review"
+        }
+      },
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/mechanisms/functions.json
+++ b/projects/biomemetics/labs/mantis/mechanisms/functions.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./function.schema.json",
+  "schemaVersion": "1.0.0",
+  "kind": "FunctionCatalog",
+  "workspaceRef": "biomemetics.mantis",
+  "catalogSpecimen": false,
+  "records": []
+}

--- a/projects/biomemetics/labs/mantis/mechanisms/mechanism.schema.json
+++ b/projects/biomemetics/labs/mantis/mechanisms/mechanism.schema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:specimendb:biomemetics:mantis:mechanisms:mechanism-catalog:v1",
+  "title": "Mantis mechanism catalog",
+  "description": "Falsifiable mechanism hypotheses bound to structures. Empty unless a Structure exists. Engineered ideas do not become biological findings.",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "kind",
+    "workspaceRef",
+    "catalogSpecimen",
+    "records"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "kind": {
+      "const": "MechanismCatalog"
+    },
+    "workspaceRef": {
+      "const": "biomemetics.mantis"
+    },
+    "catalogSpecimen": {
+      "const": false
+    },
+    "records": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/mechanism"
+      }
+    }
+  },
+  "unevaluatedProperties": false,
+  "$defs": {
+    "review": {
+      "$ref": "../observations/observation.schema.json#/$defs/review"
+    },
+    "mechanism": {
+      "type": "object",
+      "required": [
+        "schemaVersion",
+        "kind",
+        "mechanismId",
+        "structureRef",
+        "workspaceRef",
+        "hypothesis",
+        "falsifier",
+        "status",
+        "states",
+        "members",
+        "failureModes",
+        "verificationPlan",
+        "review"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "1.0.0"
+        },
+        "kind": {
+          "const": "Mechanism"
+        },
+        "mechanismId": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9.-]*$"
+        },
+        "structureRef": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9.-]*$"
+        },
+        "workspaceRef": {
+          "const": "biomemetics.mantis"
+        },
+        "hypothesis": {
+          "type": "string",
+          "minLength": 1
+        },
+        "falsifier": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "enum": ["interpreted", "unverified"]
+        },
+        "states": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "members": {
+          "type": "object",
+          "required": ["moving", "grounded"],
+          "properties": {
+            "moving": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "grounded": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "unevaluatedProperties": false
+        },
+        "failureModes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "verificationPlan": {
+          "type": "string",
+          "minLength": 1
+        },
+        "review": {
+          "$ref": "#/$defs/review"
+        }
+      },
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/mechanisms/package.json
+++ b/projects/biomemetics/labs/mantis/mechanisms/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@tmnl/mantis-mechanisms",
+  "private": true,
+  "type": "module"
+}

--- a/projects/biomemetics/labs/mantis/mechanisms/src/mechanism.ts
+++ b/projects/biomemetics/labs/mantis/mechanisms/src/mechanism.ts
@@ -1,0 +1,80 @@
+import {
+  SCHEMA_VERSION,
+  WORKSPACE_REF,
+  type BiologicalFunction,
+  type Mechanism,
+  type Structure,
+} from '../../observations/src/types.ts';
+import { PipelineRefused } from '../../observations/src/types.ts';
+import {
+  validateFunction,
+  validateMechanism,
+} from '../../observations/src/validate.ts';
+
+export interface MechanismDraft {
+  readonly mechanismId: string;
+  readonly hypothesis: string;
+  readonly falsifier: string;
+  readonly status: Mechanism['status'];
+  readonly states: readonly string[];
+  readonly members: Mechanism['members'];
+  readonly failureModes: readonly string[];
+  readonly verificationPlan: string;
+  readonly review: Mechanism['review'];
+}
+
+export interface FunctionDraft {
+  readonly functionId: string;
+  readonly statement: string;
+  readonly status: BiologicalFunction['status'];
+  readonly limits: readonly string[];
+  readonly review: BiologicalFunction['review'];
+}
+
+export const deriveMechanism = (
+  structure: Structure | undefined,
+  draft: MechanismDraft,
+): Mechanism => {
+  const record = {
+    schemaVersion: SCHEMA_VERSION,
+    kind: 'Mechanism' as const,
+    mechanismId: draft.mechanismId,
+    structureRef: structure?.structureId ?? '',
+    workspaceRef: WORKSPACE_REF,
+    hypothesis: draft.hypothesis,
+    falsifier: draft.falsifier,
+    status: draft.status,
+    states: draft.states,
+    members: draft.members,
+    failureModes: draft.failureModes,
+    verificationPlan: draft.verificationPlan,
+    review: draft.review,
+  };
+  const validated = validateMechanism(record, structure);
+  if (!validated.valid || validated.value === undefined) {
+    throw new PipelineRefused(validated.reasons);
+  }
+  return validated.value;
+};
+
+export const deriveFunction = (
+  mechanism: Mechanism | undefined,
+  draft: FunctionDraft,
+): BiologicalFunction => {
+  const record = {
+    schemaVersion: SCHEMA_VERSION,
+    kind: 'Function' as const,
+    functionId: draft.functionId,
+    mechanismRef: mechanism?.mechanismId ?? '',
+    workspaceRef: WORKSPACE_REF,
+    statement: draft.statement,
+    status: draft.status,
+    limits: draft.limits,
+    review: draft.review,
+  };
+  const validated = validateFunction(record, mechanism);
+  if (!validated.valid || validated.value === undefined) {
+    throw new PipelineRefused(validated.reasons);
+  }
+  return validated.value;
+};

--- a/projects/biomemetics/labs/mantis/morphology/README.md
+++ b/projects/biomemetics/labs/mantis/morphology/README.md
@@ -6,3 +6,7 @@ basis as `observed`, `measured`, `calculated`, `simulated`, `ref`, `target`,
 `typ`, or `unverified`.
 
 Taxonomic interpretation remains optional and explicitly qualified.
+
+Schema: `structure.schema.json`. Committed catalog: `catalog.json` (empty until
+an Observation exists). A structure cannot be `observed` without a bound
+observation.

--- a/projects/biomemetics/labs/mantis/morphology/catalog.json
+++ b/projects/biomemetics/labs/mantis/morphology/catalog.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./structure.schema.json",
+  "schemaVersion": "1.0.0",
+  "kind": "StructureCatalog",
+  "workspaceRef": "biomemetics.mantis",
+  "catalogSpecimen": false,
+  "records": []
+}

--- a/projects/biomemetics/labs/mantis/morphology/package.json
+++ b/projects/biomemetics/labs/mantis/morphology/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@tmnl/mantis-morphology",
+  "private": true,
+  "type": "module"
+}

--- a/projects/biomemetics/labs/mantis/morphology/src/structure.ts
+++ b/projects/biomemetics/labs/mantis/morphology/src/structure.ts
@@ -1,0 +1,31 @@
+import { SCHEMA_VERSION, WORKSPACE_REF, type Observation, type Structure } from '../../observations/src/types.ts';
+import { PipelineRefused } from '../../observations/src/types.ts';
+import { validateStructure } from '../../observations/src/validate.ts';
+
+export interface StructureDraft {
+  readonly structureId: string;
+  readonly basis: Structure['basis'];
+  readonly description: string;
+  readonly review: Structure['review'];
+}
+
+export const deriveStructure = (
+  observation: Observation | undefined,
+  draft: StructureDraft,
+): Structure => {
+  const record = {
+    schemaVersion: SCHEMA_VERSION,
+    kind: 'Structure' as const,
+    structureId: draft.structureId,
+    observationRef: observation?.observationId ?? '',
+    workspaceRef: WORKSPACE_REF,
+    basis: draft.basis,
+    description: draft.description,
+    review: draft.review,
+  };
+  const validated = validateStructure(record, observation);
+  if (!validated.valid || validated.value === undefined) {
+    throw new PipelineRefused(validated.reasons);
+  }
+  return validated.value;
+};

--- a/projects/biomemetics/labs/mantis/morphology/structure.schema.json
+++ b/projects/biomemetics/labs/mantis/morphology/structure.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:specimendb:biomemetics:mantis:morphology:structure-catalog:v1",
+  "title": "Mantis morphology catalog",
+  "description": "Structures derived from reviewed observations. Empty unless an Observation exists. Unseen geometry is not representable as observed.",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "kind",
+    "workspaceRef",
+    "catalogSpecimen",
+    "records"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "kind": {
+      "const": "StructureCatalog"
+    },
+    "workspaceRef": {
+      "const": "biomemetics.mantis"
+    },
+    "catalogSpecimen": {
+      "const": false
+    },
+    "records": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/structure"
+      }
+    }
+  },
+  "unevaluatedProperties": false,
+  "$defs": {
+    "review": {
+      "$ref": "../observations/observation.schema.json#/$defs/review"
+    },
+    "structure": {
+      "type": "object",
+      "required": [
+        "schemaVersion",
+        "kind",
+        "structureId",
+        "observationRef",
+        "workspaceRef",
+        "basis",
+        "description",
+        "review"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "1.0.0"
+        },
+        "kind": {
+          "const": "Structure"
+        },
+        "structureId": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9.-]*$"
+        },
+        "observationRef": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9.-]*$"
+        },
+        "workspaceRef": {
+          "const": "biomemetics.mantis"
+        },
+        "basis": {
+          "enum": [
+            "observed",
+            "measured",
+            "calculated",
+            "simulated",
+            "ref",
+            "target",
+            "typ",
+            "unverified"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "review": {
+          "$ref": "#/$defs/review"
+        }
+      },
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/observations/README.md
+++ b/projects/biomemetics/labs/mantis/observations/README.md
@@ -8,3 +8,8 @@ measurement supports that separate claim. Media intended for SpecimenDB enters
 through its normal intake path; this directory stores workspace-side analysis
 and evidence references, not fabricated specimen records.
 
+Schema: `observation.schema.json`. Committed catalog: `catalog.json` (empty;
+taxon unknown because no real media is present). Pipeline entry:
+`src/pipeline.ts`. Drop media in `media/` with a provenance sidecar; do not
+invent GPS, locality, or taxon.
+

--- a/projects/biomemetics/labs/mantis/observations/catalog.json
+++ b/projects/biomemetics/labs/mantis/observations/catalog.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "./observation.schema.json",
+  "schemaVersion": "1.0.0",
+  "kind": "ObservationCatalog",
+  "workspaceRef": "biomemetics.mantis",
+  "catalogSpecimen": false,
+  "taxon": {
+    "status": "unknown",
+    "reason": "no-real-media"
+  },
+  "records": []
+}

--- a/projects/biomemetics/labs/mantis/observations/media/README.md
+++ b/projects/biomemetics/labs/mantis/observations/media/README.md
@@ -1,0 +1,9 @@
+# Observation media
+
+Drop real source media here with a sibling `<filename>.provenance.json`.
+
+Required sidecar fields: `license`, `consent`, `mediaType`. The pipeline hashes
+the bytes; it does not invent GPS, locality, taxon, or visible structure.
+
+No mantis photo is present. Taxon remains unknown until a real drop and, if
+claimed, a cited guess.

--- a/projects/biomemetics/labs/mantis/observations/observation.schema.json
+++ b/projects/biomemetics/labs/mantis/observations/observation.schema.json
@@ -1,0 +1,317 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:specimendb:biomemetics:mantis:observations:observation-catalog:v1",
+  "title": "Mantis observation catalog",
+  "description": "Source-linked observations. Empty until real media exists. Taxon is unknown unless a cited guess is supplied. GPS and locality are not representable.",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "kind",
+    "workspaceRef",
+    "catalogSpecimen",
+    "taxon",
+    "records"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "kind": {
+      "const": "ObservationCatalog"
+    },
+    "workspaceRef": {
+      "const": "biomemetics.mantis"
+    },
+    "catalogSpecimen": {
+      "const": false
+    },
+    "taxon": {
+      "$ref": "#/$defs/taxon"
+    },
+    "records": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/observation"
+      }
+    }
+  },
+  "unevaluatedProperties": false,
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{64}$"
+    },
+    "relativePath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+    },
+    "dateTime": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "review": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "enum": ["pending", "accepted", "rejected", "superseded"]
+        },
+        "reviewer": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reviewedAt": {
+          "$ref": "#/$defs/dateTime"
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "enum": ["accepted", "rejected"]
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "required": ["reviewer", "reviewedAt"]
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "taxon": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "enum": ["unknown", "cited-guess"]
+        },
+        "reason": {
+          "enum": ["no-real-media", "media-without-citation"]
+        },
+        "rank": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "confidence": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 1
+        },
+        "citation": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "unknown"
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "required": ["reason"],
+            "not": {
+              "anyOf": [
+                { "required": ["rank"] },
+                { "required": ["name"] },
+                { "required": ["confidence"] },
+                { "required": ["citation"] }
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "cited-guess"
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "required": ["name", "confidence", "citation"],
+            "not": {
+              "required": ["reason"]
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "media": {
+      "type": "object",
+      "required": [
+        "path",
+        "sha256",
+        "mediaType",
+        "license",
+        "consent"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "mediaType": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(image|video|audio)/.+"
+        },
+        "license": {
+          "type": "string",
+          "minLength": 1
+        },
+        "consent": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "statement": {
+      "type": "object",
+      "required": ["text", "status"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "enum": ["observed", "interpreted", "unverified"]
+        },
+        "sourceRef": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "measurement": {
+      "type": "object",
+      "required": [
+        "parameterRef",
+        "value",
+        "unit",
+        "uncertainty",
+        "method",
+        "scaleEvidence"
+      ],
+      "properties": {
+        "parameterRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "value": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string",
+          "minLength": 1
+        },
+        "uncertainty": {
+          "type": "number",
+          "minimum": 0
+        },
+        "method": {
+          "type": "string",
+          "minLength": 1
+        },
+        "scaleEvidence": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sampleCount": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "observation": {
+      "type": "object",
+      "required": [
+        "schemaVersion",
+        "kind",
+        "observationId",
+        "workspaceRef",
+        "recordedAt",
+        "media",
+        "statements",
+        "taxon",
+        "review"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "1.0.0"
+        },
+        "kind": {
+          "const": "Observation"
+        },
+        "observationId": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9.-]*$"
+        },
+        "workspaceRef": {
+          "const": "biomemetics.mantis"
+        },
+        "recordedAt": {
+          "$ref": "#/$defs/dateTime"
+        },
+        "media": {
+          "$ref": "#/$defs/media"
+        },
+        "statements": {
+          "type": "array",
+          "minItems": 1,
+          "contains": {
+            "type": "object",
+            "required": ["status"],
+            "properties": {
+              "status": {
+                "const": "observed"
+              }
+            }
+          },
+          "items": {
+            "$ref": "#/$defs/statement"
+          }
+        },
+        "measurements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/measurement"
+          }
+        },
+        "taxon": {
+          "$ref": "#/$defs/taxon"
+        },
+        "review": {
+          "$ref": "#/$defs/review"
+        }
+      },
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/observations/package.json
+++ b/projects/biomemetics/labs/mantis/observations/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@tmnl/mantis-observation-pipeline",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Evidence-first observation to analog pipeline for the mantis lab",
+  "scripts": {
+    "inspect": "node --experimental-strip-types src/pipeline.ts",
+    "test": "node --test --experimental-strip-types test/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/projects/biomemetics/labs/mantis/observations/src/observation.ts
+++ b/projects/biomemetics/labs/mantis/observations/src/observation.ts
@@ -1,0 +1,115 @@
+import { createHash } from 'node:crypto';
+import { readFileSync, statSync } from 'node:fs';
+import { basename } from 'node:path';
+
+import {
+  PipelineRefused as Refused,
+  SCHEMA_VERSION,
+  WORKSPACE_REF,
+  type MediaProvenance,
+  type Observation,
+  type RefusalReason,
+  type Review,
+  type Taxon,
+} from './types.ts';
+import {
+  collectForbiddenReasons,
+  isNonBlank,
+  isObject,
+  validateObservation,
+} from './validate.ts';
+
+const MEDIA_EXT = /\.(avif|gif|heic|heif|jpe?g|mp4|png|tif|tiff|webm|webp)$/i;
+
+export const isRealMediaFile = (name: string): boolean =>
+  MEDIA_EXT.test(name) && !name.startsWith('.');
+
+export interface MediaAdmission {
+  readonly lanesRelativePath: string;
+  readonly absolutePath: string;
+  readonly observationId: string;
+  readonly recordedAt: string;
+  readonly license: string;
+  readonly consent: string;
+  readonly mediaType: string;
+  readonly statements: Observation['statements'];
+  readonly measurements?: Observation['measurements'];
+  readonly taxon?: Taxon;
+  readonly review: Review;
+  readonly caller?: unknown;
+}
+
+const digestFile = (absolutePath: string): string => {
+  const bytes = readFileSync(absolutePath);
+  return createHash('sha256').update(bytes).digest('hex');
+};
+
+export const admitObservation = (admission: MediaAdmission): Observation => {
+  const reasons: RefusalReason[] = [
+    ...collectForbiddenReasons(admission),
+    ...collectForbiddenReasons(admission.caller),
+  ];
+  try {
+    const stats = statSync(admission.absolutePath);
+    if (!stats.isFile()) reasons.push('no-real-media');
+  } catch {
+    reasons.push('no-real-media');
+  }
+  if (!isRealMediaFile(basename(admission.absolutePath))) {
+    reasons.push('no-real-media');
+  }
+  if (!isNonBlank(admission.license)) reasons.push('missing-license');
+  if (!isNonBlank(admission.consent)) reasons.push('missing-consent');
+
+  let sha256 = '';
+  if (!reasons.includes('no-real-media')) {
+    sha256 = digestFile(admission.absolutePath);
+  } else {
+    reasons.push('missing-digest');
+  }
+
+  const media: MediaProvenance = {
+    path: admission.lanesRelativePath.replaceAll('\\', '/'),
+    sha256,
+    mediaType: admission.mediaType,
+    license: admission.license,
+    consent: admission.consent,
+  };
+
+  const taxon: Taxon =
+    admission.taxon ??
+    ({ status: 'unknown', reason: 'media-without-citation' } as const);
+
+  const record = {
+    schemaVersion: SCHEMA_VERSION,
+    kind: 'Observation' as const,
+    observationId: admission.observationId,
+    workspaceRef: WORKSPACE_REF,
+    recordedAt: admission.recordedAt,
+    media,
+    statements: admission.statements,
+    ...(admission.measurements === undefined
+      ? {}
+      : { measurements: admission.measurements }),
+    taxon,
+    review: admission.review,
+  };
+
+  const validated = validateObservation(record);
+  if (!validated.valid || validated.value === undefined) {
+    throw new Refused([...new Set([...reasons, ...validated.reasons])]);
+  }
+  if (reasons.length > 0) throw new Refused([...new Set(reasons)]);
+  return validated.value;
+};
+
+export const loadProvenanceSidecar = (mediaAbsolutePath: string): JsonSidecar => {
+  const sidecarPath = `${mediaAbsolutePath}.provenance.json`;
+  const raw = JSON.parse(readFileSync(sidecarPath, 'utf8')) as unknown;
+  const reasons = collectForbiddenReasons(raw);
+  if (reasons.length > 0) throw new Refused(reasons);
+  if (!isObject(raw)) throw new Refused(['contract-invalid']);
+  return raw;
+};
+
+type JsonSidecar = Record<string, unknown>;

--- a/projects/biomemetics/labs/mantis/observations/src/pipeline.ts
+++ b/projects/biomemetics/labs/mantis/observations/src/pipeline.ts
@@ -1,0 +1,214 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { deriveAnalog, type AnalogDraft } from '../../analogs/src/analog.ts';
+import { planGovernedProjection } from '../../analogs/src/projection.ts';
+import { deriveFunction, deriveMechanism, type FunctionDraft, type MechanismDraft } from '../../mechanisms/src/mechanism.ts';
+import { deriveStructure, type StructureDraft } from '../../morphology/src/structure.ts';
+import {
+  admitObservation,
+  isRealMediaFile,
+  type MediaAdmission,
+} from './observation.ts';
+import {
+  PipelineRefused,
+  type AnalogCatalog,
+  type FunctionCatalog,
+  type GovernedProjectionPlan,
+  type LaneState,
+  type MechanismCatalog,
+  type Observation,
+  type ObservationCatalog,
+  type StructureCatalog,
+} from './types.ts';
+import {
+  collectForbiddenReasons,
+  isObject,
+  refuseLabAsSpecimen,
+  validateObservationCatalog,
+} from './validate.ts';
+
+export const lanesRootFromUrl = (url: string): string =>
+  join(dirname(fileURLToPath(url)), '..', '..');
+
+export const COMMITTED_LANES_ROOT = lanesRootFromUrl(import.meta.url);
+
+const MEDIA_DIR = 'observations/media';
+
+const readJson = (path: string): unknown =>
+  JSON.parse(readFileSync(path, 'utf8')) as unknown;
+
+const listMediaFiles = (root: string): string[] => {
+  const dir = join(root, MEDIA_DIR);
+  return readdirSync(dir)
+    .filter(isRealMediaFile)
+    .map((name) => join(MEDIA_DIR, name).replaceAll('\\', '/'))
+    .sort();
+};
+
+const loadCatalog = <T>(path: string, expectedKind: string): T => {
+  const value = readJson(path);
+  if (!isObject(value) || value.kind !== expectedKind) {
+    throw new PipelineRefused(['contract-invalid']);
+  }
+  if (value.catalogSpecimen !== false) {
+    throw new PipelineRefused(['lab-as-specimen']);
+  }
+  const forbidden = collectForbiddenReasons(value);
+  if (forbidden.length > 0) throw new PipelineRefused(forbidden);
+  return value as T;
+};
+
+export const inspectLanes = (root = COMMITTED_LANES_ROOT): LaneState => {
+  const observations = loadCatalog<ObservationCatalog>(
+    join(root, 'observations/catalog.json'),
+    'ObservationCatalog',
+  );
+  const catalogGate = validateObservationCatalog(observations);
+  if (!catalogGate.valid) {
+    throw new PipelineRefused(catalogGate.reasons);
+  }
+  return {
+    observations,
+    structures: loadCatalog<StructureCatalog>(
+      join(root, 'morphology/catalog.json'),
+      'StructureCatalog',
+    ),
+    mechanisms: loadCatalog<MechanismCatalog>(
+      join(root, 'mechanisms/catalog.json'),
+      'MechanismCatalog',
+    ),
+    functions: loadCatalog<FunctionCatalog>(
+      join(root, 'mechanisms/functions.json'),
+      'FunctionCatalog',
+    ),
+    analogs: loadCatalog<AnalogCatalog>(
+      join(root, 'analogs/catalog.json'),
+      'AnalogCatalog',
+    ),
+    mediaFiles: listMediaFiles(root),
+  };
+};
+
+export const committedStateIsEmpty = (state: LaneState): boolean =>
+  state.mediaFiles.length === 0 &&
+  state.observations.records.length === 0 &&
+  state.structures.records.length === 0 &&
+  state.mechanisms.records.length === 0 &&
+  state.functions.records.length === 0 &&
+  state.analogs.records.length === 0 &&
+  state.observations.taxon.status === 'unknown' &&
+  state.observations.taxon.reason === 'no-real-media' &&
+  state.observations.catalogSpecimen === false;
+
+export interface TraverseInput {
+  readonly media: Omit<MediaAdmission, 'lanesRelativePath' | 'absolutePath'> & {
+    readonly absolutePath: string;
+    readonly lanesRelativePath: string;
+  };
+  readonly structure?: StructureDraft;
+  readonly mechanism?: MechanismDraft;
+  readonly fn?: FunctionDraft;
+  readonly analog?: AnalogDraft;
+  readonly gitSha: string;
+  readonly runId: string;
+  readonly specimenId?: string;
+  readonly insertSpecimen?: boolean;
+  readonly writeStore?: boolean;
+  readonly caller?: unknown;
+}
+
+export interface TraverseResult {
+  readonly observation: Observation;
+  readonly structure?: ReturnType<typeof deriveStructure>;
+  readonly mechanism?: ReturnType<typeof deriveMechanism>;
+  readonly fn?: ReturnType<typeof deriveFunction>;
+  readonly analog?: ReturnType<typeof deriveAnalog>;
+  readonly projection: GovernedProjectionPlan;
+}
+
+export const traverse = (input: TraverseInput): TraverseResult => {
+  const reasons = [
+    ...collectForbiddenReasons(input),
+    ...collectForbiddenReasons(input.caller),
+    ...refuseLabAsSpecimen(input.specimenId),
+  ];
+  if (input.insertSpecimen === true) reasons.push('specimen-insert-forbidden');
+  if (input.writeStore === true) reasons.push('store-write-forbidden');
+  if (reasons.length > 0) throw new PipelineRefused([...new Set(reasons)]);
+
+  if (input.analog !== undefined && input.fn === undefined) {
+    throw new PipelineRefused(['missing-function']);
+  }
+  if (input.fn !== undefined && input.mechanism === undefined) {
+    throw new PipelineRefused(['missing-mechanism']);
+  }
+  if (input.mechanism !== undefined && input.structure === undefined) {
+    throw new PipelineRefused(['missing-structure']);
+  }
+  if (input.structure !== undefined && input.media === undefined) {
+    throw new PipelineRefused(['missing-observation']);
+  }
+
+  const observation = admitObservation({
+    ...input.media,
+    caller: input.caller,
+  });
+
+  const structure =
+    input.structure === undefined
+      ? undefined
+      : deriveStructure(observation, input.structure);
+  const mechanism =
+    input.mechanism === undefined
+      ? undefined
+      : deriveMechanism(structure, input.mechanism);
+  const fn =
+    input.fn === undefined ? undefined : deriveFunction(mechanism, input.fn);
+  const analog =
+    input.analog === undefined ? undefined : deriveAnalog(fn, input.analog);
+
+  const projection = planGovernedProjection({
+    observation,
+    structure,
+    mechanism,
+    fn,
+    analog,
+    gitSha: input.gitSha,
+    runId: input.runId,
+    specimenId: input.specimenId,
+    caller: input.caller,
+  });
+
+  if (projection.executable !== false || projection.storeWrite !== false) {
+    throw new PipelineRefused(['store-write-forbidden']);
+  }
+  return { observation, structure, mechanism, fn, analog, projection };
+};
+
+const isMain = (): boolean => {
+  const entry = process.argv[1];
+  if (entry === undefined) return false;
+  return fileURLToPath(import.meta.url) === entry;
+};
+
+if (isMain()) {
+  const state = inspectLanes();
+  const empty = committedStateIsEmpty(state);
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        empty,
+        taxon: state.observations.taxon,
+        mediaFiles: state.mediaFiles,
+        observationCount: state.observations.records.length,
+        analogCount: state.analogs.records.length,
+        catalogSpecimen: state.observations.catalogSpecimen,
+        attach: { executable: false, storeWrite: false },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}

--- a/projects/biomemetics/labs/mantis/observations/src/types.ts
+++ b/projects/biomemetics/labs/mantis/observations/src/types.ts
@@ -1,0 +1,326 @@
+/** Lane records for observation → structure → mechanism → function → analog. */
+
+export const WORKSPACE_REF = 'biomemetics.mantis' as const;
+export const SCHEMA_VERSION = '1.0.0' as const;
+
+export const LAB_AS_SPECIMEN_IDS = Object.freeze([
+  'biomemetics.mantis',
+  'mantis-lab',
+  'projects/biomemetics/labs/mantis',
+]);
+
+export const FORBIDDEN_LOCALITY_KEYS = Object.freeze([
+  'locality',
+  'gps',
+  'geo',
+  'latitude',
+  'longitude',
+  'altitudeMeters',
+]);
+
+export const FORBIDDEN_CALLER_PROSE_KEYS = Object.freeze([
+  'component',
+  'components',
+  'analogTarget',
+]);
+
+export const LOCAL_EVIDENCE_RUN = Object.freeze({
+  workstream: 'mantis-04-observation-pipeline',
+  root: 'evidence/runs',
+  layout: [
+    'run.json',
+    'inputs/',
+    'raw/',
+    'derived/',
+    'report.json',
+    'evidence-record.json',
+  ],
+});
+
+export const LOCAL_EVIDENCE_RECORD_REF =
+  /^evidence\/runs\/[A-Za-z0-9][A-Za-z0-9._-]*\/[a-fA-F0-9]{7,40}\/[A-Za-z0-9][A-Za-z0-9._-]*\/evidence-record\.json$/;
+
+export type RefusalReason =
+  | 'no-real-media'
+  | 'invented-locality'
+  | 'invented-taxon'
+  | 'lab-as-specimen'
+  | 'missing-digest'
+  | 'missing-license'
+  | 'missing-consent'
+  | 'unobserved-statement'
+  | 'missing-observation'
+  | 'missing-structure'
+  | 'missing-mechanism'
+  | 'missing-function'
+  | 'engineering-as-biology'
+  | 'source-class-relabeled'
+  | 'unverified-evidence'
+  | 'simulated-as-measured'
+  | 'caller-component-prose'
+  | 'specimen-insert-forbidden'
+  | 'store-write-forbidden'
+  | 'contract-invalid'
+  | 'measurement-incomplete'
+  | 'evidence-not-local-run';
+
+export class PipelineRefused extends Error {
+  readonly _tag = 'PipelineRefused';
+  readonly reasons: readonly RefusalReason[];
+
+  constructor(reasons: readonly RefusalReason[]) {
+    super(`PipelineRefused: ${reasons.join(',')}`);
+    this.name = 'PipelineRefused';
+    this.reasons = reasons;
+  }
+}
+
+export type ReviewStatus = 'pending' | 'accepted' | 'rejected' | 'superseded';
+
+export interface Review {
+  readonly status: ReviewStatus;
+  readonly reviewer?: string;
+  readonly reviewedAt?: string;
+  readonly notes?: string;
+}
+
+export type Taxon =
+  | {
+      readonly status: 'unknown';
+      readonly reason: 'no-real-media' | 'media-without-citation';
+    }
+  | {
+      readonly status: 'cited-guess';
+      readonly name: string;
+      readonly confidence: number;
+      readonly citation: string;
+      readonly rank?: string;
+    };
+
+export interface MediaProvenance {
+  readonly path: string;
+  readonly sha256: string;
+  readonly mediaType: string;
+  readonly license: string;
+  readonly consent: string;
+}
+
+export interface ObservationStatement {
+  readonly text: string;
+  readonly status: 'observed' | 'interpreted' | 'unverified';
+  readonly sourceRef?: string;
+}
+
+export interface Measurement {
+  readonly parameterRef: string;
+  readonly value: number;
+  readonly unit: string;
+  readonly uncertainty: number;
+  readonly method: string;
+  readonly scaleEvidence: string;
+  readonly sampleCount?: number;
+}
+
+export interface Observation {
+  readonly schemaVersion: typeof SCHEMA_VERSION;
+  readonly kind: 'Observation';
+  readonly observationId: string;
+  readonly workspaceRef: typeof WORKSPACE_REF;
+  readonly recordedAt: string;
+  readonly media: MediaProvenance;
+  readonly statements: readonly ObservationStatement[];
+  readonly measurements?: readonly Measurement[];
+  readonly taxon: Taxon;
+  readonly review: Review;
+}
+
+export type StructureBasis =
+  | 'observed'
+  | 'measured'
+  | 'calculated'
+  | 'simulated'
+  | 'ref'
+  | 'target'
+  | 'typ'
+  | 'unverified';
+
+export interface Structure {
+  readonly schemaVersion: typeof SCHEMA_VERSION;
+  readonly kind: 'Structure';
+  readonly structureId: string;
+  readonly observationRef: string;
+  readonly workspaceRef: typeof WORKSPACE_REF;
+  readonly basis: StructureBasis;
+  readonly description: string;
+  readonly review: Review;
+}
+
+export interface MechanismMembers {
+  readonly moving: readonly string[];
+  readonly grounded: readonly string[];
+}
+
+export interface Mechanism {
+  readonly schemaVersion: typeof SCHEMA_VERSION;
+  readonly kind: 'Mechanism';
+  readonly mechanismId: string;
+  readonly structureRef: string;
+  readonly workspaceRef: typeof WORKSPACE_REF;
+  readonly hypothesis: string;
+  readonly falsifier: string;
+  readonly status: 'interpreted' | 'unverified';
+  readonly states: readonly string[];
+  readonly members: MechanismMembers;
+  readonly failureModes: readonly string[];
+  readonly verificationPlan: string;
+  readonly review: Review;
+}
+
+export interface BiologicalFunction {
+  readonly schemaVersion: typeof SCHEMA_VERSION;
+  readonly kind: 'Function';
+  readonly functionId: string;
+  readonly mechanismRef: string;
+  readonly workspaceRef: typeof WORKSPACE_REF;
+  readonly statement: string;
+  readonly status: 'interpreted' | 'unverified';
+  readonly limits: readonly string[];
+  readonly review: Review;
+}
+
+export interface AnalogLink {
+  readonly schemaVersion: typeof SCHEMA_VERSION;
+  readonly kind: 'AnalogLink';
+  readonly analogId: string;
+  readonly functionRef: string;
+  readonly workspaceRef: typeof WORKSPACE_REF;
+  readonly target: string;
+  readonly direction: 'biology-to-engineering';
+  readonly equivalent: false;
+  readonly limit: string;
+  readonly nonEquivalence: string;
+  readonly note?: string;
+  readonly review: Review;
+}
+
+export interface ObservationCatalog {
+  readonly schemaVersion: typeof SCHEMA_VERSION;
+  readonly kind: 'ObservationCatalog';
+  readonly workspaceRef: typeof WORKSPACE_REF;
+  readonly catalogSpecimen: false;
+  readonly taxon: Taxon;
+  readonly records: readonly Observation[];
+}
+
+export interface StructureCatalog {
+  readonly schemaVersion: typeof SCHEMA_VERSION;
+  readonly kind: 'StructureCatalog';
+  readonly workspaceRef: typeof WORKSPACE_REF;
+  readonly catalogSpecimen: false;
+  readonly records: readonly Structure[];
+}
+
+export interface MechanismCatalog {
+  readonly schemaVersion: typeof SCHEMA_VERSION;
+  readonly kind: 'MechanismCatalog';
+  readonly workspaceRef: typeof WORKSPACE_REF;
+  readonly catalogSpecimen: false;
+  readonly records: readonly Mechanism[];
+}
+
+export interface FunctionCatalog {
+  readonly schemaVersion: typeof SCHEMA_VERSION;
+  readonly kind: 'FunctionCatalog';
+  readonly workspaceRef: typeof WORKSPACE_REF;
+  readonly catalogSpecimen: false;
+  readonly records: readonly BiologicalFunction[];
+}
+
+export interface AnalogCatalog {
+  readonly schemaVersion: typeof SCHEMA_VERSION;
+  readonly kind: 'AnalogCatalog';
+  readonly workspaceRef: typeof WORKSPACE_REF;
+  readonly catalogSpecimen: false;
+  readonly records: readonly AnalogLink[];
+}
+
+export interface LaneState {
+  readonly observations: ObservationCatalog;
+  readonly structures: StructureCatalog;
+  readonly mechanisms: MechanismCatalog;
+  readonly functions: FunctionCatalog;
+  readonly analogs: AnalogCatalog;
+  readonly mediaFiles: readonly string[];
+}
+
+export type SpecimenComponentDraft =
+  | { readonly _tag: 'Observation'; readonly text: string }
+  | { readonly _tag: 'Structure'; readonly text: string }
+  | { readonly _tag: 'Mechanism'; readonly text: string }
+  | { readonly _tag: 'Function'; readonly text: string }
+  | {
+      readonly _tag: 'AnalogLink';
+      readonly target: string;
+      readonly note?: string;
+    };
+
+/**
+ * Read-only mirror of the #16 Attach RPC shape (PR 33). This pipeline never
+ * calls a store and never inserts a Specimen.
+ */
+export const AttachRpcContract = {
+  name: 'Attach',
+  payload: {
+    specimenId: 'SpecimenId',
+    component: 'governed-admission',
+    provenance: 'ProjectionProvenance',
+  },
+  success: {
+    localityMutated: false,
+    taxonMutated: false,
+    storeWrite: false,
+    mode: 'stub',
+  },
+  error: 'AttachRefused',
+} as const;
+
+export interface ProjectionProvenance {
+  readonly evidenceId: string;
+  readonly evidenceRef: string;
+  readonly claimRefs: readonly string[];
+  readonly sourceClass: 'observed' | 'measured';
+  readonly recordedAt: string;
+  readonly inputRefs: readonly { readonly ref: string; readonly role: string; readonly sha256?: string }[];
+  readonly observationSourceRefs: readonly string[];
+  readonly artifactRefs: readonly {
+    readonly path?: string;
+    readonly mediaType: string;
+    readonly sha256?: string;
+  }[];
+  readonly review: {
+    readonly reviewer: string;
+    readonly reviewedAt: string;
+  };
+}
+
+export interface ComponentProjection {
+  readonly component: SpecimenComponentDraft;
+  readonly provenance: ProjectionProvenance;
+}
+
+export interface GovernedProjectionPlan {
+  readonly projections: readonly ComponentProjection[];
+  readonly executable: false;
+  readonly storeWrite: false;
+  readonly localityMutated: false;
+  readonly taxonMutated: false;
+  readonly blocker: 'specimendb-attach-unavailable';
+  readonly blockers: readonly (
+    | 'specimendb-attach-unavailable'
+    | 'no-admissible-evidence'
+  )[];
+  readonly evidenceRef: string;
+}
+
+export const localEvidenceRef = (gitSha: string, runId: string): string =>
+  `${LOCAL_EVIDENCE_RUN.root}/${LOCAL_EVIDENCE_RUN.workstream}/${gitSha}/${runId}/evidence-record.json`;

--- a/projects/biomemetics/labs/mantis/observations/src/validate.ts
+++ b/projects/biomemetics/labs/mantis/observations/src/validate.ts
@@ -1,0 +1,593 @@
+import {
+  FORBIDDEN_CALLER_PROSE_KEYS,
+  FORBIDDEN_LOCALITY_KEYS,
+  LAB_AS_SPECIMEN_IDS,
+  SCHEMA_VERSION,
+  WORKSPACE_REF,
+  type AnalogLink,
+  type BiologicalFunction,
+  type Measurement,
+  type Mechanism,
+  type Observation,
+  type ObservationCatalog,
+  type RefusalReason,
+  type Review,
+  type Structure,
+  type Taxon,
+} from './types.ts';
+
+export type JsonObject = Record<string, unknown>;
+
+const ID = /^[a-z][a-z0-9.-]*$/;
+const SHA256 = /^[a-fA-F0-9]{64}$/;
+const DATETIME =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+const RELATIVE = /^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$)).+$/;
+const MEDIA_TYPE = /^(image|video|audio)\/.+/;
+
+export const isObject = (value: unknown): value is JsonObject =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const isNonBlank = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim() !== '';
+
+const hasOnlyKeys = (value: JsonObject, allowed: ReadonlySet<string>): boolean =>
+  Object.keys(value).every((key) => allowed.has(key));
+
+export const collectForbiddenReasons = (value: unknown): RefusalReason[] => {
+  const reasons = new Set<RefusalReason>();
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    if (!isObject(node)) return;
+    for (const key of Object.keys(node)) {
+      if ((FORBIDDEN_LOCALITY_KEYS as readonly string[]).includes(key)) {
+        reasons.add('invented-locality');
+      }
+      if ((FORBIDDEN_CALLER_PROSE_KEYS as readonly string[]).includes(key)) {
+        reasons.add('caller-component-prose');
+      }
+      if (key === 'taxon' && typeof node[key] === 'string') {
+        reasons.add('invented-taxon');
+      }
+      walk(node[key]);
+    }
+  };
+  walk(value);
+  return [...reasons];
+};
+
+export const refuseLabAsSpecimen = (id: string | undefined): RefusalReason[] => {
+  if (id === undefined) return [];
+  return LAB_AS_SPECIMEN_IDS.includes(id.trim()) ? ['lab-as-specimen'] : [];
+};
+
+const dateOk = (value: unknown): boolean =>
+  isNonBlank(value) && DATETIME.test(value) && Number.isFinite(Date.parse(value));
+
+const uniqueNonBlank = (value: unknown, minItems: number): value is string[] =>
+  Array.isArray(value) &&
+  value.length >= minItems &&
+  value.every(isNonBlank) &&
+  new Set(value).size === value.length;
+
+export const validateReview = (value: unknown, errors: string[]): void => {
+  if (!isObject(value)) {
+    errors.push('/review must be an object');
+    return;
+  }
+  if (!hasOnlyKeys(value, new Set(['status', 'reviewer', 'reviewedAt', 'notes']))) {
+    errors.push('/review contains an unknown property');
+  }
+  const status = String(value.status);
+  if (!['pending', 'accepted', 'rejected', 'superseded'].includes(status)) {
+    errors.push('/review/status is invalid');
+  }
+  if (status === 'accepted' || status === 'rejected') {
+    if (!isNonBlank(value.reviewer)) errors.push('/review/reviewer is required');
+    if (!dateOk(value.reviewedAt)) errors.push('/review/reviewedAt is required');
+  }
+  if (value.reviewer !== undefined && !isNonBlank(value.reviewer)) {
+    errors.push('/review/reviewer is invalid');
+  }
+  if (value.reviewedAt !== undefined && !dateOk(value.reviewedAt)) {
+    errors.push('/review/reviewedAt is invalid');
+  }
+  if (value.notes !== undefined && !isNonBlank(value.notes)) {
+    errors.push('/review/notes is invalid');
+  }
+};
+
+export const reviewIsAccepted = (review: Review): boolean =>
+  review.status === 'accepted' &&
+  isNonBlank(review.reviewer) &&
+  dateOk(review.reviewedAt);
+
+export const validateTaxon = (value: unknown, errors: string[]): RefusalReason[] => {
+  const reasons: RefusalReason[] = [];
+  if (!isObject(value)) {
+    errors.push('/taxon must be an object');
+    reasons.push('invented-taxon');
+    return reasons;
+  }
+  if (
+    !hasOnlyKeys(
+      value,
+      new Set(['status', 'reason', 'rank', 'name', 'confidence', 'citation']),
+    )
+  ) {
+    errors.push('/taxon contains an unknown property');
+    reasons.push('invented-taxon');
+  }
+  if (value.status === 'unknown') {
+    if (
+      value.reason !== 'no-real-media' &&
+      value.reason !== 'media-without-citation'
+    ) {
+      errors.push('/taxon/reason is invalid');
+      reasons.push('invented-taxon');
+    }
+    if (
+      value.rank !== undefined ||
+      value.name !== undefined ||
+      value.confidence !== undefined ||
+      value.citation !== undefined
+    ) {
+      errors.push('/taxon unknown cannot carry a name');
+      reasons.push('invented-taxon');
+    }
+    return reasons;
+  }
+  if (value.status === 'cited-guess') {
+    if (!isNonBlank(value.name)) {
+      errors.push('/taxon/name is required');
+      reasons.push('invented-taxon');
+    }
+    if (!isNonBlank(value.citation)) {
+      errors.push('/taxon/citation is required');
+      reasons.push('invented-taxon');
+    }
+    if (
+      typeof value.confidence !== 'number' ||
+      !(value.confidence > 0) ||
+      value.confidence > 1
+    ) {
+      errors.push('/taxon/confidence is invalid');
+      reasons.push('invented-taxon');
+    }
+    if (value.rank !== undefined && !isNonBlank(value.rank)) {
+      errors.push('/taxon/rank is invalid');
+    }
+    if (value.reason !== undefined) {
+      errors.push('/taxon cited-guess cannot carry a missing-media reason');
+      reasons.push('invented-taxon');
+    }
+    return reasons;
+  }
+  errors.push('/taxon/status is invalid');
+  reasons.push('invented-taxon');
+  return reasons;
+};
+
+const validateMeasurement = (
+  value: unknown,
+  index: number,
+  errors: string[],
+): RefusalReason[] => {
+  const reasons: RefusalReason[] = [];
+  if (!isObject(value)) {
+    errors.push(`/measurements/${index} must be an object`);
+    return ['measurement-incomplete'];
+  }
+  const allowed = new Set([
+    'parameterRef',
+    'value',
+    'unit',
+    'uncertainty',
+    'method',
+    'scaleEvidence',
+    'sampleCount',
+  ]);
+  if (!hasOnlyKeys(value, allowed)) {
+    errors.push(`/measurements/${index} contains an unknown property`);
+  }
+  const complete =
+    isNonBlank(value.parameterRef) &&
+    typeof value.value === 'number' &&
+    Number.isFinite(value.value) &&
+    isNonBlank(value.unit) &&
+    typeof value.uncertainty === 'number' &&
+    Number.isFinite(value.uncertainty) &&
+    value.uncertainty >= 0 &&
+    isNonBlank(value.method) &&
+    isNonBlank(value.scaleEvidence);
+  if (!complete) {
+    errors.push(`/measurements/${index} is incomplete`);
+    reasons.push('measurement-incomplete');
+  }
+  if (
+    value.sampleCount !== undefined &&
+    !(Number.isInteger(value.sampleCount) && Number(value.sampleCount) >= 1)
+  ) {
+    errors.push(`/measurements/${index}/sampleCount is invalid`);
+    reasons.push('measurement-incomplete');
+  }
+  return reasons;
+};
+
+export interface Validation<T> {
+  readonly valid: boolean;
+  readonly errors: readonly string[];
+  readonly reasons: readonly RefusalReason[];
+  readonly value?: T;
+}
+
+const fail = (errors: string[], reasons: RefusalReason[]): Validation<never> => ({
+  valid: false,
+  errors,
+  reasons: [...new Set(reasons.length > 0 ? reasons : ['contract-invalid'])],
+});
+
+export const validateObservation = (input: unknown): Validation<Observation> => {
+  const errors: string[] = [];
+  const reasons: RefusalReason[] = collectForbiddenReasons(input);
+  if (!isObject(input)) return fail(['/ must be an object'], reasons);
+  const allowed = new Set([
+    'schemaVersion',
+    'kind',
+    'observationId',
+    'workspaceRef',
+    'recordedAt',
+    'media',
+    'statements',
+    'measurements',
+    'taxon',
+    'review',
+  ]);
+  if (!hasOnlyKeys(input, allowed)) errors.push('/ contains an unknown property');
+  if (input.schemaVersion !== SCHEMA_VERSION) errors.push('/schemaVersion is invalid');
+  if (input.kind !== 'Observation') errors.push('/kind must equal Observation');
+  if (!isNonBlank(input.observationId) || !ID.test(input.observationId)) {
+    errors.push('/observationId is invalid');
+  }
+  if (input.workspaceRef !== WORKSPACE_REF) errors.push('/workspaceRef is invalid');
+  if (!dateOk(input.recordedAt)) errors.push('/recordedAt is invalid');
+  if (!isObject(input.media)) {
+    errors.push('/media must be an object');
+    reasons.push('no-real-media');
+  } else {
+    if (
+      !hasOnlyKeys(
+        input.media,
+        new Set(['path', 'sha256', 'mediaType', 'license', 'consent']),
+      )
+    ) {
+      errors.push('/media contains an unknown property');
+    }
+    if (!isNonBlank(input.media.path) || !RELATIVE.test(input.media.path)) {
+      errors.push('/media/path is invalid');
+    }
+    if (!isNonBlank(input.media.sha256) || !SHA256.test(input.media.sha256)) {
+      errors.push('/media/sha256 is invalid');
+      reasons.push('missing-digest');
+    }
+    if (!isNonBlank(input.media.mediaType) || !MEDIA_TYPE.test(input.media.mediaType)) {
+      errors.push('/media/mediaType is invalid');
+    }
+    if (!isNonBlank(input.media.license)) {
+      errors.push('/media/license is required');
+      reasons.push('missing-license');
+    }
+    if (!isNonBlank(input.media.consent)) {
+      errors.push('/media/consent is required');
+      reasons.push('missing-consent');
+    }
+  }
+  if (!Array.isArray(input.statements) || input.statements.length < 1) {
+    errors.push('/statements requires at least one item');
+    reasons.push('unobserved-statement');
+  } else {
+    let observed = 0;
+    input.statements.forEach((statement, index) => {
+      if (!isObject(statement)) {
+        errors.push(`/statements/${index} must be an object`);
+        return;
+      }
+      if (!hasOnlyKeys(statement, new Set(['text', 'status', 'sourceRef']))) {
+        errors.push(`/statements/${index} contains an unknown property`);
+      }
+      if (!isNonBlank(statement.text)) errors.push(`/statements/${index}/text is required`);
+      if (!['observed', 'interpreted', 'unverified'].includes(String(statement.status))) {
+        errors.push(`/statements/${index}/status is invalid`);
+      }
+      if (statement.status === 'observed') observed += 1;
+      if (statement.sourceRef !== undefined && !isNonBlank(statement.sourceRef)) {
+        errors.push(`/statements/${index}/sourceRef is invalid`);
+      }
+    });
+    if (observed < 1) {
+      errors.push('/statements requires an observed item');
+      reasons.push('unobserved-statement');
+    }
+  }
+  if (input.measurements !== undefined) {
+    if (!Array.isArray(input.measurements)) {
+      errors.push('/measurements must be an array');
+    } else {
+      input.measurements.forEach((measurement, index) => {
+        reasons.push(...validateMeasurement(measurement, index, errors));
+      });
+    }
+  }
+  reasons.push(...validateTaxon(input.taxon, errors));
+  validateReview(input.review, errors);
+  if (errors.length > 0 || reasons.length > 0) return fail(errors, reasons);
+  return { valid: true, errors: [], reasons: [], value: input as Observation };
+};
+
+export const validateStructure = (
+  input: unknown,
+  observation?: Observation,
+): Validation<Structure> => {
+  const errors: string[] = [];
+  const reasons: RefusalReason[] = collectForbiddenReasons(input);
+  if (!isObject(input)) return fail(['/ must be an object'], reasons);
+  if (observation === undefined) reasons.push('missing-observation');
+  const allowed = new Set([
+    'schemaVersion',
+    'kind',
+    'structureId',
+    'observationRef',
+    'workspaceRef',
+    'basis',
+    'description',
+    'review',
+  ]);
+  if (!hasOnlyKeys(input, allowed)) errors.push('/ contains an unknown property');
+  if (input.schemaVersion !== SCHEMA_VERSION) errors.push('/schemaVersion is invalid');
+  if (input.kind !== 'Structure') errors.push('/kind must equal Structure');
+  if (!isNonBlank(input.structureId) || !ID.test(input.structureId)) {
+    errors.push('/structureId is invalid');
+  }
+  if (!isNonBlank(input.observationRef) || !ID.test(input.observationRef)) {
+    errors.push('/observationRef is invalid');
+    reasons.push('missing-observation');
+  }
+  if (
+    observation !== undefined &&
+    input.observationRef !== observation.observationId
+  ) {
+    errors.push('/observationRef does not match the supplied observation');
+    reasons.push('missing-observation');
+  }
+  if (input.workspaceRef !== WORKSPACE_REF) errors.push('/workspaceRef is invalid');
+  const basis = String(input.basis);
+  if (
+    ![
+      'observed',
+      'measured',
+      'calculated',
+      'simulated',
+      'ref',
+      'target',
+      'typ',
+      'unverified',
+    ].includes(basis)
+  ) {
+    errors.push('/basis is invalid');
+  }
+  if (basis === 'observed' && observation !== undefined) {
+    const visible = observation.statements.some(
+      (statement) => statement.status === 'observed',
+    );
+    if (!visible) reasons.push('unobserved-statement');
+  }
+  if (
+    basis === 'measured' &&
+    (observation === undefined || (observation.measurements?.length ?? 0) < 1)
+  ) {
+    reasons.push('measurement-incomplete');
+  }
+  if (!isNonBlank(input.description)) errors.push('/description is required');
+  validateReview(input.review, errors);
+  if (errors.length > 0 || reasons.length > 0) return fail(errors, reasons);
+  return { valid: true, errors: [], reasons: [], value: input as Structure };
+};
+
+export const validateMechanism = (
+  input: unknown,
+  structure?: Structure,
+): Validation<Mechanism> => {
+  const errors: string[] = [];
+  const reasons: RefusalReason[] = collectForbiddenReasons(input);
+  if (!isObject(input)) return fail(['/ must be an object'], reasons);
+  if (structure === undefined) reasons.push('missing-structure');
+  const allowed = new Set([
+    'schemaVersion',
+    'kind',
+    'mechanismId',
+    'structureRef',
+    'workspaceRef',
+    'hypothesis',
+    'falsifier',
+    'status',
+    'states',
+    'members',
+    'failureModes',
+    'verificationPlan',
+    'review',
+  ]);
+  if (!hasOnlyKeys(input, allowed)) errors.push('/ contains an unknown property');
+  if (input.schemaVersion !== SCHEMA_VERSION) errors.push('/schemaVersion is invalid');
+  if (input.kind !== 'Mechanism') errors.push('/kind must equal Mechanism');
+  if (!isNonBlank(input.mechanismId) || !ID.test(input.mechanismId)) {
+    errors.push('/mechanismId is invalid');
+  }
+  if (!isNonBlank(input.structureRef) || !ID.test(input.structureRef)) {
+    errors.push('/structureRef is invalid');
+    reasons.push('missing-structure');
+  }
+  if (structure !== undefined && input.structureRef !== structure.structureId) {
+    reasons.push('missing-structure');
+  }
+  if (input.workspaceRef !== WORKSPACE_REF) errors.push('/workspaceRef is invalid');
+  if (!isNonBlank(input.hypothesis)) errors.push('/hypothesis is required');
+  if (!isNonBlank(input.falsifier)) errors.push('/falsifier is required');
+  if (input.status === 'observed') reasons.push('source-class-relabeled');
+  if (input.status !== 'interpreted' && input.status !== 'unverified') {
+    errors.push('/status is invalid');
+  }
+  if (!uniqueNonBlank(input.states, 1)) errors.push('/states is invalid');
+  if (!isObject(input.members)) {
+    errors.push('/members must be an object');
+  } else {
+    if (!hasOnlyKeys(input.members, new Set(['moving', 'grounded']))) {
+      errors.push('/members contains an unknown property');
+    }
+    if (!Array.isArray(input.members.moving) || !input.members.moving.every(isNonBlank)) {
+      errors.push('/members/moving is invalid');
+    }
+    if (
+      !Array.isArray(input.members.grounded) ||
+      !input.members.grounded.every(isNonBlank)
+    ) {
+      errors.push('/members/grounded is invalid');
+    }
+  }
+  if (!Array.isArray(input.failureModes) || input.failureModes.length < 1) {
+    errors.push('/failureModes requires at least one item');
+  }
+  if (!isNonBlank(input.verificationPlan)) errors.push('/verificationPlan is required');
+  validateReview(input.review, errors);
+  if (errors.length > 0 || reasons.length > 0) return fail(errors, reasons);
+  return { valid: true, errors: [], reasons: [], value: input as Mechanism };
+};
+
+export const validateFunction = (
+  input: unknown,
+  mechanism?: Mechanism,
+): Validation<BiologicalFunction> => {
+  const errors: string[] = [];
+  const reasons: RefusalReason[] = collectForbiddenReasons(input);
+  if (!isObject(input)) return fail(['/ must be an object'], reasons);
+  if (mechanism === undefined) reasons.push('missing-mechanism');
+  const allowed = new Set([
+    'schemaVersion',
+    'kind',
+    'functionId',
+    'mechanismRef',
+    'workspaceRef',
+    'statement',
+    'status',
+    'limits',
+    'review',
+  ]);
+  if (!hasOnlyKeys(input, allowed)) errors.push('/ contains an unknown property');
+  if (input.schemaVersion !== SCHEMA_VERSION) errors.push('/schemaVersion is invalid');
+  if (input.kind !== 'Function') errors.push('/kind must equal Function');
+  if (!isNonBlank(input.functionId) || !ID.test(input.functionId)) {
+    errors.push('/functionId is invalid');
+  }
+  if (!isNonBlank(input.mechanismRef) || !ID.test(input.mechanismRef)) {
+    errors.push('/mechanismRef is invalid');
+    reasons.push('missing-mechanism');
+  }
+  if (mechanism !== undefined && input.mechanismRef !== mechanism.mechanismId) {
+    reasons.push('missing-mechanism');
+  }
+  if (input.workspaceRef !== WORKSPACE_REF) errors.push('/workspaceRef is invalid');
+  if (!isNonBlank(input.statement)) errors.push('/statement is required');
+  if (input.status === 'observed') reasons.push('source-class-relabeled');
+  if (input.status !== 'interpreted' && input.status !== 'unverified') {
+    errors.push('/status is invalid');
+  }
+  if (!Array.isArray(input.limits) || input.limits.length < 1 || !input.limits.every(isNonBlank)) {
+    errors.push('/limits requires at least one item');
+  }
+  validateReview(input.review, errors);
+  if (errors.length > 0 || reasons.length > 0) return fail(errors, reasons);
+  return { valid: true, errors: [], reasons: [], value: input as BiologicalFunction };
+};
+
+export const validateAnalog = (
+  input: unknown,
+  fn?: BiologicalFunction,
+): Validation<AnalogLink> => {
+  const errors: string[] = [];
+  const reasons: RefusalReason[] = collectForbiddenReasons(input);
+  if (!isObject(input)) return fail(['/ must be an object'], reasons);
+  if (fn === undefined) reasons.push('missing-function');
+  const allowed = new Set([
+    'schemaVersion',
+    'kind',
+    'analogId',
+    'functionRef',
+    'workspaceRef',
+    'target',
+    'direction',
+    'equivalent',
+    'limit',
+    'nonEquivalence',
+    'note',
+    'review',
+  ]);
+  if (!hasOnlyKeys(input, allowed)) errors.push('/ contains an unknown property');
+  if (input.schemaVersion !== SCHEMA_VERSION) errors.push('/schemaVersion is invalid');
+  if (input.kind !== 'AnalogLink') errors.push('/kind must equal AnalogLink');
+  if (!isNonBlank(input.analogId) || !ID.test(input.analogId)) {
+    errors.push('/analogId is invalid');
+  }
+  if (!isNonBlank(input.functionRef) || !ID.test(input.functionRef)) {
+    errors.push('/functionRef is invalid');
+    reasons.push('missing-function');
+  }
+  if (fn !== undefined && input.functionRef !== fn.functionId) {
+    reasons.push('missing-function');
+  }
+  if (input.workspaceRef !== WORKSPACE_REF) errors.push('/workspaceRef is invalid');
+  if (!isNonBlank(input.target)) errors.push('/target is required');
+  if (isNonBlank(input.target)) {
+    reasons.push(...refuseLabAsSpecimen(input.target));
+  }
+  if (input.direction !== 'biology-to-engineering' || input.equivalent !== false) {
+    errors.push('/direction and equivalent must remain biology-to-engineering / false');
+    reasons.push('engineering-as-biology');
+  }
+  if (!isNonBlank(input.limit)) errors.push('/limit is required');
+  if (!isNonBlank(input.nonEquivalence)) errors.push('/nonEquivalence is required');
+  if (input.note !== undefined && !isNonBlank(input.note)) errors.push('/note is invalid');
+  validateReview(input.review, errors);
+  if (errors.length > 0 || reasons.length > 0) return fail(errors, reasons);
+  return { valid: true, errors: [], reasons: [], value: input as AnalogLink };
+};
+
+export const validateObservationCatalog = (
+  input: unknown,
+): Validation<ObservationCatalog> => {
+  const errors: string[] = [];
+  const reasons: RefusalReason[] = collectForbiddenReasons(input);
+  if (!isObject(input)) return fail(['/ must be an object'], reasons);
+  if (input.kind !== 'ObservationCatalog') errors.push('/kind is invalid');
+  if (input.workspaceRef !== WORKSPACE_REF) errors.push('/workspaceRef is invalid');
+  if (input.catalogSpecimen !== false) reasons.push('lab-as-specimen');
+  reasons.push(...validateTaxon(input.taxon, errors));
+  if (!Array.isArray(input.records)) {
+    errors.push('/records must be an array');
+  } else {
+    input.records.forEach((record) => {
+      const inner = validateObservation(record);
+      if (!inner.valid) {
+        errors.push(...inner.errors);
+        reasons.push(...inner.reasons);
+      }
+    });
+  }
+  if (errors.length > 0 || reasons.length > 0) return fail(errors, reasons);
+  return { valid: true, errors: [], reasons: [], value: input as ObservationCatalog };
+};
+
+export const asReview = (value: Review): Review => value;
+
+export type { Measurement };

--- a/projects/biomemetics/labs/mantis/observations/test/pipeline.test.ts
+++ b/projects/biomemetics/labs/mantis/observations/test/pipeline.test.ts
@@ -1,0 +1,404 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { deriveAnalog } from '../../analogs/src/analog.ts';
+import { planGovernedProjection } from '../../analogs/src/projection.ts';
+import { deriveFunction, deriveMechanism } from '../../mechanisms/src/mechanism.ts';
+import { deriveStructure } from '../../morphology/src/structure.ts';
+import {
+  COMMITTED_LANES_ROOT,
+  committedStateIsEmpty,
+  inspectLanes,
+  traverse,
+} from '../src/pipeline.ts';
+import { PipelineRefused, type Review } from '../src/types.ts';
+
+const accepted: Review = {
+  status: 'accepted',
+  reviewer: 'reviewer@example.test',
+  reviewedAt: '2026-08-20T13:00:00Z',
+};
+
+const pending: Review = { status: 'pending' };
+
+const gitSha = 'e435400442ce4fe099073ebd0e384d12a3aca09e';
+
+const writeMedia = (): { absolutePath: string; lanesRelativePath: string } => {
+  const dir = mkdtempSync(join(tmpdir(), 'mantis-obs-'));
+  const absolutePath = join(dir, 'drop.jpg');
+  writeFileSync(absolutePath, Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+  return {
+    absolutePath,
+    lanesRelativePath: 'observations/media/drop.jpg',
+  };
+};
+
+const visibleStatements = [
+  {
+    text: 'A segmented raptorial foreleg is visible in the frame.',
+    status: 'observed' as const,
+    sourceRef: 'observations/media/drop.jpg',
+  },
+];
+
+const mediaBase = () => ({
+  ...writeMedia(),
+  observationId: 'obs-drop-01',
+  recordedAt: '2026-08-20T12:00:00Z',
+  license: 'CC-BY-4.0',
+  consent: 'owner-supplied laboratory drop',
+  mediaType: 'image/jpeg',
+  statements: visibleStatements,
+  review: accepted,
+});
+
+const structureDraft = {
+  structureId: 'str-foreleg-01',
+  basis: 'observed' as const,
+  description: 'Segmented raptorial foreleg visible in the admitted frame.',
+  review: accepted,
+};
+
+const mechanismDraft = {
+  mechanismId: 'mech-grasp-01',
+  hypothesis: 'Spines on the foreleg increase prey retention during a grasp.',
+  falsifier: 'A grasp sequence without spine contact would retain prey equally.',
+  status: 'unverified' as const,
+  states: ['open', 'close', 'hold'],
+  members: { moving: ['tibia'], grounded: ['coxa'] },
+  failureModes: ['slip under load'],
+  verificationPlan: 'High-speed video of a grasp with scale.',
+  review: accepted,
+};
+
+const functionDraft = {
+  functionId: 'fn-retain-01',
+  statement: 'The foreleg retains prey after contact.',
+  status: 'unverified' as const,
+  limits: ['Not observed as a completed strike in this frame.'],
+  review: accepted,
+};
+
+const analogDraft = {
+  analogId: 'an-latch-01',
+  target: 'terrarium.binder.retention',
+  limit: 'Inspiration for a latch geometry study only.',
+  nonEquivalence: 'A printed latch is not a raptorial tibia.',
+  note: 'Directional mapping; independent mechanical evidence still required.',
+  review: accepted,
+};
+
+const refuse = (fn: () => unknown): PipelineRefused => {
+  try {
+    fn();
+  } catch (error) {
+    assert.equal(error instanceof PipelineRefused, true);
+    return error as PipelineRefused;
+  }
+  throw new Error('expected PipelineRefused');
+};
+
+test('committed lanes stay empty: no photo, taxon unknown, lab is not a Specimen', () => {
+  const state = inspectLanes(COMMITTED_LANES_ROOT);
+  assert.equal(committedStateIsEmpty(state), true);
+  assert.deepEqual(state.observations.taxon, {
+    status: 'unknown',
+    reason: 'no-real-media',
+  });
+  assert.equal(state.observations.catalogSpecimen, false);
+  assert.deepEqual(state.mediaFiles, []);
+  assert.deepEqual(state.analogs.records, []);
+});
+
+test('refuses invented GPS/locality on the caller envelope', () => {
+  const error = refuse(() =>
+    traverse({
+      media: mediaBase(),
+      gitSha,
+      runId: 'run-01',
+      caller: { gps: { lat: 1, lon: 2 } },
+    }),
+  );
+  assert.ok(error.reasons.includes('invented-locality'));
+});
+
+test('refuses an uncited taxon name', () => {
+  const error = refuse(() =>
+    traverse({
+      media: {
+        ...mediaBase(),
+        taxon: 'Mantis religiosa' as unknown as never,
+      },
+      gitSha,
+      runId: 'run-01',
+    }),
+  );
+  assert.ok(error.reasons.includes('invented-taxon'));
+});
+
+test('refuses treating the lab as a Specimen or inserting one', () => {
+  const lab = refuse(() =>
+    traverse({
+      media: mediaBase(),
+      gitSha,
+      runId: 'run-01',
+      specimenId: 'biomemetics.mantis',
+    }),
+  );
+  assert.ok(lab.reasons.includes('lab-as-specimen'));
+
+  const insert = refuse(() =>
+    traverse({
+      media: mediaBase(),
+      gitSha,
+      runId: 'run-01',
+      insertSpecimen: true,
+    }),
+  );
+  assert.ok(insert.reasons.includes('specimen-insert-forbidden'));
+});
+
+test('refuses a store write and an injected attach cannot execute', () => {
+  const error = refuse(() =>
+    traverse({
+      media: mediaBase(),
+      gitSha,
+      runId: 'run-01',
+      writeStore: true,
+    }),
+  );
+  assert.ok(error.reasons.includes('store-write-forbidden'));
+
+  let writes = 0;
+  const result = traverse({
+    media: mediaBase(),
+    structure: structureDraft,
+    mechanism: mechanismDraft,
+    fn: functionDraft,
+    analog: analogDraft,
+    gitSha,
+    runId: 'run-01',
+  });
+  const attach = async () => {
+    writes += 1;
+    return { storeWrite: true };
+  };
+  void attach;
+  assert.equal(result.projection.executable, false);
+  assert.equal(result.projection.storeWrite, false);
+  assert.equal(result.projection.localityMutated, false);
+  assert.equal(result.projection.taxonMutated, false);
+  assert.equal(result.projection.blocker, 'specimendb-attach-unavailable');
+  assert.equal(writes, 0);
+});
+
+test('refuses analog without function', () => {
+  const missing = refuse(() =>
+    traverse({
+      media: mediaBase(),
+      structure: structureDraft,
+      mechanism: mechanismDraft,
+      analog: analogDraft,
+      gitSha,
+      runId: 'run-01',
+    }),
+  );
+  assert.ok(missing.reasons.includes('missing-function'));
+});
+
+test('validateAnalog refuses equivalence and lab targets', async () => {
+  const { validateAnalog } = await import('../src/validate.ts');
+  const fn = {
+    schemaVersion: '1.0.0' as const,
+    kind: 'Function' as const,
+    functionId: 'fn-retain-01',
+    mechanismRef: 'mech-grasp-01',
+    workspaceRef: 'biomemetics.mantis' as const,
+    statement: 'The foreleg retains prey after contact.',
+    status: 'unverified' as const,
+    limits: ['Frame only.'],
+    review: accepted,
+  };
+  const equivalent = validateAnalog(
+    {
+      schemaVersion: '1.0.0',
+      kind: 'AnalogLink',
+      analogId: 'an-bad',
+      functionRef: 'fn-retain-01',
+      workspaceRef: 'biomemetics.mantis',
+      target: 'terrarium.binder.retention',
+      direction: 'engineering-to-biology',
+      equivalent: true,
+      limit: 'none',
+      nonEquivalence: 'claimed identical',
+      review: accepted,
+    },
+    fn,
+  );
+  assert.equal(equivalent.valid, false);
+  assert.ok(equivalent.reasons.includes('engineering-as-biology'));
+
+  const labTarget = validateAnalog(
+    {
+      schemaVersion: '1.0.0',
+      kind: 'AnalogLink',
+      analogId: 'an-lab',
+      functionRef: 'fn-retain-01',
+      workspaceRef: 'biomemetics.mantis',
+      target: 'biomemetics.mantis',
+      direction: 'biology-to-engineering',
+      equivalent: false,
+      limit: 'none',
+      nonEquivalence: 'lab is not an analog target',
+      review: accepted,
+    },
+    fn,
+  );
+  assert.ok(labTarget.reasons.includes('lab-as-specimen'));
+});
+
+test('refuses measured structure without measurements, and simulated-as-measured', () => {
+  const error = refuse(() =>
+    traverse({
+      media: mediaBase(),
+      structure: { ...structureDraft, basis: 'measured' },
+      gitSha,
+      runId: 'run-01',
+    }),
+  );
+  assert.ok(error.reasons.includes('measurement-incomplete'));
+
+  const relabel = refuse(() =>
+    deriveMechanism(undefined, {
+      ...mechanismDraft,
+      status: 'observed' as unknown as 'unverified',
+    }),
+  );
+  assert.ok(relabel.reasons.includes('source-class-relabeled'));
+});
+
+test('refuses incomplete measurements and missing license/consent/media', () => {
+  const incomplete = refuse(() =>
+    traverse({
+      media: {
+        ...mediaBase(),
+        measurements: [
+          {
+            parameterRef: 'foreleg.length',
+            value: 12,
+            unit: 'mm',
+            uncertainty: 0,
+            method: '',
+            scaleEvidence: '',
+          },
+        ],
+      },
+      gitSha,
+      runId: 'run-01',
+    }),
+  );
+  assert.ok(incomplete.reasons.includes('measurement-incomplete'));
+
+  const noLicense = refuse(() =>
+    traverse({
+      media: { ...mediaBase(), license: '' },
+      gitSha,
+      runId: 'run-01',
+    }),
+  );
+  assert.ok(noLicense.reasons.includes('missing-license'));
+
+  const noFile = refuse(() =>
+    traverse({
+      media: {
+        ...mediaBase(),
+        absolutePath: join(tmpdir(), 'no-such-mantis.jpg'),
+      },
+      gitSha,
+      runId: 'run-01',
+    }),
+  );
+  assert.ok(noFile.reasons.includes('no-real-media'));
+});
+
+test('real media can traverse observation → structure → mechanism → function → analog', () => {
+  const result = traverse({
+    media: mediaBase(),
+    structure: structureDraft,
+    mechanism: mechanismDraft,
+    fn: functionDraft,
+    analog: analogDraft,
+    gitSha,
+    runId: 'run-01',
+  });
+  assert.equal(result.observation.kind, 'Observation');
+  assert.equal(result.observation.taxon.status, 'unknown');
+  assert.equal(result.observation.media.sha256.length, 64);
+  assert.equal(result.structure?.kind, 'Structure');
+  assert.equal(result.mechanism?.kind, 'Mechanism');
+  assert.equal(result.fn?.kind, 'Function');
+  assert.equal(result.analog?.kind, 'AnalogLink');
+  assert.equal(result.analog?.equivalent, false);
+  assert.equal(result.analog?.direction, 'biology-to-engineering');
+  assert.equal(result.projection.executable, false);
+  assert.equal(result.projection.storeWrite, false);
+  assert.match(
+    result.projection.evidenceRef,
+    /^evidence\/runs\/mantis-04-observation-pipeline\//,
+  );
+  assert.deepEqual(
+    result.projection.projections.map((item) => item.component._tag),
+    ['Observation', 'Structure', 'Mechanism', 'Function', 'AnalogLink'],
+  );
+  const analog = result.projection.projections.at(-1)?.component;
+  assert.equal(analog?._tag, 'AnalogLink');
+  if (analog?._tag === 'AnalogLink') {
+    assert.equal(analog.target, 'terrarium.binder.retention');
+  }
+});
+
+test('cited taxon guess requires a citation; unverified observation cannot project', () => {
+  const cited = traverse({
+    media: {
+      ...mediaBase(),
+      taxon: {
+        status: 'cited-guess',
+        name: 'operator-cited-guess',
+        confidence: 0.4,
+        citation: 'operator-supplied literature handle, not a determination',
+      },
+    },
+    gitSha,
+    runId: 'run-01',
+  });
+  assert.equal(cited.observation.taxon.status, 'cited-guess');
+  if (cited.observation.taxon.status === 'cited-guess') {
+    assert.equal(cited.observation.taxon.citation.length > 0, true);
+  }
+
+  const unverified = refuse(() =>
+    planGovernedProjection({
+      observation: {
+        ...cited.observation,
+        review: pending,
+      },
+      gitSha,
+      runId: 'run-01',
+    }),
+  );
+  assert.ok(unverified.reasons.includes('unverified-evidence'));
+});
+
+test('downstream derive without an upstream record is empty-or-refused', () => {
+  const structure = refuse(() => deriveStructure(undefined, structureDraft));
+  assert.ok(structure.reasons.includes('missing-observation'));
+  const mechanism = refuse(() => deriveMechanism(undefined, mechanismDraft));
+  assert.ok(mechanism.reasons.includes('missing-structure'));
+  const fn = refuse(() => deriveFunction(undefined, functionDraft));
+  assert.ok(fn.reasons.includes('missing-mechanism'));
+  const analog = refuse(() => deriveAnalog(undefined, analogDraft));
+  assert.ok(analog.reasons.includes('missing-function'));
+});

--- a/projects/biomemetics/labs/mantis/observations/tsconfig.json
+++ b/projects/biomemetics/labs/mantis/observations/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": "..",
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../morphology/src/**/*.ts",
+    "../mechanisms/src/**/*.ts",
+    "../analogs/src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tracks #19. Does not touch PR #12 / `packages/specimendb` / PR #33. Do not merge.

Observation → morphology/structure → mechanism → function → analog under the four knowledge lanes. Committed catalogs are empty: there is no mantis photo, taxon is `unknown` / `no-real-media`, and the lab is not a Specimen.

Write set (only):
- `projects/biomemetics/labs/mantis/observations/**`
- `projects/biomemetics/labs/mantis/morphology/**`
- `projects/biomemetics/labs/mantis/mechanisms/**`
- `projects/biomemetics/labs/mantis/analogs/**`

Behavior:
- Real media is required to admit an Observation (digest, license, consent). Tests use a temp file; nothing is invented in-tree.
- Taxon is unknown unless a cited guess is supplied. GPS/locality keys are refused.
- Downstream records exist only when bound to the previous lane. Analogs are directional and non-equivalent.
- Governed projection mirrors the #16 Attach tags (PR 33) as read-only: `executable: false`, `storeWrite: false`. It does not call a store or insert a Specimen. Evidence refs stay under `evidence/runs/mantis-04-observation-pipeline/<sha>/<run-id>/`.

Acceptance:
```
cd projects/biomemetics/labs/mantis/observations
node --test --experimental-strip-types test/*.test.ts
node --experimental-strip-types src/pipeline.ts
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40ca00a1-66f4-4453-88ab-29b8690521b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40ca00a1-66f4-4453-88ab-29b8690521b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

