### PR TITLE
feat(specimendb): page-function synth and bind Terminal/Workbench wells

### DIFF
--- a/packages/specimendb/docs/functionalization-journal.md
+++ b/packages/specimendb/docs/functionalization-journal.md
@@ -176,3 +176,14 @@ Static HTML + vendored ExifTool WASM. Not a React surface. Does not call PGlite,
 | F-108 | stamp + download | — | now | on-device `writeMetadata`; no upload; no Intake |
 | F-109 | ExifTool WASM | — | now | `vendor/`; no CDN at shot time |
 
+## Strips found after the first walk
+
+The strip journal is the floor. `docs/page-function-synth.md` is the product bag (export, assay execute, edit meta, analog edges, media layers, capture→intake, viewer, filters, last-modified, owner, …). Do not rewrite verdicts above. These rows are new glass that already had a well, now filled from store data that already exists.
+
+| ID | Strip | Component | Verdict | Bind |
+|---|---|---|---|---|
+| F-110 | Terminal `PROTOCOL ID` value | SpecimenId | now | selected branded id. F-014 still kills SP- / SEQ- theater |
+| F-111 | Workbench `EXPORT DB` | Specimen list | now | download `specimendb-catalog.json` of List items. Empty catalog is `[]`. F-045 chrome was the button type; RUN SIM stays inert |
+| F-112 | Workbench `LAST_UPDATED` | createdAt / Exif DateTimeOriginal | now | `LAST_UPDATED` + ISO, or DateTimeOriginal when that tag arrived. Never the constant `14m AGO` |
+| F-113 | Terminal process log EXIF lines | Exif | now | Make / Model / DateTimeOriginal when tags arrived. GPS stays on the locality line |
+

--- a/packages/specimendb/docs/page-function-synth.md
+++ b/packages/specimendb/docs/page-function-synth.md
@@ -1,0 +1,344 @@
+# Page-function synth
+
+The strip journal (`functionalization-journal.md`) walked the glass left to right. That is the floor. This file is the product bag: every theoretical function the six Variant pages plus `/capture/` pretend to do, the subsystem each one needs, what is actually bound, and the next binds that make the catalog work.
+
+Specimen is the only type. AnalogCard is a card template. PGlite is SoT. Intake/Get/List/Promote are the only RPCs. Locality is `unknown` unless EXIF GPS or capture-page geo arrived. No SP- / SEQ- / OD- / PX- / COL- / GEK- ids, no invented GPS, no taxon, no ML%.
+
+Bind state in this file:
+
+| State | Meaning |
+|---|---|
+| **live** | Reads or writes the store. Real branded id, real Status, real Claim, real Media, locality from EXIF or `unknown`. |
+| **empty-unknown** | Well exists. Renders empty or `unknown`. Waiting on a component that is allowed to stay missing. |
+| **chrome** | Type only. No store write. Keep the look. |
+| **theater** | A fake value was on the Variant HTML (SP-2023-084, 99.8%, oceanography, "14m AGO" as a constant). Killed. Well stays. |
+| **missing** | The glass wants it. No well, no RPC, or both. |
+
+Now-rows from the journal stay now. This cut binds three wells the journal left chrome or empty even though the store already has the data: Terminal PROTOCOL ID, Workbench EXPORT DB, Workbench LAST_UPDATED. Plus EXIF lines in the Terminal process log when tags actually arrived.
+
+---
+
+## Terminal `/intake` IntakeDrop
+
+Raw intake bench. Variant Terminal HTML, not a mashed shell. Media bytes live here (F-006). Query and status filters do not. Those belong on Workbench.
+
+### Theoretical functions
+
+| Function | What the glass pretends | Subsystem | Bind | Goal |
+|---|---|---|---|---|
+| Initiate intake | Drop or pick field media, spawn a raw Specimen | Intake RPC, AssetStore, EXIF, Status=`raw`, Locality | **live** | JPEG/HEIC only. `.raw` / `.tiff` / `.csv` / sequencing archives stay later. |
+| Local catalog list | Scroll of filed records | List RPC | **live** | Keep. Empty card chrome when List is empty. |
+| SYS_ONLINE | Client can talk to the catalog | List success | **live** | List error → SYS_OFFLINE. No fake heartbeat. |
+| Card select / Get | Open one record | Get RPC | **live** | Same Get as every other page. |
+| Status pill | Show and advance lab state | Status, Promote | **live** | Click real card → `raw → filed → working → dead`. Empty chrome does not Promote. |
+| Claim line | 10-second one-liner | Claim | **live** (empty) | Stays empty until someone attaches Claim. No filename-as-claim. |
+| Media well | Field photo in the card | Media bytes, object URL | **live** | Session object URL from the dropped File. Reload loses the preview (no GetMedia RPC). |
+| IMG_SRC caption | Filename under the well | Media.filename | **live** as label | Label, not a claim. |
+| Locality | Where it was collected | Locality, EXIF GPS | **live** | `unknown` unless EXIF. Never invent coords. |
+| Tag chips (3) | Discipline / method labels | Tag | **empty-unknown** | Empty slots until Tag is attached. No LEPIDOPTERA theater. |
+| PROTOCOL ID well | Accession / protocol string | SpecimenId | **live** this cut | Selected branded id. F-014 still kills SP-/SEQ- theater. |
+| CLASS / ORDER | Taxonomy ranks | Taxon | **theater** well | Empty. No binomial. No ML%. |
+| EXTRACTION VECTOR | Prep / extraction method | Structure / Mechanism (none yet) | **empty-unknown** | Keep empty. Needs a real component later. |
+| THERMAL BASE | Temperature / thermal metric | later assay | **empty-unknown** | No invented °C. |
+| SPECTROSCOPY | Spectral ID / taxon-from-spectra | Taxon, spectral | **theater** well | Empty. No 99.8%. |
+| CELLULAR VIABILITY | Live/dead assay readout | later assay | **empty-unknown** | Keep empty. |
+| ANALYSIS_ACTIVE | A working analysis is running | chrome | **chrome** | Type only. Does not Promote. |
+| `_ LIVE_FEED` | Streaming instrument | live feed | **chrome** | Keep the mark. No fake waveform data. |
+| Waveform panel | Chromatophore / spectral trace | later assay, viewer | **empty-unknown** | Empty tech-grid. No R:0.992. |
+| Process log | Chronological notes + what arrived | Observation, Exif, Media | **live** for arrived facts | Claim, locality, filename. EXIF Make/Model/DateTimeOriginal when tags exist. Observation notes stay empty-unknown. |
+| Last-modified | How stale the record is | Specimen.createdAt, Exif DateTimeOriginal | **missing** on this page | Bound on Workbench LAST_UPDATED. Terminal does not grow a second clock. |
+| Owner / UID | Who holds the record | no Owner component | **missing** | Do not invent DR. E. VANCE. No owner RPC. |
+| INITIATE_SCAN | Kick a scan / capture from the bench | capture path, later instrument | **missing** | Not on this React page. Capture is `/capture/`. |
+| EDIT_RECORD | Mutate claim / tags / meta | Update RPC (does not exist) | **missing** | IntakePayload.claim exists. UI never sends it. |
+| Query accession | Search the rail | search | **missing** here | Workbench owns Q QUERY. Do not mash filters onto Terminal. |
+| Status filters | ALL / pending / archived | Status filter | **missing** here | Variant HTML showed ACQ_PENDING. We bind the real machine on Workbench (RAW/FILED/WORKING/DEAD). |
+| Broader intake types | `.raw` `.tiff` `.csv` telemetry, seq archives | Intake, media kind | **missing** | `isJpegHeic` rejects them with `JPEG/HEIC first`. |
+| Crosshair / SPECIMEN_DB mark | Lab chrome | chrome | **chrome** | Keep. |
+| Empty card template | Density when the catalog is empty | chrome | **chrome** | Stays. No "NO RECORDS". |
+
+### Subsystems this page needs
+
+Intake, List, Get, Promote, AssetStore, EXIF extract, Locality, Status machine, Claim, Media bytes, Tag (when), Observation (when), Taxon (never invent). No search. No export. No analog graph.
+
+### Goal
+
+A drop of a no-GPS JPEG files a branded id, Status `raw`, Media bytes, locality `unknown`, PROTOCOL ID equal to that id, process log showing filename. A GPS JPEG shows real coords. Promote from the pill. That path is live. Next on this page is GetMedia so the well survives reload, then a Claim/Observation write so the log is not only EXIF.
+
+---
+
+## Workbench `/rail` SpecimenRail
+
+Catalog workbench. Query + status filter + properties log. Photo well on the rail is chrome (media now is Terminal F-006). Icon strip plus opens intake. Other strip icons are chrome.
+
+### Theoretical functions
+
+| Function | What the glass pretends | Subsystem | Bind | Goal |
+|---|---|---|---|---|
+| List on mount | Rail of specimens | List RPC | **live** | Empty card chrome when empty. |
+| Q QUERY ACCESSION ID | Filter by id | search (client) | **live** | Lowercase `includes` on SpecimenId. Does not match filename or claim. Placeholder is accession id, so that is correct. |
+| Status filters | ALL / RAW / FILED / WORKING / DEAD | Status | **live** | Client filter on List. Variant labels (ACQ_PENDING, REQUIRES_QC, ARCHIVED) were theater for this machine. |
+| Intake sequence | Drop telemetry, spawn raw | Intake | **live** | Same JPEG/HEIC gate. |
+| Card Status + Promote | Advance the machine | Status, Promote | **live** | Empty chrome does not Promote. |
+| Card Claim | One-liner | Claim | **live** (empty) | Empty unless attached. |
+| Card locality + pin | Collection place | Locality | **live** | `unknown` or EXIF. F-034 was `when`; the well is filled. |
+| Tag chips `[ ]` | Three tags | Tag | **empty-unknown** | Empty `[]` slots. |
+| Accession id on card | Identity | SpecimenId | **live** | Branded UUID. No SP-. |
+| Photo well `h-40` | Field photo on the rail | Media | **chrome** | Empty on purpose. Bytes live on Terminal. |
+| Get on select | Fill the detail column | Get | **live** | |
+| EXPORT DB | Dump the catalog | export, List | **live** this cut | Downloads `specimendb-catalog.json` of current List items. Empty catalog downloads `[]`. No store write. |
+| RUN SIM | Run a physics / FEM sim | sim, later working | **chrome** / **theater** ids | Button stays. No click handler. No SEQ- / sim theater. |
+| VIEWPORT_XZ | Spatial / section viewer | viewer, Media | **empty-unknown** | ViewportMark chrome. No fake scan. |
+| MAG | Magnification readout | viewer | **chrome** | Label only. |
+| ACTIVE_RENDER | Viewer is drawing | chrome | **chrome** | |
+| CLASSIFICATION ranks | Phylum Class Order Family | Taxon | **theater** well | Empty ranks. Never fill from ML. |
+| STRUCTURAL METRICS | Tensile / density / modulus | Structure | **empty-unknown** | Keep empty. |
+| Elev / Temp | Field environment | Locality.altitude, later | **empty-unknown** | Altitude exists on Locality when EXIF had it. Not painted yet. No invented °C. |
+| OBSERVATION LOG | Notes | Observation | **empty-unknown** | Empty `<p>`. |
+| LAST_UPDATED | Record clock | createdAt, Exif DateTimeOriginal | **live** this cut | `LAST_UPDATED` + ISO createdAt, or DateTimeOriginal when that tag arrived. Never the constant `14m AGO`. |
+| ONLINE | Client health | List success | **live** | Hidden text ONLINE/OFFLINE. |
+| Icon strip (cube/grid/sliders) | App nav | catalog routing | **chrome** | Plus is intake. Other icons do not route. Testbed routing is the URL. |
+| Edit meta | Change claim / tags | Update RPC | **missing** | |
+| Capture from workbench | Camera | capture path | **missing** | `/capture/` is a different page. |
+
+### Subsystems this page needs
+
+List, Get, Intake, Promote, search (id), status filter, export, Locality, Claim, Tag, Taxon (empty), Structure (empty), Observation (empty), viewer (later), sim (later), Update (missing).
+
+### Goal
+
+Query + filter + intake + Promote + export is the operational core. Next is painting Locality.altitude into Elev when `fixed`, then an Observation write into the log, then VIEWPORT showing Media bytes (that fights the "photo well is Terminal" split; do it only when GetMedia exists).
+
+---
+
+## Assay `/assay` WorkingPanel
+
+Working biology. 440px rail, dashed intake, focus record, viewport, four channels, instrument / environment / log. Variant also showed EXECUTE ASSAY, EDIT META, instrument feedout, SEQ-882.C. Those last ones are not in the React page.
+
+### Theoretical functions
+
+| Function | What the glass pretends | Subsystem | Bind | Goal |
+|---|---|---|---|---|
+| INITIATE_INTAKE_PROTOCOL | Drop media, spawn raw | Intake | **live** | Same JPEG/HEIC. |
+| Working-set rail | 440px list | List | **live** | Empty chrome when empty. |
+| Get on rail select | Focus one Specimen | Get | **live** | |
+| CURRENT_FOCUS_RECORD | The active working id | SpecimenId | **live** after select | Empty string until Get. No SEQ-. |
+| Focus Status + Promote | Advance while working | Status, Promote | **live** | |
+| Focus Claim | One-liner | Claim | **live** (empty) | |
+| Focus locality | Place | Locality | **live** | `unknown` unless EXIF. |
+| Focus coords theater | GPS numbers next to focus | Locality numbers | **theater** | Killed. |
+| VIEWPORT | Live stage / media | Media, viewer | **empty-unknown** | Empty stage. |
+| CH-01..CH-04 | Media / instrument channels | media layers | **empty-unknown** | Empty wells. Attach-layer is missing. |
+| INSTRUMENT GAIN/OFFSET/WINDOW | Scope controls | later assay | **empty-unknown** | Keep empty. |
+| ENVIRONMENT SALINITY/PRESSURE/CURRENT | Oceanography | never | **theater** well | Empty. Do not invent a reef. |
+| LOG | Assay notes + errors | Observation, intakeError | **live** for errors | Intake errors only. Observation empty. |
+| EXECUTE ASSAY | Run the working protocol | assay execute, working status | **missing** | Not in the React tree. Needs Status `working` plus a real runner. No fake spectra. |
+| EDIT META | Patch claim / tags | Update RPC | **missing** | |
+| Instrument feedout | Live stream | live feed | **missing** | |
+| Channel kickers | CH-01 labels | chrome | **chrome** | |
+
+### Subsystems this page needs
+
+Intake, List, Get, Promote, Status, Claim, Locality, Media/viewer, media layers, Observation, assay runner (missing), Update (missing), live feed (later). Environment metrics are never.
+
+### Goal
+
+Rail + focus + Promote is live. Do not fill channels or instrument until there is a working runner that writes real Observation or Media. EXECUTE ASSAY is the next glass bind, and it is blocked on that runner plus Status already `working`.
+
+---
+
+## Dactyl `/dactyl` AnalogCard
+
+One-specimen analog cards in a grid. AnalogCard is not a second entity. Active Queue is chrome. Scrollbars are 6px on `dactyl.css`.
+
+### Theoretical functions
+
+| Function | What the glass pretends | Subsystem | Bind | Goal |
+|---|---|---|---|---|
+| DROP_FIELD_MEDIA | Intake | Intake | **live** | |
+| AnalogCard grid | List as analog cards | List | **live** | Template chrome when empty. |
+| Get on card select | Select one Specimen | Get | **live** | |
+| Card Status + Promote | Machine | Status, Promote | **live** | |
+| Card Claim | One-liner | Claim | **live** (empty) | |
+| Locality | Place | Locality | **live** | `unknown` unless EXIF. |
+| Analog coords theater | GPS on the analog | Locality numbers | **theater** | Killed. |
+| Fake analog ids | GEK- / OD- | SpecimenId theater | **theater** | Killed. Real branded id on the card. |
+| Analog tags | Tags on the analog | Tag | **empty-unknown** | Not painted (Assay-like card has no tag row). |
+| Card media well | Photo | Media | **empty-unknown** | Empty chrome. Bytes live on Terminal. |
+| ACTIVE QUEUE | Working set of analogs | chrome, not a type | **chrome** | Three empty slots. Do not promote Queue to an entity. |
+| Analog graph / edges | This specimen is like that one | AnalogLink | **empty-unknown** | Component exists. No UI, no write RPC. |
+| Stomatopod seed | Demo rows | seed | **theater** | Do not seed. |
+| Analog as a type | Second catalog type |  | **never** | Same Specimen. |
+
+### Subsystems this page needs
+
+Intake, List, Get, Promote, Status, Claim, Locality, AnalogLink (later), Tag (when), Media (when). No seed.
+
+### Goal
+
+Grid of real Specimens is live. Next is rendering AnalogLink targets as other SpecimenIds (Get the target, do not invent OD-). Writing an AnalogLink needs Update or AttachComponent, which does not exist.
+
+---
+
+## Catalog `/catalog` AppShell
+
+Hosted catalog page. Named AppShell. It is not the SPA router. Testbed `main.tsx` pathname switch is the router. Breadcrumb `SPECIMEN_DB / CATALOG` is chrome.
+
+### Theoretical functions
+
+| Function | What the glass pretends | Subsystem | Bind | Goal |
+|---|---|---|---|---|
+| Routed chrome | App frame around pages | catalog routing | **chrome** | This component is one page. Other routes are sibling pages. |
+| Breadcrumbs | Where you are | chrome | **chrome** | |
+| Intake drop | File media into the hosted catalog | Intake | **live** | Copy says JPEG/HEIC and GPS only if the file has it. Honest. |
+| Hosted cards | Grid of records | List | **live** | Empty chrome when empty. |
+| Select card | Get | Get | **live** | |
+| Card Status + Promote | Machine | Status, Promote | **live** | |
+| Card locality | Place | Locality | **live** | `unknown` unless EXIF. |
+| Card Claim | One-liner | Claim | **live** (empty) | |
+| Card id | Identity | SpecimenId | **live** | No OD-. |
+| Card Media filename | Attached file | Media.filename | **live** as label | No bytes well on this page. |
+| Catalog filters | Status / type chips | Status filter | **chrome** | F-084 type only. Workbench already has live filters. Copying StatusFilters here is cheap later. |
+| Taxon on cards | Rank / binomial | Taxon | **theater** | Empty. |
+| Catalog coords | GPS | Locality numbers | **theater** | Killed. |
+| Seed rows | Demo catalog | seed | **theater** | Do not seed. |
+| Left nav rail | Jump Terminal / Workbench / Assay / … | catalog routing | **missing** | Variant board has the rail. Testbed is typed URLs. |
+
+### Subsystems this page needs
+
+Intake, List, Get, Promote, Status, Claim, Locality, Media label, search/filter (chrome here), routing (testbed).
+
+### Goal
+
+Hosted intake + list is live. Next cheap bind is the same StatusFilters as Workbench. Routing between the six pages is a testbed concern until a real nav rail exists. Do not restyle this into a generic charcoal shell.
+
+---
+
+## Accession `/accession` DossierView
+
+Fat dossier. Photo rail + taxonomy table + field metrics + spectral grid + observer log. Variant also showed INITIATE_SCAN, EDIT_RECORD, OWNER, LAST_MODIFIED, ML confidence, a reflectance table with peak rows. Those extra controls are not in the React tree.
+
+### Theoretical functions
+
+| Function | What the glass pretends | Subsystem | Bind | Goal |
+|---|---|---|---|---|
+| FILE TO DOSSIER | Intake into this record set | Intake | **live** | Spawns a new Specimen. Does not attach a layer onto the selected one. |
+| Photo rail | List as thumbs | List, Media bytes | **live** | Object URL when this session dropped the file. |
+| Get on rail select | Fill the dossier | Get | **live** | |
+| Dossier Status + Promote | Machine | Status, Promote | **live** | |
+| Dossier Claim | One-liner | Claim | **live** (empty) | |
+| Lead photo | Large media | Media bytes | **live** | Same session object URL. |
+| IMG_SRC | Filename | Media.filename | **live** as label | |
+| Taxonomy table | Kingdom → Species | Taxon | **empty-unknown** | Rank rows exist. Cells empty. No binomial. No 99.8% (ML-GEN). |
+| Field-metrics locality | Place | Locality | **live** | `unknown` unless EXIF. |
+| Field-metrics Elev | Altitude | Locality.altitudeMeters | **empty-unknown** | Value exists on `fixed` Locality. Not painted. |
+| Field-metrics Temp | Ambient °C | later / never invent | **empty-unknown** | No invented 24.2°C. |
+| Spectral grid | UV…NIR reflectance | later assay | **empty-unknown** | Band kickers, empty wells. No peak theater. |
+| Observer log | Chronological notes | Observation | **empty-unknown** | Empty div. |
+| INITIATE_SCAN | Start a scan | capture / instrument | **missing** | |
+| EDIT_RECORD | Patch the dossier | Update RPC | **missing** | |
+| OWNER / UID | Custody | no Owner component | **missing** / **theater** | Do not invent DR. E. VANCE. |
+| LAST_MODIFIED | Clock | createdAt, Exif | **missing** here | Same data as Workbench LAST_UPDATED. Cheap to copy that line. |
+| Fake dossier ids | SP- / SEQ- / COL- | SpecimenId theater | **theater** | Killed. |
+| Attach layer | Another Media on the same Specimen | media layers, Attach | **missing** | Intake always creates a new Specimen. |
+
+### Subsystems this page needs
+
+Intake, List, Get, Promote, Media bytes, Status, Claim, Locality, Taxon (empty), Observation (empty), spectral (later), Update (missing), Owner (does not exist), media layers (missing).
+
+### Goal
+
+Dossier of a real selected Specimen is live for id, status, claim, locality, photo. Next cheap binds: LAST_UPDATED line from createdAt, Elev from Locality.altitudeMeters when `fixed`. Taxonomy stays empty until a human attaches Taxon. Spectral stays empty until a working assay writes numbers.
+
+---
+
+## Capture `/capture/` static phone page
+
+Seventh surface. Not a Variant run. Static HTML + vendored ExifTool WASM. Does not call PGlite, RPC, or Intake. The photo never uploads.
+
+### Theoretical functions
+
+| Function | What the glass pretends | Subsystem | Bind | Goal |
+|---|---|---|---|---|
+| Take or choose JPEG | Device camera / picker | capture | **live** | `accept="image/jpeg,image/*"` + `capture="environment"`. |
+| Locality acquiring | Ask the device | navigator.geolocation | **live** | enableHighAccuracy. No IP geo. |
+| Locality fixed | Stamp GPS tags | capture-page geo | **live** | Written into EXIF on download. |
+| Locality unknown | Denied / timeout / missing | Locality | **live** | GPS tags omitted. Never invented. |
+| Stamp + download | Bake DateTimeOriginal ± GPS | ExifTool WASM | **live** | On-device `writeMetadata`. |
+| Download name | Predictable filename | chrome naming | **live** | `specimen-YYYYMMDD-HHmmss.jpg`. Not a SpecimenId. |
+| Preview | Show the chosen file | Media preview | **live** | Object URL. |
+| Upload to catalog | capture→store | Intake | **missing** | Locked: the photo never uploads. Handoff is download, then drop onto `/intake` or `/rail`. |
+| CDN ExifTool | Fetch WASM from the net |  | **never** | Vendored under `capture/vendor/`. |
+
+### Subsystems this page needs
+
+Device geo, ExifTool WASM, download. Intake is a later handoff, not a call from this page.
+
+### Goal
+
+Keep capture offline. The operational path is stamp → download → drop on a catalog page. Wiring fetch(Intake) from the phone would break the "never uploads" lock. Do not.
+
+---
+
+## Cross-page subsystem map
+
+| Subsystem | Pages | RPC / code | Bind |
+|---|---|---|---|
+| Intake (spawn raw Specimen + Media + Exif + Locality) | all six Variant pages | `SpecimenRpcs.Intake` → `SpecimenRepo.intake` | live. JPEG/HEIC. Optional `claim` / `geo` unused by UI. |
+| List | all six | `List` | live |
+| Get on select | all six | `Get` | live |
+| Promote status machine `raw → filed → working → dead` | all six (real cards only) | `Promote` | live. Dead stays dead. |
+| PGlite SoT | repo, not UI | `@effect/sql-pglite@4.0.0-beta.93` | live in tests/repo. Testbed uses memory client with the same EXIF rules. |
+| AssetStore | Intake | `media/store.ts` | live on repo. UI never reads bytes back (no GetMedia). |
+| EXIF extract | Intake, capture stamp | `media/exif.ts`, capture ExifTool | live. Sidecar always written. |
+| Locality unknown / fixed | all pages that print locality | Locality component, `localityView` | live |
+| Search (accession id) | Workbench | client `visibleSpecimens` query | live. List RPC has no filter. |
+| Status filters | Workbench live; Catalog chrome; Terminal absent | client `statusFilter` | live on `/rail` only |
+| Export DB | Workbench | client dump of List | live this cut. No new RPC. |
+| Media bytes / viewer | Terminal + Accession live; Workbench/Dactyl chrome empty | object URL at drop | live in-session. Missing across reload. |
+| Media layers / attach layer | Assay channels, Accession intake | no Attach RPC | missing. Intake always inserts a new Specimen. |
+| Capture path | `/capture/` then drop | static page, then Intake | live as two steps. Not one RPC. |
+| Tag | Terminal / Workbench wells | Tag component | empty-unknown. No attach UI. |
+| Taxon | Terminal CLASS/ORDER, Workbench CLASSIFICATION, Accession table, Catalog cards | Taxon component | empty-unknown / theater killed. Never invent. |
+| Claim write | every claim line | Claim component, IntakePayload.claim | read live, write missing from UI. |
+| Observation / observer log / process log | Terminal, Workbench, Assay, Accession | Observation component | empty-unknown except Terminal EXIF/filename facts and Assay intakeError. |
+| Analog graph | Dactyl | AnalogLink | component only. No UI. |
+| Structure / Mechanism / Function | Workbench metrics, Terminal EXTRACTION VECTOR | those components | empty-unknown |
+| Question | none on glass | Question component | missing from every page |
+| Update / edit meta / EDIT_RECORD | Workbench, Assay, Accession | **no RPC** | missing. Biggest hole after GetMedia. |
+| Assay execute / RUN SIM / FEM / spectral numbers | Workbench RUN SIM, Assay EXECUTE, Accession spectral, Terminal waveform | none | chrome wells. later. No fake traces. |
+| Live feed / instrument | Terminal LIVE_FEED, Assay feedout | none | chrome |
+| Owner / UID | Accession, Variant header | no component | missing. Do not invent. |
+| Catalog routing | Variant left rail, testbed URLs | `testbed/main.tsx` | chrome. Six sibling pages. |
+| Seed / demo rows | Catalog, Dactyl |  | never |
+
+There is no DuckDB path. Do not retarget the store.
+
+---
+
+## Iteration order
+
+Bind next so the catalog actually works, not so the journal gets longer.
+
+1. **This cut (done).** Terminal PROTOCOL ID = selected branded id. Workbench EXPORT DB = List JSON. Workbench LAST_UPDATED = createdAt or DateTimeOriginal. Terminal process log prints EXIF Make/Model/DateTimeOriginal when those tags arrived.
+2. **GetMedia (or read AssetStore from the client).** Terminal and Accession wells go blank after reload. That is the first thing a lab will call a bug.
+3. **AttachComponent / Update RPC.** Claim, Tag, Observation, AnalogLink, Taxon (human), Structure cannot be written from the glass. IntakePayload.claim is a back door that the UI does not use. Pick one write (`Observation` or `Claim`) and bind it on Terminal process log + Workbench OBSERVATION LOG.
+4. **Paint Locality.altitudeMeters into Elev** on Workbench and Accession when state is `fixed`. Still no invented Temp.
+5. **Copy Workbench StatusFilters onto Catalog** (F-084). Same store field. Cheap.
+6. **Copy LAST_UPDATED onto Accession.** Same helper.
+7. **AnalogLink read.** Dactyl cards list `target` SpecimenIds that already exist. No seed. No OD-.
+8. **Broader Intake kinds** (tiff/csv/raw) only after JPEG/HEIC + GetMedia are boring.
+9. **EXECUTE ASSAY / RUN SIM / waveform / spectral / channels.** Needs a working runner that writes real Observation or Media. Until then the wells stay empty.
+10. **capture→Intake in one hop.** Blocked on purpose. Keep download-then-drop.
+11. **Owner, ML taxon, GPS theater, SEQ- ids.** Never.
+
+Do not mash Terminal and Workbench into one shell to "finish" search. Query stays on `/rail`.
+
+---
+
+## This cut vs deferred
+
+**Walked.** Terminal, Workbench, Assay, Dactyl, Catalog, Accession, Capture.
+
+**Bound.** PROTOCOL ID, EXPORT DB, LAST_UPDATED, EXIF process-log lines. Existing now-rows (Intake/List/Get/Promote/Status/Claim/Media/locality) were already live; this does not relitigate them.
+
+**Deferred.** GetMedia, Update/Attach, Elev from altitude, Catalog filters, Accession clock, AnalogLink UI, assay runner, capture upload, taxon, owner, sim.

--- a/packages/specimendb/src/ui/IntakeDrop.tsx
+++ b/packages/specimendb/src/ui/IntakeDrop.tsx
@@ -11,7 +11,7 @@ import { statusOf } from '../schemas/specimen.js';
 import type { Specimen } from '../schemas/specimen.js';
 import type { SpecimenStatus } from '../schemas/components.js';
 import { at, localityLabel, onStatusPromote, visibleSpecimens, type CatalogState, type CatalogSurface } from './catalog-stx.js';
-import { claimLine, imgSrcLabel, mediaLabel, tagSlots } from './catalog-view.js';
+import { claimLine, exifLogLines, imgSrcLabel, mediaLabel, tagSlots } from './catalog-view.js';
 import { useIntakeBind, type IntakeBind } from './intake-bind.js';
 import './catalog.css';
 
@@ -311,7 +311,12 @@ function IntakeDropDetail() {
             <div className="sdb-t-kicker" data-testid="kicker">
               {kicker}
             </div>
-            <div className="sdb-t-cell-value" />
+            <div
+              className="sdb-t-cell-value"
+              {...(kicker === 'PROTOCOL ID' ? { 'data-testid': 'protocol-id' } : {})}
+            >
+              {kicker === 'PROTOCOL ID' && selected !== null ? selected.id : ''}
+            </div>
           </div>
         ))}
       </div>
@@ -336,6 +341,11 @@ function IntakeDropDetail() {
                     {mediaLabel(selected)}
                   </p>
                 ) : null}
+                {exifLogLines(selected).map((line) => (
+                  <p className="sdb-t-locality" key={line} data-testid="detail-exif">
+                    {line}
+                  </p>
+                ))}
               </>
             ) : null}
             {intakeError !== null ? <p className="sdb-error">{intakeError}</p> : null}

--- a/packages/specimendb/src/ui/SpecimenRail.tsx
+++ b/packages/specimendb/src/ui/SpecimenRail.tsx
@@ -12,7 +12,7 @@ import type { Specimen } from '../schemas/specimen.js';
 import type { SpecimenStatus } from '../schemas/components.js';
 import { at, localityLabel, onStatusPromote, visibleSpecimens, type CatalogState, type CatalogSurface } from './catalog-stx.js';
 import { AccessionQuery, StatusFilters } from './catalog-controls.js';
-import { claimLine, tagSlots } from './catalog-view.js';
+import { claimLine, downloadCatalogJson, lastUpdatedLine, tagSlots } from './catalog-view.js';
 import { useIntakeBind, type IntakeBind } from './intake-bind.js';
 import { ViewportMark } from './marks.js';
 import './catalog.css';
@@ -329,8 +329,17 @@ function SpecimenRailDetail() {
           ) : null}
         </div>
         <div className="sdb-w-actions">
-          <button type="button">EXPORT DB</button>
-          <button type="button">RUN SIM</button>
+          <button
+            type="button"
+            data-testid="export-db"
+            data-export="true"
+            onClick={() => downloadCatalogJson(catalog.store.get().items)}
+          >
+            EXPORT DB
+          </button>
+          <button type="button" data-testid="run-sim">
+            RUN SIM
+          </button>
         </div>
       </div>
       <div className="sdb-w-viewport">
@@ -355,6 +364,12 @@ function SpecimenRailDetail() {
 }
 
 function SpecimenRailProperties() {
+  const { catalog } = useRail();
+  const selected = useFocus(
+    catalog.store,
+    at<CatalogState['selected']>(catalog.store.lens.selected),
+  );
+
   return (
     <aside className="sdb-w-props" data-testid="properties-log">
       <header className="sdb-w-props-header">PROPERTIES LOG</header>
@@ -401,7 +416,9 @@ function SpecimenRailProperties() {
         </div>
         <p className="sdb-w-obs" />
       </section>
-      <div className="sdb-w-updated">LAST_UPDATED</div>
+      <div className="sdb-w-updated" data-testid="last-updated">
+        {lastUpdatedLine(selected)}
+      </div>
     </aside>
   );
 }

--- a/packages/specimendb/src/ui/catalog-view.ts
+++ b/packages/specimendb/src/ui/catalog-view.ts
@@ -4,9 +4,13 @@
  * Tag chips stay empty until someone attaches a Tag (when).
  */
 
-import { mediaOf, type Specimen } from '../schemas/specimen.js';
+import { exifOf, mediaOf, type Specimen } from '../schemas/specimen.js';
 
 export const EMPTY_TAG_SLOTS = ['', '', ''] as const;
+
+export const CATALOG_EXPORT_FILENAME = 'specimendb-catalog.json';
+
+const EXIF_LOG_KEYS = ['DateTimeOriginal', 'Make', 'Model'] as const;
 
 export const claimLine = (specimen: Specimen): string => {
   const claim = specimen.components.find((component) => component._tag === 'Claim');
@@ -30,4 +34,49 @@ export const mediaLabel = (specimen?: Specimen): string => {
 export const imgSrcLabel = (specimen?: Specimen): string => {
   const name = mediaLabel(specimen);
   return name.length > 0 ? `IMG_SRC: ${name}` : 'IMG_SRC';
+};
+
+const exifString = (specimen: Specimen, key: (typeof EXIF_LOG_KEYS)[number]): string | undefined => {
+  const value = exifOf(specimen)?.tags[key];
+  if (typeof value === 'string' && value.length > 0) return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return undefined;
+};
+
+/** Make / Model / DateTimeOriginal only. GPS stays on the locality line. */
+export const exifLogLines = (specimen: Specimen): ReadonlyArray<string> =>
+  EXIF_LOG_KEYS.flatMap((key) => {
+    const value = exifString(specimen, key);
+    return value === undefined ? [] : [`${key} ${value}`];
+  });
+
+/** ISO createdAt, or DateTimeOriginal when that tag arrived. Never a fake "14m AGO". */
+export const lastUpdatedLine = (specimen: Specimen | null): string => {
+  if (specimen === null) return 'LAST_UPDATED';
+  const fromExif = exifString(specimen, 'DateTimeOriginal');
+  return `LAST_UPDATED ${fromExif ?? specimen.createdAt}`;
+};
+
+export const catalogExportPayload = (specimens: ReadonlyArray<Specimen>): string =>
+  JSON.stringify(
+    specimens.map((specimen) => ({
+      id: specimen.id,
+      createdAt: specimen.createdAt,
+      components: specimen.components,
+    })),
+    null,
+    2,
+  );
+
+export const downloadCatalogJson = (specimens: ReadonlyArray<Specimen>): void => {
+  const blob = new Blob([catalogExportPayload(specimens)], { type: 'application/json' });
+  const href = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = href;
+  anchor.download = CATALOG_EXPORT_FILENAME;
+  anchor.rel = 'noopener';
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(href);
 };

--- a/packages/specimendb/src/ui/catalog.css
+++ b/packages/specimendb/src/ui/catalog.css
@@ -991,6 +991,10 @@ button.sdb-w-card {
   border: 1px solid #333;
 }
 
+.sdb-w-actions button[data-export] {
+  cursor: pointer;
+}
+
 .sdb-w-viewport {
   position: relative;
   display: flex;

--- a/packages/specimendb/test/ui.test.tsx
+++ b/packages/specimendb/test/ui.test.tsx
@@ -5,7 +5,7 @@ import React, { useMemo } from 'react';
 import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import * as Effect from 'effect/Effect';
 import * as RpcTest from 'effect/unstable/rpc/RpcTest';
-import { StatusComponent, LocalityComponent } from '../src/schemas/components.js';
+import { StatusComponent, LocalityComponent, ExifComponent } from '../src/schemas/components.js';
 import { trustSpecimenId } from '../src/schemas/identifiers.js';
 import { localityOf, nextStatus, statusOf } from '../src/schemas/specimen.js';
 import type { Specimen } from '../src/schemas/specimen.js';
@@ -204,8 +204,10 @@ describe('IntakeDrop Terminal + SpecimenRail Workbench', () => {
       expect(calls.get).toBeGreaterThan(getsAfterIntake);
     });
     expect(view.getByTestId('detail-id').textContent).toContain(id);
+    expect(view.getByTestId('protocol-id').textContent).toBe(id);
     expect(view.getByTestId('detail-locality').textContent).toBe('unknown');
     expect(view.getByTestId('detail-status').getAttribute('data-status')).toBe('raw');
+    expect(view.queryByTestId('detail-exif')).toBeNull();
 
     const html = view.container.textContent ?? '';
     for (const banned of BANISHED) {
@@ -255,6 +257,7 @@ describe('IntakeDrop Terminal + SpecimenRail Workbench', () => {
     await waitFor(() => {
       expect(terminal.getByTestId('card-chrome')).toBeTruthy();
     });
+    expect(terminal.getByTestId('protocol-id').textContent).toBe('');
     expect(terminal.container.textContent).not.toContain('NO RECORDS');
     expect(terminal.container.textContent).not.toContain('NO SELECTION');
     terminal.unmount();
@@ -263,6 +266,7 @@ describe('IntakeDrop Terminal + SpecimenRail Workbench', () => {
     await waitFor(() => {
       expect(workbench.getByTestId('card-chrome')).toBeTruthy();
     });
+    expect(workbench.getByTestId('last-updated').textContent).toBe('LAST_UPDATED');
     expect(workbench.container.textContent).not.toContain('NO RECORDS');
     expect(workbench.container.textContent).not.toContain('NO SELECTION');
   });
@@ -399,6 +403,100 @@ describe('IntakeDrop Terminal + SpecimenRail Workbench', () => {
     expect(view.getByTestId('claim').textContent).toBe('');
     expect(view.queryByTestId('media-bytes')).toBeNull();
     expect(view.getByTestId('locality').textContent).toBe('unknown');
+    expect(view.getByTestId('last-updated').textContent).toBe(`LAST_UPDATED ${specimen.createdAt}`);
+    expect(view.getByTestId('last-updated').textContent).not.toContain('14m AGO');
+  });
+
+  it('Workbench EXPORT DB dumps List JSON and RUN SIM stays inert', async () => {
+    const id = trustSpecimenId('11111111-1111-4111-8111-111111111111');
+    const specimen: Specimen = {
+      id,
+      createdAt: '2026-08-20T00:00:00.000Z',
+      components: [new StatusComponent({ value: 'raw' }), new LocalityComponent({ state: 'unknown' })],
+    };
+    const client: SpecimenRpcClient = {
+      List: () => Effect.succeed([specimen]),
+      Get: () => Effect.succeed(specimen),
+      Intake: () => Effect.die('Intake should not run'),
+      Promote: () => Effect.die('Promote should not run'),
+    };
+
+    const blobs: Blob[] = [];
+    const realCreate = URL.createObjectURL.bind(URL);
+    URL.createObjectURL = (obj) => {
+      if (obj instanceof Blob) blobs.push(obj);
+      return realCreate(obj);
+    };
+    const downloads: string[] = [];
+    const realClick = HTMLAnchorElement.prototype.click;
+    HTMLAnchorElement.prototype.click = function clickStub(this: HTMLAnchorElement) {
+      downloads.push(this.download);
+    };
+
+    try {
+      const view = render(React.createElement(WorkbenchPage, { client }));
+      await waitFor(() => {
+        expect(view.getByTestId('specimen-id').textContent).toBe(id);
+      });
+
+      await act(async () => {
+        fireEvent.click(view.getByTestId('run-sim'));
+      });
+      expect(blobs).toHaveLength(0);
+      expect(downloads).toHaveLength(0);
+
+      await act(async () => {
+        fireEvent.click(view.getByTestId('export-db'));
+      });
+      expect(blobs).toHaveLength(1);
+      expect(downloads).toEqual(['specimendb-catalog.json']);
+      const text = await blobs[0]!.text();
+      const dumped = JSON.parse(text) as ReadonlyArray<{ readonly id: string; readonly createdAt: string }>;
+      expect(dumped).toHaveLength(1);
+      expect(dumped[0]?.id).toBe(id);
+      expect(dumped[0]?.createdAt).toBe(specimen.createdAt);
+      expect(text).not.toContain('SP-2023-084');
+      expect(text).not.toContain('14m AGO');
+    } finally {
+      URL.createObjectURL = realCreate;
+      HTMLAnchorElement.prototype.click = realClick;
+    }
+  });
+
+  it('Terminal PROTOCOL ID and process log bind branded id and arrived EXIF tags', async () => {
+    const id = trustSpecimenId('11111111-1111-4111-8111-111111111111');
+    const specimen: Specimen = {
+      id,
+      createdAt: '2026-08-20T00:00:00.000Z',
+      components: [
+        new StatusComponent({ value: 'raw' }),
+        new LocalityComponent({ state: 'unknown' }),
+        new ExifComponent({
+          tags: { DateTimeOriginal: '2026:08:20 12:00:00', Make: 'FieldCam', GPSLatitude: 37 },
+        }),
+      ],
+    };
+    const client: SpecimenRpcClient = {
+      List: () => Effect.succeed([specimen]),
+      Get: () => Effect.succeed(specimen),
+      Intake: () => Effect.die('Intake should not run'),
+      Promote: () => Effect.die('Promote should not run'),
+    };
+    const view = render(React.createElement(TerminalPage, { client }));
+    await waitFor(() => {
+      expect(view.getByTestId('specimen-id').textContent).toBe(id);
+    });
+    await act(async () => {
+      fireEvent.click(view.getByTestId('specimen-card'));
+    });
+    await waitFor(() => {
+      expect(view.getByTestId('protocol-id').textContent).toBe(id);
+    });
+    const lines = view.getAllByTestId('detail-exif').map((node) => node.textContent);
+    expect(lines).toContain('DateTimeOriginal 2026:08:20 12:00:00');
+    expect(lines).toContain('Make FieldCam');
+    expect(view.container.textContent).not.toContain('GPSLatitude');
+    expect(view.container.textContent).not.toContain('SP-2023-084');
   });
 
   it('Workbench no-GPS JPEG files raw + unknown and rail status chrome Promotes to filed', async () => {
@@ -812,6 +910,10 @@ describe('six full pages', () => {
       'F-101',
       'F-102',
       'F-105',
+      'F-110',
+      'F-111',
+      'F-112',
+      'F-113',
     ]) {
       expect(journal).toContain(id);
     }
@@ -823,5 +925,10 @@ describe('six full pages', () => {
     expect(journal).toContain('F-108');
     expect(journal).toContain('F-109');
     expect(journal).toContain('Promote');
+    const synth = readFileSync(resolve(process.cwd(), 'docs/page-function-synth.md'), 'utf8');
+    expect(synth).toContain('Page-function synth');
+    expect(synth).toContain('GetMedia');
+    expect(synth).toContain('EXECUTE ASSAY');
+    expect(synth).toContain('capture→store');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Draft off PR 12 tip. Do not merge.

Walked every catalog page (six Variant runs + `/capture/`) and wrote the product bag into `packages/specimendb/docs/page-function-synth.md`. The strip journal stays the floor. This file is every theoretical function, the subsystem it needs, bind state, and the iteration order to make the catalog work.

## Pages walked

| Route | Page | Component |
|---|---|---|
| `/intake` | Terminal | IntakeDrop |
| `/rail` | Workbench | SpecimenRail |
| `/assay` | Assay | WorkingPanel |
| `/dactyl` | Dactyl | AnalogCard (template, not a type) |
| `/catalog` | Catalog | AppShell (hosted catalog page, not the SPA router) |
| `/accession` | Accession | DossierView |
| `/capture/` | Phone capture | static HTML + ExifTool WASM |

## Subsystems named

Intake, List, Get, Promote, PGlite SoT, AssetStore, EXIF, Locality, Status machine, search, status filters, export, Media bytes/viewer, media layers, capture path, Tag, Taxon, Claim write, Observation, AnalogLink, Structure/Mechanism/Function, Question, Update/edit meta (no RPC), assay execute / RUN SIM / spectral, live feed, Owner (no component), catalog routing, seed (never).

## Bound this cut

On the v1 pages only, from data the store already has. No invented GPS, taxon, or SP-/SEQ- ids.

- Terminal PROTOCOL ID well shows the selected branded SpecimenId (F-110). F-014 still kills theater.
- Workbench EXPORT DB downloads `specimendb-catalog.json` of List items (F-111). Empty catalog is `[]`. RUN SIM stays inert.
- Workbench LAST_UPDATED prints ISO `createdAt`, or Exif DateTimeOriginal when that tag arrived (F-112). Never the constant `14m AGO`.
- Terminal process log prints Make / Model / DateTimeOriginal when those tags arrived (F-113). GPS stays on the locality line.

Journal append only. Existing never/when/later verdicts are untouched.

## Deferred

GetMedia (wells die on reload), Update/Attach RPC (Claim, Tag, Observation, AnalogLink cannot be written from the glass), Elev from Locality.altitudeMeters, Catalog status filters, Accession clock, AnalogLink UI, assay runner / EXECUTE ASSAY / waveform / spectral, capture→Intake in one hop (locked: photo never uploads), Owner, ML taxon.

Tests: existing vitest kept honest, plus coverage for the four binds. `bun test:run` is 37 passing.

Locks held: Specimen is the only type. Effect / sql-pglite 4.0.0-beta.93. No DuckDB. No VANTA_* restyle. No Impeccable. No mantis / terrarium / KiCad / CAD / #15–#41.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-571a91e1-ba35-4ea1-8086-f361d0aef233?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-571a91e1-ba35-4ea1-8086-f361d0aef233&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

