### PR TITLE
feat(specimendb): provenance schema — stable ref + W7 (#60)

### DIFF
--- a/packages/specimendb/src/models/LabEntityModel.ts
+++ b/packages/specimendb/src/models/LabEntityModel.ts
@@ -1,0 +1,47 @@
+/**
+ * Persistence-shaped lab entity. Same fields as the provenance record.
+ *
+ * No `lab_entities` table in this cut (#61). Do not call SqlModel.makeRepository
+ * here. Pin stays `@effect/sql-pglite` / `effect` 4.0.0-beta.93.
+ *
+ * @module @tmnl/specimendb/models/LabEntityModel
+ */
+
+import { Model } from 'effect/unstable/schema';
+import * as Schema from 'effect/Schema';
+import {
+  Agent,
+  ContentAddress,
+  EntityKind,
+  HonestyClass,
+  ProvenanceWhat,
+  ProvenanceWhen,
+} from '../schemas/provenance.js';
+import { EntityRef, SpecimenId } from '../schemas/identifiers.js';
+
+/**
+ * App-provided compact ref is the row identity when tables land.
+ * GeneratedByApp: present on select/insert/update/json; omitted from jsonCreate.
+ */
+export class LabEntityModel extends Model.Class<LabEntityModel>('LabEntityModel')({
+  ref: Model.GeneratedByApp(EntityRef),
+  kind: EntityKind,
+  label: Schema.String.check(Schema.isMinLength(1)),
+  class: HonestyClass,
+  bytes: Schema.optional(ContentAddress),
+  used: Schema.optional(Schema.Array(EntityRef)),
+  generated: Schema.optional(Schema.Array(EntityRef)),
+  wasGeneratedBy: Schema.optional(EntityRef),
+  wasAssociatedWith: Schema.optional(Schema.Array(Agent)),
+  wasDerivedFrom: Schema.optional(Schema.Array(EntityRef)),
+  wasInvalidatedBy: Schema.optional(EntityRef),
+  who: Schema.optional(Schema.Array(Agent)),
+  what: Schema.optional(ProvenanceWhat),
+  when: Schema.optional(ProvenanceWhen),
+  where: Schema.optional(Schema.String),
+  why: Schema.optional(Schema.String),
+  how: Schema.optional(Schema.String),
+  specimenId: Schema.optional(SpecimenId),
+  payloadSchemaId: Schema.optional(Schema.String),
+  payload: Schema.optional(Schema.Unknown),
+}) {}

--- a/packages/specimendb/src/models/index.ts
+++ b/packages/specimendb/src/models/index.ts
@@ -1,6 +1,8 @@
 /**
  * Persistence models. Schema is the source of truth; the repo stores these.
  *
+ * LabEntityModel is the provenance row shape. No lab_entities table yet (#61).
+ *
  * @module @tmnl/specimendb/models
  */
 
@@ -12,3 +14,5 @@ export {
   type IntakePayload,
   type IntakeResult,
 } from '../schemas/specimen.js';
+
+export { LabEntityModel } from './LabEntityModel.js';

--- a/packages/specimendb/src/schemas/identifiers.ts
+++ b/packages/specimendb/src/schemas/identifiers.ts
@@ -1,5 +1,9 @@
 /**
- * Branded identifiers for the specimen catalog.
+ * Branded identifiers for the specimen catalog and lab provenance refs.
+ *
+ * Compact lab refs: `gbg:<kind>:<local>@<rev>`. `@<rev>` is a citation
+ * (PR number or git SHA), not a second identity. `gbg:specimen:<id>` maps
+ * onto {@link SpecimenId}; do not fork that brand.
  *
  * @module @tmnl/specimendb/schemas/identifiers
  */
@@ -12,3 +16,45 @@ export const SpecimenId = Schema.String.pipe(
 export type SpecimenId = typeof SpecimenId.Type;
 
 export const trustSpecimenId = (id: string): SpecimenId => id as SpecimenId;
+
+/**
+ * `gbg:<kind>:<local>` with optional `@<rev>`.
+ * Local may contain colons (`gbg:run:doctor:<run-id>`).
+ */
+export const ENTITY_REF_PATTERN =
+  /^gbg:([a-z][a-z0-9-]*):([A-Za-z0-9._:-]+)(?:@([A-Za-z0-9._-]+))?$/;
+
+export const EntityRef = Schema.String.check(
+  Schema.isMinLength(1),
+  Schema.isPattern(ENTITY_REF_PATTERN),
+).pipe(
+  Schema.brand('EntityRef'),
+);
+export type EntityRef = typeof EntityRef.Type;
+
+export const trustEntityRef = (ref: string): EntityRef => ref as EntityRef;
+
+export type ParsedEntityRef = {
+  readonly kind: string;
+  readonly local: string;
+  readonly rev: string | undefined;
+};
+
+export const parseEntityRef = (ref: string): ParsedEntityRef | undefined => {
+  const match = ENTITY_REF_PATTERN.exec(ref);
+  if (match === null || match[1] === undefined || match[2] === undefined) {
+    return undefined;
+  }
+  return { kind: match[1], local: match[2], rev: match[3] };
+};
+
+/** Map an existing catalog id onto a compact specimen ref. Does not mint a new brand. */
+export const specimenRefFromId = (id: SpecimenId): EntityRef =>
+  trustEntityRef(`gbg:specimen:${id}`);
+
+/** Inverse of {@link specimenRefFromId}. Undefined if the ref is not a specimen. */
+export const specimenIdFromRef = (ref: EntityRef): SpecimenId | undefined => {
+  const parsed = parseEntityRef(ref);
+  if (parsed === undefined || parsed.kind !== 'specimen') return undefined;
+  return trustSpecimenId(parsed.local);
+};

--- a/packages/specimendb/src/schemas/index.ts
+++ b/packages/specimendb/src/schemas/index.ts
@@ -2,4 +2,5 @@ export * from './identifiers.js';
 export * from './errors.js';
 export * from './components.js';
 export * from './specimen.js';
+export * from './provenance.js';
 export * from './config.js';

--- a/packages/specimendb/src/schemas/provenance.ts
+++ b/packages/specimendb/src/schemas/provenance.ts
@@ -1,0 +1,201 @@
+/**
+ * Lab provenance record — one shape for every entity that has a stable ref.
+ *
+ * Kind is a field, not a table. Specimen is a common bundle, not a privileged
+ * type. Vocabulary is W3C PROV-DM (Entity / Activity / Agent, used /
+ * wasGeneratedBy / wasAssociatedWith / wasDerivedFrom) encoded as Effect
+ * Schema. Not RDF/OWL. Not OpenLineage. Not tmnl GEOINT provenance.
+ *
+ * W7 (who / what / when / where / why / how) lives on Kind=activity.
+ * Honesty class lives on the generated entity. Operations are entities.
+ *
+ * EVA bind, PGlite tables, and activity-log RPC are later cuts (#61 / #76).
+ *
+ * @module @tmnl/specimendb/schemas/provenance
+ */
+
+import * as Schema from 'effect/Schema';
+import {
+  EntityRef,
+  parseEntityRef,
+  SpecimenId,
+} from './identifiers.js';
+
+/** v1 kinds. Later kinds are a schema change, not a new table. */
+export const EntityKind = Schema.Literals([
+  'specimen',
+  'sheet',
+  'solid',
+  'media',
+  'run',
+  'report',
+  'pr',
+  'issue',
+  'observation',
+  'analog',
+  'view',
+  'activity',
+] as const);
+export type EntityKind = typeof EntityKind.Type;
+
+/**
+ * Honesty class. Travels on the generated entity. A Look PNG cannot promote it.
+ * `live` only when the tool was present and the workflow passed.
+ */
+export const HonestyClass = Schema.Literals([
+  'projected',
+  'diagram',
+  'theoretical',
+  'draft-measured',
+  'unverified',
+  'live',
+] as const);
+export type HonestyClass = typeof HonestyClass.Type;
+
+/** PROV agent types. Person / SoftwareAgent / Organization. */
+export const AgentType = Schema.Literals(['person', 'software', 'organization'] as const);
+export type AgentType = typeof AgentType.Type;
+
+export class Agent extends Schema.TaggedClass<Agent>()('Agent', {
+  agentType: AgentType,
+  /** Human name, tool, login, or cloud-agent id. Not a display-only label for the entity ref. */
+  label: Schema.String.check(Schema.isMinLength(1)),
+  /** Optional durable handle (GitHub login, `bc-…`, tool id). Not GPS / taxon / SKU. */
+  ref: Schema.optional(Schema.String),
+}) {}
+
+/** Optional content address. Path is a locator, not an id. */
+export const ContentAddress = Schema.Struct({
+  gitSha: Schema.optional(Schema.String),
+  digest: Schema.optional(Schema.String),
+  path: Schema.optional(Schema.String),
+});
+export type ContentAddress = typeof ContentAddress.Type;
+
+/** W7 `what` — entity refs in / out. PROV used / generated / invalidated. */
+export const ProvenanceWhat = Schema.Struct({
+  used: Schema.Array(EntityRef),
+  generated: Schema.Array(EntityRef),
+  invalidated: Schema.optional(Schema.Array(EntityRef)),
+});
+export type ProvenanceWhat = typeof ProvenanceWhat.Type;
+
+/** W7 `when` — UTC plus optional git SHA of the tree. */
+export const ProvenanceWhen = Schema.Struct({
+  startedAt: Schema.String.check(Schema.isMinLength(1)),
+  completedAt: Schema.optional(Schema.String),
+  gitSha: Schema.optional(Schema.String),
+});
+export type ProvenanceWhen = typeof ProvenanceWhen.Type;
+
+/**
+ * Identity of PR 57 `doctor-report.v1.json`. Wrap the document; do not fork
+ * its fields. `$id`: `urn:specimendb:biomemetics:mantis:environment-doctor-report:v1`.
+ */
+export const DOCTOR_REPORT_SCHEMA_ID =
+  'urn:specimendb:biomemetics:mantis:environment-doctor-report:v1';
+
+export const DoctorReportPayload = Schema.Struct({
+  schemaVersion: Schema.Literals(['1.0.0'] as const),
+  kind: Schema.Literals(['MantisEnvironmentDoctorReport'] as const),
+  command: Schema.String.check(Schema.isMinLength(1)),
+  startedAt: Schema.String.check(Schema.isMinLength(1)),
+  completedAt: Schema.String.check(Schema.isMinLength(1)),
+  runner: Schema.Unknown,
+  lab: Schema.Unknown,
+  tools: Schema.Unknown,
+  shells: Schema.Unknown,
+  checks: Schema.Unknown,
+  fixtures: Schema.Unknown,
+  blockers: Schema.Unknown,
+  ok: Schema.Boolean,
+  failed: Schema.Array(Schema.String),
+  independentVerification: Schema.optional(Schema.Unknown),
+});
+export type DoctorReportPayload = typeof DoctorReportPayload.Type;
+
+const labEntityFields = {
+  /** Durable compact ref. Not a display name. */
+  ref: EntityRef,
+  /** Kind is data. */
+  kind: EntityKind,
+  /** Human name. Not the id. */
+  label: Schema.String.check(Schema.isMinLength(1)),
+  /** Honesty class. Required on every record. */
+  class: HonestyClass,
+  bytes: Schema.optional(ContentAddress),
+
+  // PROV relations (refs). Queryable edges; not a second catalog.
+  used: Schema.optional(Schema.Array(EntityRef)),
+  generated: Schema.optional(Schema.Array(EntityRef)),
+  wasGeneratedBy: Schema.optional(EntityRef),
+  wasAssociatedWith: Schema.optional(Schema.Array(Agent)),
+  wasDerivedFrom: Schema.optional(Schema.Array(EntityRef)),
+  wasInvalidatedBy: Schema.optional(EntityRef),
+
+  // W7 — required when kind=activity. `where` may be the string `unknown`.
+  who: Schema.optional(Schema.Array(Agent)),
+  what: Schema.optional(ProvenanceWhat),
+  when: Schema.optional(ProvenanceWhen),
+  where: Schema.optional(Schema.String),
+  why: Schema.optional(Schema.String),
+  how: Schema.optional(Schema.String),
+
+  /** Existing SpecimenId when kind=specimen. Same brand; not a fork. */
+  specimenId: Schema.optional(SpecimenId),
+
+  /** Schema identity for a wrapped payload (doctor report `$id`). */
+  payloadSchemaId: Schema.optional(Schema.String),
+  payload: Schema.optional(Schema.Unknown),
+} as const;
+
+const activityHasW7 = Schema.makeFilter<{
+  readonly kind: EntityKind;
+  readonly who?: ReadonlyArray<Agent>;
+  readonly what?: ProvenanceWhat;
+  readonly when?: ProvenanceWhen;
+  readonly where?: string;
+  readonly why?: string;
+  readonly how?: string;
+  readonly specimenId?: SpecimenId;
+  readonly ref: EntityRef;
+}>((entity) => {
+  if (entity.kind === 'activity') {
+    if (
+      entity.who === undefined ||
+      entity.who.length === 0 ||
+      entity.what === undefined ||
+      entity.when === undefined ||
+      entity.where === undefined ||
+      entity.where.length === 0 ||
+      entity.why === undefined ||
+      entity.why.length === 0 ||
+      entity.how === undefined ||
+      entity.how.length === 0
+    ) {
+      return 'activity entities require W7: who, what, when, where, why, how';
+    }
+  }
+  if (entity.kind === 'specimen') {
+    const parsed = parseEntityRef(entity.ref);
+    if (parsed === undefined || parsed.kind !== 'specimen') {
+      return 'specimen entities must use ref gbg:specimen:<id>';
+    }
+    if (entity.specimenId === undefined || entity.specimenId !== parsed.local) {
+      return 'specimenId must equal the local part of gbg:specimen:<id>';
+    }
+  }
+  return undefined;
+});
+
+/**
+ * One Effect Schema record for sheets, solids, runs, specimens, activities.
+ * Views are projections over this record; they are not a second SoT.
+ */
+export class LabEntity extends Schema.TaggedClass<LabEntity>()('LabEntity', labEntityFields) {}
+
+/** Decode path that enforces W7 on activities and specimen-id mapping. */
+export const LabEntityRecord = LabEntity.pipe(Schema.check(activityHasW7));
+
+export const decodeLabEntity = Schema.decodeUnknownSync(LabEntityRecord);
+export const decodeDoctorReportPayload = Schema.decodeUnknownSync(DoctorReportPayload);

--- a/packages/specimendb/test/fixtures/provenance/activity-freecad-part-occt.json
+++ b/packages/specimendb/test/fixtures/provenance/activity-freecad-part-occt.json
@@ -1,0 +1,37 @@
+{
+  "_tag": "LabEntity",
+  "ref": "gbg:activity:freecad-part-occt@fe8f875a",
+  "kind": "activity",
+  "label": "CAD-01 STEP export (PR 34)",
+  "class": "draft-measured",
+  "bytes": {
+    "gitSha": "fe8f875a80b37a1003f05f3a0190fbe2f0417842"
+  },
+  "who": [
+    {
+      "_tag": "Agent",
+      "agentType": "software",
+      "label": "freecad-part-occt"
+    }
+  ],
+  "what": {
+    "used": [],
+    "generated": ["gbg:step:B01@fe8f875a"]
+  },
+  "when": {
+    "startedAt": "2026-08-20T10:05:07Z",
+    "gitSha": "fe8f875a80b37a1003f05f3a0190fbe2f0417842"
+  },
+  "where": "unknown",
+  "why": "#28",
+  "how": "freecad-part-occt",
+  "used": [],
+  "generated": ["gbg:step:B01@fe8f875a"],
+  "wasAssociatedWith": [
+    {
+      "_tag": "Agent",
+      "agentType": "software",
+      "label": "freecad-part-occt"
+    }
+  ]
+}

--- a/packages/specimendb/test/fixtures/provenance/run-doctor-pr57.json
+++ b/packages/specimendb/test/fixtures/provenance/run-doctor-pr57.json
@@ -1,0 +1,38 @@
+{
+  "_tag": "LabEntity",
+  "ref": "gbg:run:doctor:pr57-fixture",
+  "kind": "run",
+  "label": "mantis doctor (PR 57 wrap)",
+  "class": "unverified",
+  "bytes": {
+    "gitSha": "0f07f02ec587c8d8f3228cff3b6d193ec311363f"
+  },
+  "payloadSchemaId": "urn:specimendb:biomemetics:mantis:environment-doctor-report:v1",
+  "payload": {
+    "schemaVersion": "1.0.0",
+    "kind": "MantisEnvironmentDoctorReport",
+    "command": "mantis doctor",
+    "startedAt": "2026-08-20T00:00:00.000Z",
+    "completedAt": "2026-08-20T00:00:01.000Z",
+    "ok": false,
+    "failed": ["fixture-only"],
+    "runner": {
+      "identityClass": "cursor-cloud",
+      "shell": null,
+      "isolationRoot": "/tmp/specimendb-provenance-fixture"
+    },
+    "lab": {
+      "repositoryPath": "projects/biomemetics/labs/mantis",
+      "flakeLock": {},
+      "git": {
+        "head": "0f07f02ec587c8d8f3228cff3b6d193ec311363f"
+      },
+      "nix": {}
+    },
+    "tools": {},
+    "shells": [],
+    "checks": [],
+    "fixtures": [],
+    "blockers": []
+  }
+}

--- a/packages/specimendb/test/fixtures/provenance/sheet-s01-pr58.json
+++ b/packages/specimendb/test/fixtures/provenance/sheet-s01-pr58.json
@@ -1,0 +1,10 @@
+{
+  "_tag": "LabEntity",
+  "ref": "gbg:sheet:S01@pr58",
+  "kind": "sheet",
+  "label": "S01",
+  "class": "projected",
+  "bytes": {
+    "gitSha": "b64d101e805e7f3ab760d15ad38d13d359c7dce1"
+  }
+}

--- a/packages/specimendb/test/fixtures/provenance/solid-b01-fe8f875a.json
+++ b/packages/specimendb/test/fixtures/provenance/solid-b01-fe8f875a.json
@@ -1,0 +1,11 @@
+{
+  "_tag": "LabEntity",
+  "ref": "gbg:step:B01@fe8f875a",
+  "kind": "solid",
+  "label": "B01",
+  "class": "draft-measured",
+  "bytes": {
+    "gitSha": "fe8f875a80b37a1003f05f3a0190fbe2f0417842"
+  },
+  "wasGeneratedBy": "gbg:activity:freecad-part-occt@fe8f875a"
+}

--- a/packages/specimendb/test/fixtures/provenance/specimen-fixture-catalog-001.json
+++ b/packages/specimendb/test/fixtures/provenance/specimen-fixture-catalog-001.json
@@ -1,0 +1,8 @@
+{
+  "_tag": "LabEntity",
+  "ref": "gbg:specimen:fixture-catalog-001",
+  "kind": "specimen",
+  "label": "fixture specimen",
+  "class": "unverified",
+  "specimenId": "fixture-catalog-001"
+}

--- a/packages/specimendb/test/provenance.test.ts
+++ b/packages/specimendb/test/provenance.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Provenance schema (#60): one LabEntity record, compact gbg: refs, W7 on
+ * activities, honesty class on generated entities. Fixtures only — not live rows.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import * as Schema from 'effect/Schema';
+import {
+  decodeDoctorReportPayload,
+  decodeLabEntity,
+  DOCTOR_REPORT_SCHEMA_ID,
+  LabEntity,
+  LabEntityRecord,
+} from '../src/schemas/provenance.js';
+import {
+  EntityRef,
+  parseEntityRef,
+  specimenIdFromRef,
+  specimenRefFromId,
+  trustSpecimenId,
+} from '../src/schemas/identifiers.js';
+import { LabEntityModel } from '../src/models/LabEntityModel.js';
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'provenance');
+
+const load = (name: string): unknown =>
+  JSON.parse(readFileSync(join(fixturesDir, name), 'utf8')) as unknown;
+
+const decodeFails = (input: unknown): boolean => {
+  try {
+    decodeLabEntity(input);
+    return false;
+  } catch {
+    return true;
+  }
+};
+
+describe('compact gbg: refs', () => {
+  it('parses sheet / step / specimen / run / activity grammar', () => {
+    expect(parseEntityRef('gbg:sheet:S01@pr58')).toEqual({
+      kind: 'sheet',
+      local: 'S01',
+      rev: 'pr58',
+    });
+    expect(parseEntityRef('gbg:step:B01@fe8f875a')).toEqual({
+      kind: 'step',
+      local: 'B01',
+      rev: 'fe8f875a',
+    });
+    expect(parseEntityRef('gbg:specimen:fixture-catalog-001')).toEqual({
+      kind: 'specimen',
+      local: 'fixture-catalog-001',
+      rev: undefined,
+    });
+    expect(parseEntityRef('gbg:run:doctor:pr57-fixture')).toEqual({
+      kind: 'run',
+      local: 'doctor:pr57-fixture',
+      rev: undefined,
+    });
+    expect(parseEntityRef('gbg:activity:export-carriage@pr58')).toEqual({
+      kind: 'activity',
+      local: 'export-carriage',
+      rev: 'pr58',
+    });
+  });
+
+  it('maps gbg:specimen:<id> onto the existing SpecimenId brand', () => {
+    const id = trustSpecimenId('fixture-catalog-001');
+    const ref = specimenRefFromId(id);
+    expect(ref).toBe('gbg:specimen:fixture-catalog-001');
+    expect(specimenIdFromRef(ref)).toBe(id);
+  });
+
+  it('rejects a missing or malformed ref', () => {
+    expect(() => Schema.decodeUnknownSync(EntityRef)('')).toThrow();
+    expect(() => Schema.decodeUnknownSync(EntityRef)('sheet:S01@pr58')).toThrow();
+    expect(() => Schema.decodeUnknownSync(EntityRef)('gbg:SHEET:S01@pr58')).toThrow();
+  });
+});
+
+describe('LabEntity fixtures', () => {
+  it('parses sheet S01@pr58 as projected', () => {
+    const entity = decodeLabEntity(load('sheet-s01-pr58.json'));
+    expect(entity.ref).toBe('gbg:sheet:S01@pr58');
+    expect(entity.kind).toBe('sheet');
+    expect(entity.class).toBe('projected');
+  });
+
+  it('parses solid B01@fe8f875a as draft-measured (PR 34)', () => {
+    const entity = decodeLabEntity(load('solid-b01-fe8f875a.json'));
+    expect(entity.ref).toBe('gbg:step:B01@fe8f875a');
+    expect(entity.kind).toBe('solid');
+    expect(entity.class).toBe('draft-measured');
+    expect(entity.wasGeneratedBy).toBe('gbg:activity:freecad-part-occt@fe8f875a');
+  });
+
+  it('parses the STEP export activity that generated B01', () => {
+    const entity = decodeLabEntity(load('activity-freecad-part-occt.json'));
+    expect(entity.kind).toBe('activity');
+    expect(entity.how).toBe('freecad-part-occt');
+    expect(entity.what?.generated).toContain('gbg:step:B01@fe8f875a');
+    expect(entity.generated).toContain('gbg:step:B01@fe8f875a');
+    expect(entity.where).toBe('unknown');
+  });
+
+  it('wraps PR 57 doctor-report.v1.json without forking it', () => {
+    const entity = decodeLabEntity(load('run-doctor-pr57.json'));
+    expect(entity.ref).toBe('gbg:run:doctor:pr57-fixture');
+    expect(entity.kind).toBe('run');
+    expect(entity.class).toBe('unverified');
+    expect(entity.payloadSchemaId).toBe(DOCTOR_REPORT_SCHEMA_ID);
+    const report = decodeDoctorReportPayload(entity.payload);
+    expect(report.kind).toBe('MantisEnvironmentDoctorReport');
+    expect(report.schemaVersion).toBe('1.0.0');
+    expect(report.ok).toBe(false);
+  });
+
+  it('parses one Specimen on the existing brand', () => {
+    const entity = decodeLabEntity(load('specimen-fixture-catalog-001.json'));
+    expect(entity.kind).toBe('specimen');
+    expect(entity.specimenId).toBe('fixture-catalog-001');
+    expect(specimenIdFromRef(entity.ref)).toBe(entity.specimenId);
+  });
+
+  it('rejects a missing ref', () => {
+    const sheet = load('sheet-s01-pr58.json') as { ref?: string };
+    const { ref: _ref, ...rest } = sheet;
+    expect(decodeFails(rest)).toBe(true);
+  });
+
+  it('rejects a missing class', () => {
+    const sheet = load('sheet-s01-pr58.json') as { class?: string };
+    const { class: _class, ...rest } = sheet;
+    expect(decodeFails(rest)).toBe(true);
+  });
+
+  it('rejects an activity missing W7', () => {
+    expect(
+      decodeFails({
+        _tag: 'LabEntity',
+        ref: 'gbg:activity:export-carriage@pr58',
+        kind: 'activity',
+        label: 'export_carriage_step.py',
+        class: 'theoretical',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('LabEntityModel (no table)', () => {
+  it('exposes json / insert variants without a lab_entities table', () => {
+    expect(LabEntityModel.json).toBeDefined();
+    expect(LabEntityModel.insert).toBeDefined();
+    const decoded = Schema.decodeUnknownSync(LabEntity)(load('sheet-s01-pr58.json'));
+    expect(decoded._tag).toBe('LabEntity');
+    expect(LabEntityRecord).toBeDefined();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes nothing. Implements #60. Refs #59 #69 #74 #75 #76.

Schema + fixtures only. Draft. Do not merge.

## Record

One Effect Schema (`LabEntity`) in `packages/specimendb` for every entity that has a stable ref. Kind is a field. Honesty class is a field. Specimen is a common bundle, not a privileged type.

- Compact refs: `gbg:<kind>:<local>@<rev>` (branded `EntityRef`). `gbg:specimen:<id>` maps onto the existing `SpecimenId` brand.
- PROV-DM vocabulary (Entity / Activity / Agent, used / wasGeneratedBy / wasAssociatedWith / wasDerivedFrom) as Effect Schema. Not RDF/OWL. Not OpenLineage.
- W7 (who / what / when / where / why / how) on `kind=activity`. `where` may be `unknown`.
- `Model.Class` (`LabEntityModel`) is the persistence shape. No `lab_entities` table (#61).

## Fixtures (not minted live rows)

1. sheet `gbg:sheet:S01@pr58` — `projected`
2. solid `gbg:step:B01@fe8f875a` — `draft-measured` (PR 34)
3. doctor run wrapping PR 57 `doctor-report.v1.json` identity (`MantisEnvironmentDoctorReport`) — `unverified` fixture, schema not forked
4. one Specimen on the existing brand (`gbg:specimen:fixture-catalog-001`)
5. activity `gbg:activity:freecad-part-occt@fe8f875a` that generated B01

Tests parse those examples and reject a missing ref / missing class (and an activity missing W7).

## Out

Viewer, shop route, activity-log RPC, EVA/PGlite adapter, STEP regen, Terminal/Workbench restyle, GPS/taxon/SKU/pinout, merge of 34/45/57/58/75.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b2697e6-22c2-42d0-b1cb-bb72651941c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b2697e6-22c2-42d0-b1cb-bb72651941c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

