### PR TITLE
feat(specimendb): lift /catalog /assay /dactyl /accession from Variant HTML

### DIFF
--- a/packages/specimendb/src/ui/AnalogCard.tsx
+++ b/packages/specimendb/src/ui/AnalogCard.tsx
@@ -1,6 +1,7 @@
 /**
  * AnalogCard — Dactyl card template and full-page grid.
- * AnalogCard is not a second type. Active Queue is chrome.
+ * Lift of 94e9fc0d HTML: w-80 intake, Active Queue chrome, analog card grid,
+ * SYSTEM.CORE footer + list count. AnalogCard is not a second type.
  *
  * @module @tmnl/specimendb/ui
  */
@@ -11,7 +12,7 @@ import { statusOf } from '../schemas/specimen.js';
 import type { Specimen } from '../schemas/specimen.js';
 import type { SpecimenStatus } from '../schemas/components.js';
 import { at, localityLabel, onStatusPromote, visibleSpecimens, type CatalogState, type CatalogSurface } from './catalog-stx.js';
-import { claimLine } from './catalog-view.js';
+import { claimLine, tagSlots } from './catalog-view.js';
 import { useIntakeBind, type IntakeBind } from './intake-bind.js';
 import './dactyl.css';
 
@@ -78,12 +79,29 @@ function AnalogCardRoot({ catalog, children }: AnalogCardPageProps) {
         {children ?? (
           <>
             <aside className="sdb-d-intake">
+              <header className="sdb-d-brand">
+                <div className="sdb-d-brand-row">
+                  <i className="ph-fill ph-hexagon" />
+                  <h1>
+                    SPECIMEN<span>_DB</span>
+                  </h1>
+                  <span className="sdb-d-cursor" />
+                </div>
+                <span className="sdb-d-ver">v2.1.4</span>
+              </header>
               <AnalogCardIntake />
               <AnalogCardQueue />
+              <div className="sdb-d-sync">
+                <span>
+                  <i className="ph ph-hard-drives" /> DB_SYNC
+                </span>
+                <span className="sdb-d-sync-ok">OK</span>
+              </div>
             </aside>
             <main className="sdb-d-main">
-              <header className="sdb-d-head">DACTYL // ANALOG CARD</header>
+              <AnalogCardHead />
               <AnalogCardGrid />
+              <AnalogCardFoot />
             </main>
           </>
         )}
@@ -104,7 +122,7 @@ function AnalogCardIntake() {
   );
 
   return (
-    <>
+    <div className="sdb-d-zone-wrap">
       <button
         type="button"
         className="sdb-d-zone"
@@ -117,23 +135,32 @@ function AnalogCardIntake() {
         onDragLeave={bind.onDragLeave}
         onDrop={bind.onDrop}
       >
-        <span>
-          {intakeStatus === 'dropping' ? 'INTAKE_IN_FLIGHT' : 'DROP_FIELD_MEDIA'}
+        <span className="sdb-d-corner sdb-d-corner-tl" />
+        <span className="sdb-d-corner sdb-d-corner-tr" />
+        <span className="sdb-d-corner sdb-d-corner-bl" />
+        <span className="sdb-d-corner sdb-d-corner-br" />
+        <i className="ph ph-scan" />
+        <span className="sdb-d-zone-title">
+          {intakeStatus === 'dropping' ? 'INTAKE_IN_FLIGHT' : 'INITIATE INTAKE'}
         </span>
+        <span className="sdb-d-zone-sub">DROP RAW DATA OR DRAG FILES</span>
       </button>
       {intakeError !== null ? (
         <p className="sdb-d-error" data-testid="intake-error">
           {intakeError}
         </p>
       ) : null}
-    </>
+    </div>
   );
 }
 
 function AnalogCardQueue() {
   return (
     <section className="sdb-d-queue" data-testid="active-queue">
-      <div className="sdb-d-kicker">ACTIVE QUEUE</div>
+      <div className="sdb-d-queue-head">
+        <span>Active Queue</span>
+        <span />
+      </div>
       {QUEUE_SLOTS.map((_, index) => (
         <div className="sdb-d-queue-slot" key={`queue-${index}`} />
       ))}
@@ -141,16 +168,54 @@ function AnalogCardQueue() {
   );
 }
 
+function AnalogCardHead() {
+  const { catalog } = useDactyl();
+  const { value, set } = useStx(catalog.store);
+  return (
+    <header className="sdb-d-head">
+      <div className="sdb-d-head-left">
+        <span>
+          <i className="ph ph-funnel-simple" /> Filter Parameters
+        </span>
+        <span className="sdb-d-head-div" />
+        <span className="sdb-d-viewing">
+          VIEWING: <span>GLOBAL_CATALOG</span>
+        </span>
+      </div>
+      <div className="sdb-d-query-wrap">
+        <i className="ph ph-magnifying-glass" />
+        <input
+          className="sdb-d-query"
+          data-testid="rail-query"
+          value={value.query}
+          placeholder="QUERY DATABASE..."
+          onChange={(event) => set({ ...value, query: event.target.value })}
+          spellCheck={false}
+        />
+      </div>
+    </header>
+  );
+}
+
 function AnalogCardChrome() {
   return (
     <article className="sdb-d-card" data-empty="true" data-testid="card-chrome">
-      <div className="sdb-d-well" />
-      <div className="sdb-d-card-body">
+      <div className="sdb-d-well">
+        <i className="ph-light ph-bug" />
         <span className="sdb-d-chip" data-status="raw">
           raw
         </span>
+        <span className="sdb-d-id" />
+      </div>
+      <div className="sdb-d-card-body">
         <p className="sdb-d-claim" data-testid="claim" />
+        <div className="sdb-d-tags">
+          {tagSlots().map((_, index) => (
+            <span className="sdb-d-tag" key={`empty-tag-${index}`} />
+          ))}
+        </div>
         <span className="sdb-d-locality" data-testid="locality">
+          <i className="ph ph-crosshair" />
           unknown
         </span>
       </div>
@@ -164,12 +229,14 @@ function AnalogCardGrid() {
   const rows = visibleSpecimens(value);
 
   return (
-    <div className="sdb-d-grid" data-testid="rail-list">
-      {rows.length === 0 ? (
-        <AnalogCardChrome />
-      ) : (
-        rows.map((specimen) => <AnalogCardCard key={specimen.id} specimen={specimen} />)
-      )}
+    <div className="sdb-d-grid-wrap">
+      <div className="sdb-d-grid" data-testid="rail-list">
+        {rows.length === 0 ? (
+          <AnalogCardChrome />
+        ) : (
+          rows.map((specimen) => <AnalogCardCard key={specimen.id} specimen={specimen} />)
+        )}
+      </div>
     </div>
   );
 }
@@ -180,7 +247,12 @@ function AnalogCardCard({ specimen }: { readonly specimen: Specimen }) {
     catalog.store,
     at<CatalogState['selectedId']>(catalog.store.lens.selectedId),
   );
+  const previews = useFocus(
+    catalog.store,
+    at<CatalogState['previews']>(catalog.store.lens.previews),
+  );
   const status = (statusOf(specimen) ?? 'raw') satisfies SpecimenStatus;
+  const preview = previews[specimen.id];
 
   return (
     <button
@@ -190,26 +262,47 @@ function AnalogCardCard({ specimen }: { readonly specimen: Specimen }) {
       data-selected={selectedId === specimen.id ? 'true' : 'false'}
       onClick={() => void catalog.select(specimen.id)}
     >
-      <div className="sdb-d-well" />
+      <div className="sdb-d-well">
+        <i className="ph-light ph-bug" />
+        {preview !== undefined ? <img src={preview} alt="" /> : null}
+        <StatusChip status={status} testId="status-pill" onPromote={onStatusPromote(catalog, specimen.id)} />
+        <span className="sdb-d-id" data-testid="specimen-id">
+          {specimen.id}
+        </span>
+      </div>
       <div className="sdb-d-card-body">
-        <div className="sdb-d-idrow">
-          <span className="sdb-d-id" data-testid="specimen-id">
-            {specimen.id}
-          </span>
-          <StatusChip
-            status={status}
-            testId="status-pill"
-            onPromote={onStatusPromote(catalog, specimen.id)}
-          />
-        </div>
         <p className="sdb-d-claim" data-testid="claim">
           {claimLine(specimen)}
         </p>
+        <div className="sdb-d-tags">
+          {tagSlots(specimen).map((tag, index) => (
+            <span className="sdb-d-tag" key={`${specimen.id}:tag:${index}`}>
+              {tag}
+            </span>
+          ))}
+        </div>
         <span className="sdb-d-locality" data-testid="locality">
+          <i className="ph ph-crosshair" />
           {localityLabel(specimen)}
         </span>
       </div>
     </button>
+  );
+}
+
+function AnalogCardFoot() {
+  const { catalog } = useDactyl();
+  const { value } = useStx(catalog.store);
+  const count = visibleSpecimens(value).length;
+  const online = useFocus(catalog.store, at<CatalogState['online']>(catalog.store.lens.online));
+  return (
+    <footer className="sdb-d-foot">
+      <div className="sdb-d-foot-left">
+        <span>SYSTEM.CORE // {online ? 'ONLINE' : 'OFFLINE'}</span>
+        <span>LOAD</span>
+      </div>
+      <span className="sdb-d-foot-count">{count} SPECIMENS LOADED INTO VIEW</span>
+    </footer>
   );
 }
 

--- a/packages/specimendb/src/ui/AppShell.tsx
+++ b/packages/specimendb/src/ui/AppShell.tsx
@@ -1,6 +1,7 @@
 /**
- * AppShell — full Catalog page. Routed catalog + intake drop.
- * Hosts catalog cards. Not a mashed Terminal/Workbench shell.
+ * AppShell — full Catalog page. Lift of e90f6c74 HTML + run-06.jsx.
+ * 380px rail, intake drop, thin SPECIMEN_DB chrome. Not a mashed Terminal shell.
+ * Breadcrumbs stay SPECIMEN_DB / CATALOG — never OD-* as data.
  *
  * @module @tmnl/specimendb/ui
  */
@@ -11,7 +12,7 @@ import { statusOf } from '../schemas/specimen.js';
 import type { Specimen } from '../schemas/specimen.js';
 import type { SpecimenStatus } from '../schemas/components.js';
 import { at, localityLabel, onStatusPromote, visibleSpecimens, type CatalogState, type CatalogSurface } from './catalog-stx.js';
-import { claimLine, mediaLabel } from './catalog-view.js';
+import { claimLine, imgSrcLabel, mediaLabel, tagSlots } from './catalog-view.js';
 import { useIntakeBind, type IntakeBind } from './intake-bind.js';
 import './catalog-app.css';
 
@@ -30,18 +31,25 @@ const useShell = (): ShellContextValue => {
   return ctx;
 };
 
+const SCAN_WELLS = ['SEM_SCAN_01', 'CT_SLICE_Y', 'SPECTRA_XYZ'] as const;
+const METRIC_ROWS = ['Specimen Mass', 'Impact Velocity', 'Peak Force', 'C-Axis Modulus', 'Helicoidal Pitch'] as const;
+const CONTEXT_ROWS = ['Depth', 'Salinity', 'Temp', 'Substrate'] as const;
+
 const StatusChip = ({
   status,
   testId,
+  inline,
   onPromote,
 }: {
   readonly status: SpecimenStatus;
   readonly testId?: string;
+  readonly inline?: boolean;
   readonly onPromote?: (event: { readonly stopPropagation: () => void; readonly preventDefault: () => void }) => void;
 }) => (
   <span
     className="sdb-c-chip"
     data-status={status}
+    data-inline={inline ? 'true' : undefined}
     data-testid={testId}
     {...(onPromote !== undefined ? { 'data-promote': 'true', onClick: onPromote } : {})}
   >
@@ -75,10 +83,21 @@ function AppShellRoot({ catalog, children }: AppShellProps) {
         />
         {children ?? (
           <>
-            <AppShellHeader />
-            <div className="sdb-c-body">
+            <aside className="sdb-c-rail">
+              <header className="sdb-c-rail-head">
+                <div className="sdb-c-rail-brand">
+                  <i className="ph ph-hexagon" />
+                  <span>SPECIMEN_DB</span>
+                </div>
+                <span className="sdb-c-sys">SYS.09</span>
+              </header>
               <AppShellIntake />
               <AppShellCards />
+            </aside>
+            <div className="sdb-c-outlet sdb-c-scanlines">
+              <div className="sdb-c-grid-bg" />
+              <AppShellHeader />
+              <AppShellOutlet />
             </div>
           </>
         )}
@@ -90,10 +109,19 @@ function AppShellRoot({ catalog, children }: AppShellProps) {
 function AppShellHeader() {
   return (
     <header className="sdb-c-header">
-      <div className="sdb-c-crumb" data-testid="catalog-crumb">
+      <nav className="sdb-c-crumb" data-testid="catalog-crumb">
         SPECIMEN_DB / CATALOG
+      </nav>
+      <div className="sdb-c-actions">
+        <button type="button" className="sdb-c-btn">
+          <i className="ph ph-sliders-horizontal" />
+          Adjust Parameters
+        </button>
+        <button type="button" className="sdb-c-btn">
+          <i className="ph ph-export" />
+          Export Dataset
+        </button>
       </div>
-      <h1>Catalog</h1>
     </header>
   );
 }
@@ -123,10 +151,14 @@ function AppShellIntake() {
         onDragLeave={bind.onDragLeave}
         onDrop={bind.onDrop}
       >
+        <span className="sdb-c-corner sdb-c-corner-tl" />
+        <span className="sdb-c-corner sdb-c-corner-tr" />
+        <span className="sdb-c-corner sdb-c-corner-bl" />
+        <span className="sdb-c-corner sdb-c-corner-br" />
+        <i className="ph ph-download-simple" />
         <span className="sdb-c-zone-title">
-          {intakeStatus === 'dropping' ? 'Filing…' : 'Drop specimen media'}
+          {intakeStatus === 'dropping' ? 'Filing…' : 'Intake Drop Zone'}
         </span>
-        <span className="sdb-c-zone-sub">JPEG / HEIC. GPS only if the file already has it.</span>
       </button>
       {intakeError !== null ? (
         <p className="sdb-c-error" data-testid="intake-error">
@@ -140,16 +172,29 @@ function AppShellIntake() {
 function CatalogCardChrome() {
   return (
     <article className="sdb-c-card" data-empty="true" data-testid="card-chrome">
-      <div className="sdb-c-card-top">
+      <div className="sdb-c-well">
+        <span className="sdb-c-well-fill" />
+        <span className="sdb-c-well-dot">
+          <span />
+        </span>
         <span className="sdb-c-chip" data-status="raw">
           raw
         </span>
-        <span className="sdb-c-locality" data-testid="locality">
-          unknown
-        </span>
       </div>
-      <p className="sdb-c-claim" data-testid="claim" />
-      <span className="sdb-c-id" />
+      <div className="sdb-c-card-body">
+        <p className="sdb-c-claim" data-testid="claim" />
+        <div className="sdb-c-tags">
+          {tagSlots().map((_, index) => (
+            <span className="sdb-c-tag" key={`empty-tag-${index}`} />
+          ))}
+        </div>
+        <div className="sdb-c-meta">
+          <span className="sdb-c-id" />
+          <span className="sdb-c-locality" data-testid="locality">
+            unknown
+          </span>
+        </div>
+      </div>
     </article>
   );
 }
@@ -160,7 +205,7 @@ function AppShellCards() {
   const rows = visibleSpecimens(value);
 
   return (
-    <section className="sdb-c-grid" data-testid="rail-list">
+    <section className="sdb-c-list sdb-c-scroll" data-testid="rail-list">
       {rows.length === 0 ? (
         <CatalogCardChrome />
       ) : (
@@ -176,35 +221,150 @@ function AppShellCard({ specimen }: { readonly specimen: Specimen }) {
     catalog.store,
     at<CatalogState['selectedId']>(catalog.store.lens.selectedId),
   );
+  const previews = useFocus(
+    catalog.store,
+    at<CatalogState['previews']>(catalog.store.lens.previews),
+  );
   const status = (statusOf(specimen) ?? 'raw') satisfies SpecimenStatus;
   const media = mediaLabel(specimen);
+  const preview = previews[specimen.id];
 
   return (
     <button
       type="button"
       className="sdb-c-card"
       data-testid="specimen-card"
+      data-status={status}
       data-selected={selectedId === specimen.id ? 'true' : 'false'}
       onClick={() => void catalog.select(specimen.id)}
     >
-      <div className="sdb-c-card-top">
-        <StatusChip
-          status={status}
-          testId="status-pill"
-          onPromote={onStatusPromote(catalog, specimen.id)}
-        />
-        <span className="sdb-c-locality" data-testid="locality">
-          {localityLabel(specimen)}
+      <div className="sdb-c-well">
+        <span className="sdb-c-well-fill" />
+        <span className="sdb-c-well-dot">
+          <span />
         </span>
+        {preview !== undefined ? <img src={preview} alt="" /> : null}
+        <StatusChip status={status} testId="status-pill" onPromote={onStatusPromote(catalog, specimen.id)} />
       </div>
-      <p className="sdb-c-claim" data-testid="claim">
-        {claimLine(specimen)}
-      </p>
-      <span className="sdb-c-id" data-testid="specimen-id">
-        {specimen.id}
-      </span>
-      {media !== '' ? <span className="sdb-c-media">{media}</span> : null}
+      <div className="sdb-c-card-body">
+        <p className="sdb-c-claim" data-testid="claim">
+          {claimLine(specimen)}
+        </p>
+        <div className="sdb-c-tags">
+          {tagSlots(specimen).map((tag, index) => (
+            <span className="sdb-c-tag" key={`${specimen.id}:tag:${index}`}>
+              {tag}
+            </span>
+          ))}
+        </div>
+        <div className="sdb-c-meta">
+          <span className="sdb-c-id" data-testid="specimen-id">
+            {specimen.id}
+          </span>
+          <span className="sdb-c-locality" data-testid="locality">
+            {localityLabel(specimen)}
+          </span>
+        </div>
+        {media !== '' ? <span className="sdb-c-media">{media}</span> : null}
+      </div>
     </button>
+  );
+}
+
+function AppShellOutlet() {
+  const { catalog } = useShell();
+  const selected = useFocus(
+    catalog.store,
+    at<CatalogState['selected']>(catalog.store.lens.selected),
+  );
+  const previews = useFocus(
+    catalog.store,
+    at<CatalogState['previews']>(catalog.store.lens.previews),
+  );
+  const status = selected === null ? undefined : (statusOf(selected) ?? 'raw');
+  const preview = selected === null ? undefined : previews[selected.id];
+
+  return (
+    <div className="sdb-c-body sdb-c-scroll" data-testid="specimen-detail">
+      <div className="sdb-c-lead">
+        <h1 className="sdb-c-title" data-testid="detail-id">
+          {selected?.id ?? ''}
+        </h1>
+        {status !== undefined && selected !== null ? (
+          <StatusChip
+            status={status}
+            inline
+            testId="detail-status"
+            onPromote={onStatusPromote(catalog, selected.id)}
+          />
+        ) : null}
+        <p className="sdb-c-lead-claim" data-testid="detail-claim">
+          {selected === null ? '' : claimLine(selected)}
+        </p>
+        {selected !== null ? (
+          <p className="sdb-c-locality" data-testid="detail-locality">
+            {localityLabel(selected)}
+          </p>
+        ) : null}
+
+        <div className="sdb-c-stage">
+          <div>
+            <figure className="sdb-c-photo">
+              {preview !== undefined ? <img src={preview} alt="" /> : null}
+              <span className="sdb-c-photo-cap">{selected === null ? 'IMG_SRC' : imgSrcLabel(selected)}</span>
+            </figure>
+            <div className="sdb-c-scans">
+              {SCAN_WELLS.map((well) => (
+                <div className="sdb-c-scan" key={well}>
+                  <header className="sdb-c-scan-head">
+                    <span>{well}</span>
+                    <i className="ph ph-scan" />
+                  </header>
+                  <div className="sdb-c-scan-well" />
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="sdb-c-side">
+            <section className="sdb-c-wellbox">
+              <h2>
+                <span className="sdb-c-dot" />
+                Morphological Metrics
+              </h2>
+              <dl className="sdb-c-dl">
+                {METRIC_ROWS.map((row) => (
+                  <div key={row}>
+                    <dt>{row}</dt>
+                    <dd />
+                  </div>
+                ))}
+              </dl>
+            </section>
+            <section className="sdb-c-wellbox">
+              <h2>
+                <span className="sdb-c-dot" />
+                Collection Context
+              </h2>
+              <dl className="sdb-c-dl">
+                {CONTEXT_ROWS.map((row) => (
+                  <div key={row}>
+                    <dt>{row}</dt>
+                    <dd />
+                  </div>
+                ))}
+              </dl>
+            </section>
+            <section className="sdb-c-log">
+              <h2>
+                <span>Sys_Log // Live Compute</span>
+                <span className="sdb-c-dot" />
+              </h2>
+              <div className="sdb-c-log-body" />
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/packages/specimendb/src/ui/DossierView.tsx
+++ b/packages/specimendb/src/ui/DossierView.tsx
@@ -1,6 +1,7 @@
 /**
- * DossierView — full Accession page. Fat dossier: photo rail, claim, status,
- * empty taxonomy table, field-metrics wells, empty spectral grid, empty log.
+ * DossierView — full Accession page. Fat dossier chrome from Variant board stills
+ * (no HTML extract on the branch). Id / taxonomy / field-metrics / spectral /
+ * observer-log wells stay drawn. Now-slots only when a selected specimen exists.
  *
  * @module @tmnl/specimendb/ui
  */
@@ -30,8 +31,9 @@ const useDossier = (): DossierContextValue => {
   return ctx;
 };
 
-const TAXON_RANKS = ['Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus', 'Species'] as const;
-const SPECTRAL_BANDS = ['UV', 'VIOLET', 'BLUE', 'GREEN', 'RED', 'NIR'] as const;
+const TAXON_RANKS = ['KINGDOM', 'PHYLUM', 'CLASS', 'ORDER', 'FAMILY', 'GENUS', 'SPECIES'] as const;
+const SPECTRAL_COLS = ['WAVELENGTH (NM)', 'REFLECTANCE (%)', 'ABSORPTION (%)', 'SCATTER (%)'] as const;
+const SPECTRAL_ROWS = 6;
 
 const StatusChip = ({
   status,
@@ -118,7 +120,8 @@ function DossierViewIntake() {
         onDragLeave={bind.onDragLeave}
         onDrop={bind.onDrop}
       >
-        {intakeStatus === 'dropping' ? 'INTAKE_IN_FLIGHT' : 'FILE TO DOSSIER'}
+        <span className="sdb-x-zone-kicker">// ACCESSION_INTAKE</span>
+        <span>{intakeStatus === 'dropping' ? 'INTAKE_IN_FLIGHT' : 'DROP FIELD MEDIA'}</span>
       </button>
       {intakeError !== null ? (
         <p className="sdb-x-error" data-testid="intake-error">
@@ -218,80 +221,114 @@ function DossierViewBody() {
 
   return (
     <div className="sdb-x-dossier" data-testid="specimen-detail">
+      <section className="sdb-x-intake-well">
+        <div className="sdb-x-kicker">// ACCESSION_INTAKE</div>
+        <div className="sdb-x-dropcap">DROP FIELD MEDIA</div>
+      </section>
+
       <header className="sdb-x-lead">
         <div className="sdb-x-photo">
           {preview !== undefined ? <img src={preview} alt="" /> : null}
           <span className="sdb-x-imgsrc">{selected === null ? 'IMG_SRC' : imgSrcLabel(selected)}</span>
         </div>
         <div className="sdb-x-lead-copy">
+          <div className="sdb-x-meta">
+            {status !== undefined && selected !== null ? (
+              <StatusChip
+                status={status}
+                testId="detail-status"
+                onPromote={onStatusPromote(catalog, selected.id)}
+              />
+            ) : (
+              <span className="sdb-x-chip" data-status="raw">
+                raw
+              </span>
+            )}
+            <span>LAST_MODIFIED</span>
+          </div>
           <h1 className="sdb-x-id-lg" data-testid="detail-id">
             {selected?.id ?? ''}
           </h1>
           <p className="sdb-x-claim" data-testid="detail-claim">
             {selected === null ? '' : claimLine(selected)}
           </p>
-          {status !== undefined && selected !== null ? (
-            <StatusChip
-              status={status}
-              testId="detail-status"
-              onPromote={onStatusPromote(catalog, selected.id)}
-            />
-          ) : (
-            <span className="sdb-x-chip" data-status="raw">
-              raw
-            </span>
-          )}
+          <div className="sdb-x-actions">
+            <button type="button" className="sdb-x-btn">
+              [ INITIATE_SCAN ]
+            </button>
+            <button type="button" className="sdb-x-btn">
+              [ EDIT_RECORD ]
+            </button>
+          </div>
         </div>
       </header>
 
-      <section className="sdb-x-section">
-        <h2>Taxonomy</h2>
-        <table className="sdb-x-table">
-          <tbody>
-            {TAXON_RANKS.map((rank) => (
-              <tr key={rank}>
-                <th>{rank}</th>
+      <div className="sdb-x-wells">
+        <section className="sdb-x-section">
+          <h2>// TAXONOMY_DATA</h2>
+          <table className="sdb-x-table">
+            <tbody>
+              {TAXON_RANKS.map((rank) => (
+                <tr key={rank}>
+                  <th>{rank}</th>
+                  <td />
+                </tr>
+              ))}
+              <tr>
+                <th>CONFIDENCE</th>
                 <td />
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </section>
+            </tbody>
+          </table>
+        </section>
 
-      <section className="sdb-x-section">
-        <h2>Field metrics</h2>
-        <div className="sdb-x-metrics">
-          <div className="sdb-x-metric">
-            <div className="sdb-x-kicker">Locality</div>
-            <div data-testid="detail-locality">{selected === null ? 'unknown' : localityLabel(selected)}</div>
-          </div>
-          <div className="sdb-x-metric">
-            <div className="sdb-x-kicker">Elev</div>
-            <div />
-          </div>
-          <div className="sdb-x-metric">
-            <div className="sdb-x-kicker">Temp</div>
-            <div />
-          </div>
-        </div>
-      </section>
-
-      <section className="sdb-x-section">
-        <h2>Spectral grid</h2>
-        <div className="sdb-x-spectra">
-          {SPECTRAL_BANDS.map((band) => (
-            <div className="sdb-x-band" key={band}>
-              <div className="sdb-x-kicker">{band}</div>
-              <div className="sdb-x-band-well" />
+        <section className="sdb-x-section">
+          <h2>// FIELD_METRICS</h2>
+          <div className="sdb-x-metrics">
+            <div className="sdb-x-metric">
+              <div className="sdb-x-kicker">COORDINATES</div>
+              <div className="sdb-x-metric-val" data-testid="detail-locality">
+                {selected === null ? 'unknown' : localityLabel(selected)}
+              </div>
             </div>
-          ))}
-        </div>
-      </section>
+            <div className="sdb-x-metric">
+              <div className="sdb-x-kicker">ELEVATION</div>
+              <div className="sdb-x-metric-val" />
+            </div>
+            <div className="sdb-x-metric">
+              <div className="sdb-x-kicker">TEMP_AMBIENT</div>
+              <div className="sdb-x-metric-val" />
+            </div>
+          </div>
+        </section>
 
-      <section className="sdb-x-section">
-        <h2>Observer log</h2>
-        <div className="sdb-x-log" />
-      </section>
+        <section className="sdb-x-section">
+          <h2>// SPECTRAL_ANALYSIS [REFLECTANCE]</h2>
+          <table className="sdb-x-table sdb-x-spectra-table">
+            <thead>
+              <tr>
+                {SPECTRAL_COLS.map((col) => (
+                  <th key={col}>{col}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: SPECTRAL_ROWS }, (_, row) => (
+                <tr key={`band-${row}`}>
+                  {SPECTRAL_COLS.map((col) => (
+                    <td key={`${row}:${col}`} />
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+
+        <section className="sdb-x-section sdb-x-span">
+          <h2>// OBSERVER_LOG</h2>
+          <div className="sdb-x-log" />
+        </section>
+      </div>
     </div>
   );
 }

--- a/packages/specimendb/src/ui/WorkingPanel.tsx
+++ b/packages/specimendb/src/ui/WorkingPanel.tsx
@@ -1,6 +1,7 @@
 /**
- * WorkingPanel — full Assay page. 440px rail, dashed h-28 intake,
- * CURRENT_FOCUS_RECORD, viewport + 4 channels, instrument / env / log.
+ * WorkingPanel — full Assay page. Lift of 9b39d6bc HTML:
+ * 440px rail, dashed [ INITIATE_INTAKE_PROTOCOL ], CURRENT_FOCUS_RECORD,
+ * VIEWPORT_01 + channel wells, INSTRUMENT_READOUT / ENV_CONTEXT / OBSERVATION_LOG.
  *
  * @module @tmnl/specimendb/ui
  */
@@ -11,7 +12,7 @@ import { statusOf } from '../schemas/specimen.js';
 import type { Specimen } from '../schemas/specimen.js';
 import type { SpecimenStatus } from '../schemas/components.js';
 import { at, localityLabel, onStatusPromote, visibleSpecimens, type CatalogState, type CatalogSurface } from './catalog-stx.js';
-import { claimLine } from './catalog-view.js';
+import { claimLine, tagSlots } from './catalog-view.js';
 import { useIntakeBind, type IntakeBind } from './intake-bind.js';
 import './assay.css';
 
@@ -30,22 +31,31 @@ const useAssay = (): AssayContextValue => {
   return ctx;
 };
 
-const CHANNELS = ['CH-01', 'CH-02', 'CH-03', 'CH-04'] as const;
-const INSTRUMENT_ROWS = ['GAIN', 'OFFSET', 'WINDOW'] as const;
-const ENV_ROWS = ['SALINITY', 'PRESSURE', 'CURRENT'] as const;
+const CHANNELS = ['CH_01_VIS', 'CH_02_UV', 'CH_03_SEM'] as const;
+const INSTRUMENT_ROWS = [
+  'TENSILE_YIELD',
+  'FRACTURE_TOUGHNESS',
+  'WATER_CONTENT',
+  'CHITIN_DENSITY',
+  'SPECTRAL_ALBEDO',
+] as const;
+const ENV_ROWS = ['TEMP_COLLECT', 'HUMIDITY'] as const;
 
 const StatusChip = ({
   status,
   testId,
+  inline,
   onPromote,
 }: {
   readonly status: SpecimenStatus;
   readonly testId?: string;
+  readonly inline?: boolean;
   readonly onPromote?: (event: { readonly stopPropagation: () => void; readonly preventDefault: () => void }) => void;
 }) => (
   <span
     className="sdb-a-chip"
     data-status={status}
+    data-inline={inline ? 'true' : undefined}
     data-testid={testId}
     {...(onPromote !== undefined ? { 'data-promote': 'true', onClick: onPromote } : {})}
   >
@@ -80,21 +90,39 @@ function WorkingPanelRoot({ catalog, children }: WorkingPanelProps) {
         {children ?? (
           <>
             <aside className="sdb-a-rail">
-              <header className="sdb-a-rail-head">WORKING SET</header>
+              <header className="sdb-a-rail-head">
+                <div className="sdb-a-rail-brand">
+                  <i className="ph-fill ph-hexagon" />
+                  <span>[ SPECIMEN_DB v3.1.0 ]</span>
+                </div>
+                <div>
+                  <button type="button" className="sdb-a-iconbtn" aria-label="filters">
+                    <i className="ph ph-faders" />
+                  </button>
+                  <button type="button" className="sdb-a-iconbtn" aria-label="sort">
+                    <i className="ph ph-sort-descending" />
+                  </button>
+                </div>
+              </header>
               <WorkingPanelList />
             </aside>
             <main className="sdb-a-main">
+              <div className="sdb-a-stage-grid" />
               <WorkingPanelIntake />
-              <WorkingPanelFocus />
-              <div className="sdb-a-stage">
-                <WorkingPanelViewport />
-                <WorkingPanelChannels />
-              </div>
-              <div className="sdb-a-panels">
-                <WorkingPanelInstrument />
-                <WorkingPanelEnv />
-                <WorkingPanelLog />
-              </div>
+              <section className="sdb-a-work sdb-a-scroll">
+                <WorkingPanelFocus />
+                <div className="sdb-a-grid">
+                  <div className="sdb-a-stage-col">
+                    <WorkingPanelViewport />
+                    <WorkingPanelChannels />
+                  </div>
+                  <div className="sdb-a-side">
+                    <WorkingPanelInstrument />
+                    <WorkingPanelEnv />
+                    <WorkingPanelLog />
+                  </div>
+                </div>
+              </section>
             </main>
           </>
         )}
@@ -128,8 +156,14 @@ function WorkingPanelIntake() {
         onDragLeave={bind.onDragLeave}
         onDrop={bind.onDrop}
       >
+        <span className="sdb-a-zone-mark">
+          <i className="ph ph-download-simple" />
+        </span>
         <span className="sdb-a-zone-copy">
-          {intakeStatus === 'dropping' ? 'INTAKE_IN_FLIGHT' : 'INITIATE_INTAKE_PROTOCOL'}
+          <span className="sdb-a-zone-title">
+            {intakeStatus === 'dropping' ? 'INTAKE_IN_FLIGHT' : '[ INITIATE_INTAKE_PROTOCOL ]'}
+          </span>
+          <span className="sdb-a-zone-sub">DRAG FIELD ASSETS OR RAW DATA PACKETS HERE</span>
         </span>
       </button>
       {intakeError !== null ? (
@@ -144,14 +178,24 @@ function WorkingPanelIntake() {
 function AssayCardChrome() {
   return (
     <article className="sdb-a-card" data-empty="true" data-testid="card-chrome">
-      <div className="sdb-a-idrow">
-        <span className="sdb-a-id" />
+      <div className="sdb-a-well">
+        <span className="sdb-a-well-mark">
+          <i className="ph ph-aperture" />
+        </span>
+        <span className="sdb-a-well-grid" />
         <span className="sdb-a-chip" data-status="raw">
           raw
         </span>
+        <span className="sdb-a-idcap" />
       </div>
       <p className="sdb-a-claim" data-testid="claim" />
+      <div className="sdb-a-tags">
+        {tagSlots().map((_, index) => (
+          <span className="sdb-a-tag" key={`empty-tag-${index}`} />
+        ))}
+      </div>
       <span className="sdb-a-locality" data-testid="locality">
+        <i className="ph ph-navigation-arrow" />
         unknown
       </span>
     </article>
@@ -164,7 +208,7 @@ function WorkingPanelList() {
   const rows = visibleSpecimens(value);
 
   return (
-    <div className="sdb-a-list" data-testid="rail-list">
+    <div className="sdb-a-list sdb-a-scroll" data-testid="rail-list">
       {rows.length === 0 ? (
         <AssayCardChrome />
       ) : (
@@ -180,30 +224,45 @@ function WorkingPanelCard({ specimen }: { readonly specimen: Specimen }) {
     catalog.store,
     at<CatalogState['selectedId']>(catalog.store.lens.selectedId),
   );
+  const previews = useFocus(
+    catalog.store,
+    at<CatalogState['previews']>(catalog.store.lens.previews),
+  );
   const status = (statusOf(specimen) ?? 'raw') satisfies SpecimenStatus;
+  const preview = previews[specimen.id];
 
   return (
     <button
       type="button"
       className="sdb-a-card"
       data-testid="specimen-card"
+      data-status={status}
       data-selected={selectedId === specimen.id ? 'true' : 'false'}
       onClick={() => void catalog.select(specimen.id)}
     >
-      <div className="sdb-a-idrow">
-        <span className="sdb-a-id" data-testid="specimen-id">
+      <div className="sdb-a-well">
+        <span className="sdb-a-well-mark">
+          <i className="ph ph-aperture" />
+        </span>
+        <span className="sdb-a-well-grid" />
+        {preview !== undefined ? <img src={preview} alt="" /> : null}
+        <StatusChip status={status} testId="status-pill" onPromote={onStatusPromote(catalog, specimen.id)} />
+        <span className="sdb-a-idcap" data-testid="specimen-id">
           {specimen.id}
         </span>
-        <StatusChip
-          status={status}
-          testId="status-pill"
-          onPromote={onStatusPromote(catalog, specimen.id)}
-        />
       </div>
       <p className="sdb-a-claim" data-testid="claim">
         {claimLine(specimen)}
       </p>
+      <div className="sdb-a-tags">
+        {tagSlots(specimen).map((tag, index) => (
+          <span className="sdb-a-tag" key={`${specimen.id}:tag:${index}`}>
+            {tag}
+          </span>
+        ))}
+      </div>
       <span className="sdb-a-locality" data-testid="locality">
+        <i className="ph ph-navigation-arrow" />
         {localityLabel(specimen)}
       </span>
     </button>
@@ -221,26 +280,38 @@ function WorkingPanelFocus() {
   return (
     <header className="sdb-a-focus" data-testid="specimen-detail">
       <div>
-        <div className="sdb-a-kicker">CURRENT_FOCUS_RECORD</div>
-        <h1 className="sdb-a-focus-id" data-testid="detail-id">
-          {selected?.id ?? ''}
-        </h1>
+        <div className="sdb-a-kicker">CURRENT_FOCUS_RECORD //</div>
+        <div className="sdb-a-focus-row">
+          <h1 className="sdb-a-focus-id" data-testid="detail-id">
+            {selected?.id ?? ''}
+          </h1>
+          {status !== undefined && selected !== null ? (
+            <StatusChip
+              status={status}
+              inline
+              testId="detail-status"
+              onPromote={onStatusPromote(catalog, selected.id)}
+            />
+          ) : null}
+        </div>
         <p className="sdb-a-claim" data-testid="detail-claim">
           {selected === null ? '' : claimLine(selected)}
         </p>
         {selected !== null ? (
           <p className="sdb-a-locality" data-testid="detail-locality">
+            <i className="ph ph-navigation-arrow" />
             {localityLabel(selected)}
           </p>
         ) : null}
       </div>
-      {status !== undefined && selected !== null ? (
-        <StatusChip
-          status={status}
-          testId="detail-status"
-          onPromote={onStatusPromote(catalog, selected.id)}
-        />
-      ) : null}
+      <div className="sdb-a-actions">
+        <button type="button" className="sdb-a-btn">
+          <i className="ph ph-terminal-window" /> EXECUTE_ASSAY
+        </button>
+        <button type="button" className="sdb-a-btn">
+          <i className="ph ph-pencil-simple" /> EDIT_META
+        </button>
+      </div>
     </header>
   );
 }
@@ -248,8 +319,25 @@ function WorkingPanelFocus() {
 function WorkingPanelViewport() {
   return (
     <section className="sdb-a-viewport">
-      <div className="sdb-a-kicker">VIEWPORT</div>
-      <div className="sdb-a-viewport-stage" />
+      <div className="sdb-a-viewport-head">
+        <span>VIEWPORT_01 // PRIMARY_SCAN</span>
+        <span>MAG</span>
+      </div>
+      <div className="sdb-a-viewport-stage">
+        <span className="sdb-a-viewport-mark">
+          <i className="ph ph-scan" />
+        </span>
+        <div className="sdb-a-reticle">
+          <span className="sdb-a-reticle-h" />
+          <span className="sdb-a-reticle-v" />
+          <span className="sdb-a-reticle-ring" />
+          <span className="sdb-a-reticle-dot" />
+        </div>
+        <div className="sdb-a-scale">
+          <span className="sdb-a-scale-bar" />
+          <span />
+        </div>
+      </div>
     </section>
   );
 }
@@ -259,10 +347,14 @@ function WorkingPanelChannels() {
     <section className="sdb-a-channels">
       {CHANNELS.map((channel) => (
         <div className="sdb-a-channel" key={channel}>
-          <div className="sdb-a-kicker">{channel}</div>
+          <div className="sdb-a-channel-cap">{channel}</div>
           <div className="sdb-a-channel-well" />
         </div>
       ))}
+      <div className="sdb-a-attach">
+        <i className="ph ph-plus" />
+        <span>ATTACH_LAYER</span>
+      </div>
     </section>
   );
 }
@@ -270,13 +362,19 @@ function WorkingPanelChannels() {
 function WorkingPanelInstrument() {
   return (
     <section className="sdb-a-panel">
-      <div className="sdb-a-kicker">INSTRUMENT</div>
-      {INSTRUMENT_ROWS.map((row) => (
-        <div className="sdb-a-row" key={row}>
-          <span>{row}</span>
-          <span />
-        </div>
-      ))}
+      <div className="sdb-a-panel-head">
+        <span>INSTRUMENT_READOUT</span>
+        <span className="sdb-a-pulse" />
+      </div>
+      <div className="sdb-a-panel-body">
+        <div className="sdb-a-section">## PHYSICAL_PROPERTIES</div>
+        {INSTRUMENT_ROWS.map((row) => (
+          <div className="sdb-a-row" key={row}>
+            <span>{row}</span>
+            <span />
+          </div>
+        ))}
+      </div>
     </section>
   );
 }
@@ -284,13 +382,21 @@ function WorkingPanelInstrument() {
 function WorkingPanelEnv() {
   return (
     <section className="sdb-a-panel">
-      <div className="sdb-a-kicker">ENVIRONMENT</div>
-      {ENV_ROWS.map((row) => (
-        <div className="sdb-a-row" key={row}>
-          <span>{row}</span>
-          <span />
+      <div className="sdb-a-panel-head">
+        <span>ENV_CONTEXT</span>
+      </div>
+      <div className="sdb-a-env">
+        {ENV_ROWS.map((row) => (
+          <div key={row}>
+            <div className="sdb-a-env-kicker">{row}</div>
+            <div className="sdb-a-env-val" />
+          </div>
+        ))}
+        <div className="sdb-a-env-span">
+          <div className="sdb-a-env-kicker">LOCALITY_NOTE</div>
+          <div className="sdb-a-env-val" />
         </div>
-      ))}
+      </div>
     </section>
   );
 }
@@ -303,8 +409,17 @@ function WorkingPanelLog() {
   );
   return (
     <section className="sdb-a-panel sdb-a-log" data-testid="assay-log">
-      <div className="sdb-a-kicker">LOG</div>
-      <div className="sdb-a-log-body">{intakeError !== null ? <p>{intakeError}</p> : null}</div>
+      <div className="sdb-a-panel-head">
+        <span>OBSERVATION_LOG</span>
+        <i className="ph ph-list-dashes" />
+      </div>
+      <div className="sdb-a-log-body sdb-a-scroll">
+        {intakeError !== null ? <p>{intakeError}</p> : null}
+        <div className="sdb-a-cursor">
+          <span>&gt;</span>
+          <span className="sdb-a-cursor-bar" />
+        </div>
+      </div>
     </section>
   );
 }

--- a/packages/specimendb/src/ui/accession.css
+++ b/packages/specimendb/src/ui/accession.css
@@ -1,4 +1,8 @@
-/* Accession / DossierView. Fat dossier. Not a coalesced charcoal shell. */
+/* Accession / DossierView. Fat-dossier chrome from Variant board stills. No Accession HTML extract. */
+
+.sdb-file-input {
+  display: none;
+}
 
 .sdb-dossier {
   box-sizing: border-box;
@@ -7,10 +11,11 @@
   height: 100vh;
   margin: 0;
   overflow: hidden;
-  background: #080808;
-  color: #d6d3d1;
+  color: #d4d4d8;
+  background: #000;
   font-family: Inter, ui-sans-serif, system-ui, sans-serif;
   font-size: 13px;
+  -webkit-font-smoothing: antialiased;
 }
 
 .sdb-dossier *,
@@ -22,35 +27,53 @@
 .sdb-x-rail {
   display: flex;
   flex-direction: column;
-  width: 280px;
-  min-width: 280px;
+  width: 300px;
+  min-width: 300px;
   height: 100%;
-  border-right: 1px solid #292524;
   overflow: hidden;
+  background: #050505;
+  border-right: 1px solid #1a1a1a;
 }
 
 .sdb-x-rail-head {
-  height: 44px;
   display: flex;
   align-items: center;
+  height: 44px;
   padding: 0 14px;
-  border-bottom: 1px solid #292524;
-  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  color: #71717a;
+  border-bottom: 1px solid #1a1a1a;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
   font-size: 10px;
   letter-spacing: 0.16em;
 }
 
 .sdb-x-zone {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 88px;
   margin: 12px;
-  height: 72px;
+  padding: 0;
   cursor: pointer;
-  color: inherit;
+  color: #71717a;
   font: inherit;
-  background: #0c0a09;
-  border: 1px dashed #44403c;
-  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
-  font-size: 9px;
+  background: #0a0a0a;
+  border: 1px dashed #333;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
   letter-spacing: 0.14em;
+}
+
+.sdb-x-zone[data-active='true'] {
+  border-color: #52525b;
+}
+
+.sdb-x-zone-kicker {
+  color: #52525b;
+  font-size: 9px;
 }
 
 .sdb-x-error {
@@ -60,12 +83,26 @@
 }
 
 .sdb-x-thumbs {
-  flex: 1;
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: 10px;
   padding: 12px;
   overflow: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #333 #000;
+}
+
+.sdb-x-thumbs::-webkit-scrollbar {
+  width: 4px;
+}
+
+.sdb-x-thumbs::-webkit-scrollbar-track {
+  background: #000;
+}
+
+.sdb-x-thumbs::-webkit-scrollbar-thumb {
+  background: #333;
 }
 
 .sdb-x-thumb {
@@ -78,8 +115,8 @@
   cursor: pointer;
   color: inherit;
   font: inherit;
-  background: #0c0a09;
-  border: 1px solid #292524;
+  background: #0a0a0a;
+  border: 1px solid #1a1a1a;
   font-size: 10px;
 }
 
@@ -88,7 +125,7 @@ button.sdb-x-thumb {
 }
 
 .sdb-x-thumb[data-selected='true'] {
-  border-color: #a8a29e;
+  border-color: #3f3f46;
 }
 
 .sdb-x-thumb[data-empty='true'] {
@@ -100,6 +137,7 @@ button.sdb-x-thumb {
   height: 96px;
   overflow: hidden;
   background: #000;
+  border: 1px solid #1a1a1a;
 }
 
 .sdb-x-thumb-well img {
@@ -110,16 +148,18 @@ button.sdb-x-thumb {
 }
 
 .sdb-x-id {
-  word-break: break-all;
-  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  overflow: hidden;
+  color: #a1a1aa;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
   font-size: 9px;
+  word-break: break-all;
 }
 
 .sdb-x-chip {
   align-self: flex-start;
-  padding: 2px 6px;
+  padding: 2px 8px;
   border: 1px solid currentColor;
-  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
   font-size: 9px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -127,40 +167,79 @@ button.sdb-x-thumb {
 
 .sdb-x-chip[data-status='raw'] {
   color: #f59e0b;
+  background: #451a03;
+  border-color: #78350f;
 }
+
 .sdb-x-chip[data-status='filed'] {
   color: #06b6d4;
+  background: #083344;
+  border-color: #164e63;
 }
+
 .sdb-x-chip[data-status='working'] {
   color: #10b981;
+  background: #022c22;
+  border-color: #064e3b;
 }
+
 .sdb-x-chip[data-status='dead'] {
   color: #f43f5e;
+  background: #4c0519;
+  border-color: #881337;
 }
 
 .sdb-x-main {
   flex: 1;
   min-width: 0;
   overflow: auto;
+  background: #000;
 }
 
 .sdb-x-dossier {
-  max-width: 960px;
+  max-width: 1100px;
   padding: 28px 36px 64px;
+}
+
+.sdb-x-intake-well {
+  margin-bottom: 24px;
+  padding: 16px;
+  background: #0a0a0a;
+  border: 1px solid #1a1a1a;
+}
+
+.sdb-x-kicker {
+  margin-bottom: 8px;
+  color: #52525b;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+}
+
+.sdb-x-dropcap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 72px;
+  color: #52525b;
+  border: 1px dashed #333;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
 }
 
 .sdb-x-lead {
   display: grid;
   grid-template-columns: 280px 1fr;
   gap: 24px;
-  margin-bottom: 32px;
+  margin-bottom: 28px;
 }
 
 .sdb-x-photo {
   position: relative;
   min-height: 280px;
   background: #000;
-  border: 1px solid #292524;
+  border: 1px solid #1a1a1a;
 }
 
 .sdb-x-photo img {
@@ -176,8 +255,9 @@ button.sdb-x-thumb {
   bottom: 8px;
   padding: 2px 6px;
   background: rgba(0, 0, 0, 0.8);
-  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
-  font-size: 8px;
+  border: 1px solid #1a1a1a;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
   letter-spacing: 0.12em;
 }
 
@@ -187,33 +267,71 @@ button.sdb-x-thumb {
   gap: 12px;
 }
 
+.sdb-x-meta {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  color: #71717a;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+}
+
 .sdb-x-id-lg {
   min-height: 1.2em;
   margin: 0;
-  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
-  font-size: 20px;
+  color: #e4e4e7;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 28px;
   font-weight: 500;
+  letter-spacing: -0.03em;
   word-break: break-all;
 }
 
 .sdb-x-claim {
   min-height: 3em;
   margin: 0;
-  font-size: 16px;
+  color: #a1a1aa;
+  font-size: 15px;
   line-height: 1.45;
 }
 
+.sdb-x-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.sdb-x-btn {
+  padding: 8px 14px;
+  color: #a1a1aa;
+  background: #0a0a0a;
+  border: 1px solid #333;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  cursor: default;
+}
+
+.sdb-x-wells {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
 .sdb-x-section {
-  margin-bottom: 28px;
+  min-height: 160px;
+  padding: 16px;
+  background: #0a0a0a;
+  border: 1px solid #1a1a1a;
 }
 
 .sdb-x-section h2 {
   margin: 0 0 12px;
-  font-size: 11px;
+  color: #71717a;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
   font-weight: 500;
   letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: #a8a29e;
 }
 
 .sdb-x-table {
@@ -224,59 +342,59 @@ button.sdb-x-thumb {
 .sdb-x-table th,
 .sdb-x-table td {
   padding: 8px 0;
-  border-bottom: 1px solid #292524;
+  border-bottom: 1px solid #1a1a1a;
   text-align: left;
   font-size: 12px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
 }
 
 .sdb-x-table th {
   width: 140px;
-  color: #a8a29e;
+  color: #71717a;
   font-weight: 400;
+  letter-spacing: 0.08em;
 }
 
 .sdb-x-table td {
   min-height: 1em;
+  color: #d4d4d8;
 }
 
 .sdb-x-metrics {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: 1fr;
   gap: 12px;
 }
 
 .sdb-x-metric {
-  min-height: 72px;
-  padding: 12px;
-  background: #0c0a09;
-  border: 1px solid #292524;
+  min-height: 48px;
 }
 
-.sdb-x-kicker {
-  margin-bottom: 8px;
-  color: #a8a29e;
-  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
-  font-size: 9px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
+.sdb-x-metric-val {
+  min-height: 1em;
+  color: #d4d4d8;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px;
 }
 
-.sdb-x-spectra {
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 8px;
+.sdb-x-spectra-table th,
+.sdb-x-spectra-table td {
+  width: auto;
+  padding: 6px 8px;
+  font-size: 11px;
 }
 
-.sdb-x-band-well {
-  min-height: 80px;
-  background: #000;
-  border: 1px solid #292524;
+.sdb-x-spectra-table td {
+  min-width: 48px;
+  min-height: 1.4em;
 }
 
 .sdb-x-log {
   min-height: 120px;
-  background: #0c0a09;
-  border: 1px solid #292524;
+}
+
+.sdb-x-span {
+  grid-column: 1 / -1;
 }
 
 [data-promote] {

--- a/packages/specimendb/src/ui/assay.css
+++ b/packages/specimendb/src/ui/assay.css
@@ -1,11 +1,18 @@
-/* Assay / WorkingPanel. Inter + JetBrains. Do not share Terminal charcoal tokens. */
+/* Assay / WorkingPanel. Lift of 9b39d6bc HTML. Inter + JetBrains. Not Terminal tokens. */
+
+.sdb-file-input {
+  display: none;
+}
 
 .sdb-assay {
   --bg-void: #000;
   --bg-charcoal: #0a0a0a;
   --bg-charcoal-elevated: #111;
   --border-dim: #1a1a1a;
+  --border-focus: #333;
   --text-primary: #a1a1aa;
+  --text-secondary: #52525b;
+  --text-dim: #3f3f46;
   --raw: #f59e0b;
   --filed: #06b6d4;
   --working: #10b981;
@@ -20,6 +27,7 @@
   color: var(--text-primary);
   font-family: Inter, ui-sans-serif, system-ui, sans-serif;
   font-size: 13px;
+  -webkit-font-smoothing: antialiased;
 }
 
 .sdb-assay *,
@@ -28,37 +36,22 @@
   box-sizing: border-box;
 }
 
-.sdb-a-rail,
-.sdb-a-log,
-.sdb-a-list {
+.sdb-a-scroll {
   scrollbar-width: thin;
   scrollbar-color: #333333 #000000;
 }
 
-.sdb-a-rail::-webkit-scrollbar,
-.sdb-a-log::-webkit-scrollbar,
-.sdb-a-list::-webkit-scrollbar {
+.sdb-a-scroll::-webkit-scrollbar {
   width: 4px;
   height: 4px;
 }
 
-.sdb-a-rail::-webkit-scrollbar-track,
-.sdb-a-log::-webkit-scrollbar-track,
-.sdb-a-list::-webkit-scrollbar-track {
-  background: #000000;
-  border-left: 1px solid #1a1a1a;
+.sdb-a-scroll::-webkit-scrollbar-track {
+  background: var(--bg-void);
 }
 
-.sdb-a-rail::-webkit-scrollbar-thumb,
-.sdb-a-log::-webkit-scrollbar-thumb,
-.sdb-a-list::-webkit-scrollbar-thumb {
-  background: #333333;
-}
-
-.sdb-a-rail::-webkit-scrollbar-thumb:hover,
-.sdb-a-log::-webkit-scrollbar-thumb:hover,
-.sdb-a-list::-webkit-scrollbar-thumb:hover {
-  background: #555555;
+.sdb-a-scroll::-webkit-scrollbar-thumb {
+  background: var(--border-focus);
 }
 
 .sdb-a-rail {
@@ -68,42 +61,76 @@
   min-width: 440px;
   height: 100%;
   overflow: hidden;
-  background: var(--bg-void);
+  background: #030303;
   border-right: 1px solid var(--border-dim);
+  box-shadow: 10px 0 20px rgba(0, 0, 0, 0.8);
 }
 
 .sdb-a-rail-head {
-  height: 48px;
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  height: 56px;
   padding: 0 16px;
+  background: #000;
+  border-bottom: 1px solid var(--border-dim);
+}
+
+.sdb-a-rail-brand {
   display: flex;
   align-items: center;
-  border-bottom: 1px solid var(--border-dim);
-  color: var(--text-primary);
+  gap: 12px;
+  color: #666;
   font-family: 'JetBrains Mono', ui-monospace, monospace;
-  font-size: 10px;
+  font-size: 12px;
   letter-spacing: 0.16em;
 }
 
-.sdb-a-list {
-  flex: 1;
+.sdb-a-rail-brand i {
+  color: #444;
+  font-size: 20px;
+}
+
+.sdb-a-iconbtn {
   display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  margin: 0;
+  padding: 0;
+  color: #555;
+  background: var(--bg-charcoal);
+  border: 1px solid var(--border-dim);
+  cursor: default;
+}
+
+.sdb-a-iconbtn + .sdb-a-iconbtn {
+  margin-left: 8px;
+}
+
+.sdb-a-list {
+  display: flex;
+  flex: 1;
   flex-direction: column;
-  gap: 12px;
-  padding: 12px;
+  gap: 16px;
+  padding: 16px;
   overflow: auto;
 }
 
 .sdb-a-card {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
   margin: 0;
   padding: 12px;
   text-align: left;
   cursor: pointer;
   color: inherit;
   font: inherit;
-  background: var(--bg-charcoal);
+  background: #080808;
   border: 1px solid var(--border-dim);
 }
 
@@ -112,210 +139,640 @@ button.sdb-a-card {
 }
 
 .sdb-a-card[data-selected='true'] {
-  border-color: #3f3f46;
+  background: #0c0c0c;
+  border-color: #222;
+}
+
+.sdb-a-card[data-selected='true']::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -1px;
+  width: 2px;
+  background: var(--working);
 }
 
 .sdb-a-card[data-empty='true'] {
   cursor: default;
 }
 
-.sdb-a-idrow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+.sdb-a-card[data-status='dead'] {
+  opacity: 0.8;
 }
 
-.sdb-a-id {
-  min-height: 1em;
-  color: #e4e4e7;
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
-  font-size: 11px;
-  word-break: break-all;
+.sdb-a-well {
+  position: relative;
+  height: 176px;
+  overflow: hidden;
+  background: #111;
+  border: 1px solid var(--border-dim);
+}
+
+.sdb-a-well-mark {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #1f1f1f;
+  font-size: 48px;
+  pointer-events: none;
+}
+
+.sdb-a-well-grid {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.2;
+  background-image:
+    linear-gradient(rgba(25, 25, 25, 0.5) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(25, 25, 25, 0.5) 1px, transparent 1px);
+  background-size: 20px 20px;
+}
+
+.sdb-a-well img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .sdb-a-chip {
-  padding: 2px 6px;
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 2px 8px;
   border: 1px solid currentColor;
   font-family: 'JetBrains Mono', ui-monospace, monospace;
   font-size: 9px;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
+  backdrop-filter: blur(8px);
 }
 
 .sdb-a-chip[data-status='raw'] {
   color: var(--raw);
+  background: #451a03;
+  border-color: #78350f;
 }
+
 .sdb-a-chip[data-status='filed'] {
   color: var(--filed);
+  background: #083344;
+  border-color: #164e63;
 }
+
 .sdb-a-chip[data-status='working'] {
   color: var(--working);
+  background: #022c22;
+  border-color: #064e3b;
 }
+
 .sdb-a-chip[data-status='dead'] {
   color: var(--dead);
+  background: #4c0519;
+  border-color: #881337;
+}
+
+.sdb-a-chip[data-inline='true'] {
+  position: static;
+}
+
+.sdb-a-idcap {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  min-width: 48px;
+  min-height: 16px;
+  padding: 2px 6px;
+  overflow: hidden;
+  color: #888;
+  background: rgba(0, 0, 0, 0.8);
+  border: 1px solid #222;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  word-break: break-all;
 }
 
 .sdb-a-claim {
-  min-height: 1.2em;
+  min-height: 1.3em;
   margin: 0;
-  color: #d4d4d8;
-  font-size: 12px;
+  color: #888;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.35;
+}
+
+.sdb-a-card[data-selected='true'] .sdb-a-claim {
+  color: #a1a1aa;
+}
+
+.sdb-a-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: auto;
+}
+
+.sdb-a-tag {
+  min-width: 48px;
+  min-height: 16px;
+  padding: 2px 6px;
+  color: #555;
+  background: #0a0a0a;
+  border: 1px solid var(--border-dim);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .sdb-a-locality {
-  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-top: 8px;
+  margin-top: 4px;
+  color: #555;
+  border-top: 1px solid var(--border-dim);
   font-family: 'JetBrains Mono', ui-monospace, monospace;
   font-size: 10px;
 }
 
 .sdb-a-main {
+  position: relative;
   display: flex;
   flex: 1;
   flex-direction: column;
   min-width: 0;
   height: 100%;
-  overflow: auto;
-  padding: 20px;
-  gap: 16px;
+  overflow: hidden;
+  background: #000;
+}
+
+.sdb-a-stage-grid {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(10, 10, 10, 0.8) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(10, 10, 10, 0.8) 1px, transparent 1px);
+  background-size: 40px 40px;
 }
 
 .sdb-a-zone {
   display: flex;
+  z-index: 1;
+  flex-shrink: 0;
   align-items: center;
   justify-content: center;
-  width: 100%;
+  gap: 24px;
+  width: calc(100% - 48px);
   height: 112px;
-  margin: 0;
+  margin: 24px 24px 0;
   padding: 0;
   cursor: pointer;
   color: inherit;
   font: inherit;
-  background: var(--bg-charcoal);
-  border: 1px dashed var(--border-dim);
+  background: #050505;
+  border: 2px dashed var(--border-dim);
 }
 
 .sdb-a-zone[data-active='true'] {
-  border-color: #3f3f46;
+  background: #080808;
+  border-color: #333;
+}
+
+.sdb-a-zone-mark {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  color: #444;
+  background: var(--bg-charcoal);
+  border: 1px solid #222;
+  font-size: 24px;
 }
 
 .sdb-a-zone-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
   font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+.sdb-a-zone-title {
+  color: #666;
   font-size: 11px;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: #e4e4e7;
+  letter-spacing: 0.2em;
+}
+
+.sdb-a-zone-sub {
+  color: #444;
+  font-size: 10px;
+  letter-spacing: 0.16em;
 }
 
 .sdb-a-error {
-  margin: 0;
+  z-index: 1;
+  margin: 8px 24px 0;
   color: var(--dead);
   font-family: 'JetBrains Mono', ui-monospace, monospace;
-  font-size: 9px;
+  font-size: 10px;
+}
+
+.sdb-a-work {
+  display: flex;
+  z-index: 1;
+  flex: 1;
+  flex-direction: column;
+  gap: 24px;
+  min-height: 0;
+  padding: 24px;
+  overflow: auto;
 }
 
 .sdb-a-focus {
   display: flex;
-  align-items: flex-start;
+  align-items: flex-end;
   justify-content: space-between;
   gap: 16px;
-  padding: 12px 0;
+  padding-bottom: 16px;
   border-bottom: 1px solid var(--border-dim);
 }
 
 .sdb-a-kicker {
-  margin-bottom: 8px;
-  color: var(--text-primary);
+  margin-bottom: 4px;
+  color: #555;
   font-family: 'JetBrains Mono', ui-monospace, monospace;
-  font-size: 9px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.2em;
 }
 
 .sdb-a-focus-id {
   min-height: 1.1em;
-  margin: 0 0 8px;
-  color: #e4e4e7;
+  margin: 0;
+  color: #d4d4d8;
   font-family: 'JetBrains Mono', ui-monospace, monospace;
-  font-size: 22px;
+  font-size: 36px;
   font-weight: 500;
+  letter-spacing: -0.04em;
   word-break: break-all;
 }
 
-.sdb-a-stage {
-  display: grid;
-  grid-template-columns: 1fr 280px;
+.sdb-a-focus-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.sdb-a-actions {
+  display: flex;
   gap: 12px;
-  min-height: 240px;
+}
+
+.sdb-a-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 16px;
+  color: #888;
+  background: #050505;
+  border: 1px solid #222;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  cursor: default;
+}
+
+.sdb-a-grid {
+  display: grid;
+  flex: 1;
+  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+  gap: 24px;
+  min-height: 0;
+}
+
+.sdb-a-stage-col {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 0;
 }
 
 .sdb-a-viewport {
-  background: var(--bg-charcoal);
+  position: relative;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 400px;
+  background: #080808;
   border: 1px solid var(--border-dim);
-  padding: 12px;
+}
+
+.sdb-a-viewport-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 24px;
+  padding: 0 12px;
+  color: #444;
+  background: #050505;
+  border-bottom: 1px solid #111;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+  letter-spacing: 0.16em;
 }
 
 .sdb-a-viewport-stage {
-  min-height: 200px;
-  background: var(--bg-void);
-  border: 1px solid var(--border-dim);
+  position: relative;
+  flex: 1;
+  overflow: hidden;
+  background: #0c0c0c;
+}
+
+.sdb-a-viewport-mark {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #1a1a1a;
+  font-size: 96px;
+  pointer-events: none;
+}
+
+.sdb-a-reticle {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.sdb-a-reticle-h,
+.sdb-a-reticle-v {
+  position: absolute;
+  background: #1a1a1a;
+}
+
+.sdb-a-reticle-h {
+  top: 50%;
+  right: 0;
+  left: 0;
+  height: 1px;
+}
+
+.sdb-a-reticle-v {
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+}
+
+.sdb-a-reticle-ring {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 128px;
+  height: 128px;
+  border: 1px solid #333;
+  border-radius: 50%;
+  opacity: 0.3;
+  transform: translate(-50%, -50%);
+}
+
+.sdb-a-reticle-dot {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  border: 1px solid #555;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.sdb-a-scale {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  color: #666;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+}
+
+.sdb-a-scale-bar {
+  position: relative;
+  width: 96px;
+  height: 1px;
+  background: #666;
+}
+
+.sdb-a-scale-bar::before,
+.sdb-a-scale-bar::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 1px;
+  height: 8px;
+  background: #666;
+  transform: translateY(-50%);
+}
+
+.sdb-a-scale-bar::before {
+  left: 0;
+}
+
+.sdb-a-scale-bar::after {
+  right: 0;
 }
 
 .sdb-a-channels {
   display: grid;
-  grid-template-rows: repeat(4, 1fr);
-  gap: 8px;
+  flex-shrink: 0;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  height: 128px;
 }
 
 .sdb-a-channel {
-  background: var(--bg-charcoal);
+  position: relative;
+  background: #080808;
   border: 1px solid var(--border-dim);
-  padding: 8px;
+}
+
+.sdb-a-channel:first-child {
+  background: #0c0c0c;
+  border-color: #222;
+}
+
+.sdb-a-channel-cap {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 2px 6px;
+  color: #444;
+  background: #050505;
+  border-right: 1px solid var(--border-dim);
+  border-bottom: 1px solid var(--border-dim);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+  letter-spacing: 0.08em;
 }
 
 .sdb-a-channel-well {
+  height: 100%;
   min-height: 36px;
-  background: var(--bg-charcoal-elevated);
 }
 
-.sdb-a-panels {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 12px;
-  min-height: 180px;
+.sdb-a-attach {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  color: #444;
+  background: #030303;
+  border: 1px dashed #222;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+  letter-spacing: 0.16em;
+}
+
+.sdb-a-side {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
 }
 
 .sdb-a-panel {
-  background: var(--bg-charcoal);
+  display: flex;
+  flex-direction: column;
+  background: #050505;
   border: 1px solid var(--border-dim);
-  padding: 12px;
+}
+
+.sdb-a-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px;
+  color: #555;
+  background: #080808;
+  border-bottom: 1px solid var(--border-dim);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+  letter-spacing: 0.16em;
+}
+
+.sdb-a-pulse {
+  width: 6px;
+  height: 6px;
+  background: var(--working);
+}
+
+.sdb-a-panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+}
+
+.sdb-a-section {
+  padding-bottom: 8px;
+  margin-bottom: 8px;
+  color: #555;
+  border-bottom: 1px solid #111;
 }
 
 .sdb-a-row {
   display: flex;
   justify-content: space-between;
   gap: 8px;
-  padding: 6px 0;
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
-  font-size: 10px;
-  color: var(--text-primary);
+  color: #666;
 }
 
 .sdb-a-row span:last-child {
   min-width: 48px;
   min-height: 1em;
+  color: #a1a1aa;
+}
+
+.sdb-a-env {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  padding: 16px;
+}
+
+.sdb-a-env-kicker {
+  margin-bottom: 4px;
+  color: #444;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+}
+
+.sdb-a-env-val {
+  min-height: 1em;
+  color: #888;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+}
+
+.sdb-a-env-span {
+  grid-column: 1 / -1;
 }
 
 .sdb-a-log {
-  overflow: auto;
+  flex: 1;
+  min-height: 200px;
 }
 
 .sdb-a-log-body {
+  flex: 1;
   min-height: 96px;
+  padding: 16px;
+  overflow: auto;
+  color: #777;
   font-family: 'JetBrains Mono', ui-monospace, monospace;
-  font-size: 10px;
+  font-size: 11px;
+}
+
+.sdb-a-cursor {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 8px;
+  margin-top: 16px;
+  color: #555;
+  border-top: 1px solid #111;
+}
+
+.sdb-a-cursor-bar {
+  width: 8px;
+  height: 12px;
+  background: #555;
 }
 
 [data-promote] {
   cursor: pointer;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sdb-a-pulse,
+  .sdb-a-cursor-bar {
+    animation: none;
+  }
 }

--- a/packages/specimendb/src/ui/catalog-app.css
+++ b/packages/specimendb/src/ui/catalog-app.css
@@ -1,18 +1,21 @@
-/* Catalog AppShell. Routed catalog + intake. Not Terminal/Workbench tokens. */
+/* Catalog AppShell. Lift of e90f6c74 HTML + run-06.jsx. Thin chrome. Not Terminal tokens. */
+
+.sdb-file-input {
+  display: none;
+}
 
 .sdb-catalog {
   box-sizing: border-box;
   display: flex;
-  flex-direction: column;
   width: 100%;
-  min-height: 100vh;
   height: 100vh;
   margin: 0;
   overflow: hidden;
-  background: #050505;
-  color: #e7e5e4;
+  color: #d4d4d8;
+  background: #000;
   font-family: Inter, ui-sans-serif, system-ui, sans-serif;
   font-size: 14px;
+  -webkit-font-smoothing: antialiased;
 }
 
 .sdb-catalog *,
@@ -21,101 +24,181 @@
   box-sizing: border-box;
 }
 
-.sdb-c-header {
-  flex-shrink: 0;
-  padding: 20px 28px 16px;
-  border-bottom: 1px solid #1c1917;
+.sdb-c-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: #1f1f22 #000000;
 }
 
-.sdb-c-crumb {
-  margin-bottom: 8px;
-  color: #a8a29e;
-  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
-  font-size: 10px;
-  letter-spacing: 0.14em;
+.sdb-c-scroll::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+
+.sdb-c-scroll::-webkit-scrollbar-track {
+  background: #000;
+}
+
+.sdb-c-scroll::-webkit-scrollbar-thumb {
+  background: #1f1f22;
+}
+
+.sdb-c-scroll::-webkit-scrollbar-thumb:hover {
+  background: #3f3f46;
+}
+
+.sdb-c-rail {
+  display: flex;
+  z-index: 2;
+  flex-direction: column;
+  width: 380px;
+  min-width: 380px;
+  height: 100%;
+  overflow: hidden;
+  background: #030303;
+  border-right: 1px solid #18181b;
+  box-shadow: 4px 0 24px rgba(0, 0, 0, 0.8);
+}
+
+.sdb-c-rail-head {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  height: 56px;
+  padding: 0 20px;
+  color: #a1a1aa;
+  background: #000;
+  border-bottom: 1px solid #18181b;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
 }
 
-.sdb-c-header h1 {
-  margin: 0;
-  font-size: 28px;
+.sdb-c-rail-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #d4d4d8;
   font-weight: 500;
-  letter-spacing: -0.03em;
 }
 
-.sdb-c-body {
-  display: flex;
-  flex: 1;
-  min-height: 0;
+.sdb-c-rail-brand i {
+  color: #71717a;
+}
+
+.sdb-c-sys {
+  color: #52525b;
 }
 
 .sdb-c-intake {
-  width: 360px;
-  min-width: 360px;
-  padding: 24px;
-  border-right: 1px solid #1c1917;
+  padding: 16px;
+  background: #050505;
+  border-bottom: 1px solid #18181b;
 }
 
 .sdb-c-zone {
+  position: relative;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-end;
-  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   width: 100%;
-  height: 220px;
+  height: 96px;
   margin: 0;
-  padding: 20px;
+  padding: 0;
+  overflow: hidden;
   cursor: pointer;
-  text-align: left;
+  text-align: center;
   color: inherit;
   font: inherit;
-  background: #0c0a09;
-  border: 1px solid #292524;
+  background: #0a0a0a;
+  border: 1px dashed #27272a;
 }
 
 .sdb-c-zone[data-active='true'] {
-  border-color: #44403c;
+  background: #111;
+  border-color: #52525b;
+}
+
+.sdb-c-zone i {
+  color: #52525b;
+  font-size: 20px;
 }
 
 .sdb-c-zone-title {
-  font-size: 16px;
-  font-weight: 500;
+  color: #71717a;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
 
-.sdb-c-zone-sub {
-  color: #a8a29e;
-  font-size: 12px;
+.sdb-c-corner {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  opacity: 0.5;
+}
+
+.sdb-c-corner-tl {
+  top: 4px;
+  left: 4px;
+  border-top: 1px solid #3f3f46;
+  border-left: 1px solid #3f3f46;
+}
+
+.sdb-c-corner-tr {
+  top: 4px;
+  right: 4px;
+  border-top: 1px solid #3f3f46;
+  border-right: 1px solid #3f3f46;
+}
+
+.sdb-c-corner-bl {
+  bottom: 4px;
+  left: 4px;
+  border-bottom: 1px solid #3f3f46;
+  border-left: 1px solid #3f3f46;
+}
+
+.sdb-c-corner-br {
+  right: 4px;
+  bottom: 4px;
+  border-right: 1px solid #3f3f46;
+  border-bottom: 1px solid #3f3f46;
 }
 
 .sdb-c-error {
-  margin: 12px 0 0;
+  margin: 8px 0 0;
   color: #f43f5e;
   font-size: 12px;
 }
 
-.sdb-c-grid {
+.sdb-c-list {
+  display: flex;
   flex: 1;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  align-content: start;
+  flex-direction: column;
   gap: 16px;
-  padding: 24px;
+  padding: 16px;
   overflow: auto;
+  background: #020202;
 }
 
 .sdb-c-card {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 10px;
   margin: 0;
-  padding: 16px;
+  padding: 0;
+  overflow: hidden;
   text-align: left;
   cursor: pointer;
   color: inherit;
   font: inherit;
-  background: #0c0a09;
-  border: 1px solid #292524;
+  background: #080808;
+  border: 1px solid #27272a;
 }
 
 button.sdb-c-card {
@@ -123,66 +206,439 @@ button.sdb-c-card {
 }
 
 .sdb-c-card[data-selected='true'] {
-  border-color: #a8a29e;
+  background: #0a0a0a;
+  border-color: #52525b;
+  box-shadow: inset 0 0 0 1px #71717a;
 }
 
 .sdb-c-card[data-empty='true'] {
   cursor: default;
 }
 
-.sdb-c-card-top {
+.sdb-c-card[data-status='dead'] {
+  opacity: 0.6;
+}
+
+.sdb-c-well {
+  position: relative;
+  height: 128px;
+  overflow: hidden;
+  background: #18181b;
+}
+
+.sdb-c-well-fill {
+  position: absolute;
+  inset: 0;
+  background: #0a0a0a;
+}
+
+.sdb-c-well-dot {
+  position: absolute;
+  top: 50%;
+  left: 50%;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid rgba(39, 39, 42, 0.5);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+.sdb-c-well-dot span {
+  width: 4px;
+  height: 4px;
+  background: rgba(63, 63, 70, 0.5);
+  border-radius: 50%;
+}
+
+.sdb-c-well img {
+  position: relative;
+  z-index: 1;
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .sdb-c-chip {
-  padding: 2px 6px;
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: #000;
   border: 1px solid currentColor;
-  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
   font-size: 9px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.8);
+}
+
+.sdb-c-chip::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  background: currentColor;
 }
 
 .sdb-c-chip[data-status='raw'] {
   color: #f59e0b;
-}
-.sdb-c-chip[data-status='filed'] {
-  color: #06b6d4;
-}
-.sdb-c-chip[data-status='working'] {
-  color: #10b981;
-}
-.sdb-c-chip[data-status='dead'] {
-  color: #f43f5e;
+  border-color: rgba(120, 53, 15, 0.4);
 }
 
-.sdb-c-locality {
-  color: #a8a29e;
-  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
-  font-size: 10px;
+.sdb-c-chip[data-status='filed'] {
+  color: #06b6d4;
+  border-color: rgba(22, 78, 99, 0.4);
+}
+
+.sdb-c-chip[data-status='working'] {
+  color: #10b981;
+  border-color: rgba(6, 78, 59, 0.4);
+}
+
+.sdb-c-chip[data-status='dead'] {
+  color: #f43f5e;
+  border-color: rgba(136, 19, 55, 0.4);
+}
+
+.sdb-c-chip[data-inline='true'] {
+  position: static;
+}
+
+.sdb-c-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
 }
 
 .sdb-c-claim {
   min-height: 2.4em;
   margin: 0;
-  font-size: 14px;
-  line-height: 1.4;
+  color: #a1a1aa;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.sdb-c-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sdb-c-tag {
+  min-width: 48px;
+  min-height: 16px;
+  padding: 2px 6px;
+  color: #71717a;
+  background: #18181b;
+  border: 1px solid #27272a;
+}
+
+.sdb-c-meta {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding-top: 12px;
+  margin-top: 4px;
+  color: #71717a;
+  border-top: 1px solid #18181b;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
 }
 
 .sdb-c-id {
   min-height: 1em;
-  color: #78716c;
-  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
-  font-size: 10px;
+  overflow: hidden;
   word-break: break-all;
 }
 
+.sdb-c-locality {
+  color: #52525b;
+}
+
 .sdb-c-media {
-  color: #a8a29e;
+  color: #71717a;
   font-size: 11px;
+}
+
+.sdb-c-outlet {
+  position: relative;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+  background: #000;
+}
+
+.sdb-c-scanlines::before {
+  content: ' ';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background:
+    linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.25) 50%),
+    linear-gradient(90deg, rgba(255, 0, 0, 0.06), rgba(0, 255, 0, 0.02), rgba(0, 0, 255, 0.06));
+  background-size: 100% 2px, 3px 100%;
+}
+
+.sdb-c-grid-bg {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.03;
+  background-image:
+    linear-gradient(#fff 1px, transparent 1px),
+    linear-gradient(90deg, #fff 1px, transparent 1px);
+  background-size: 64px 64px;
+}
+
+.sdb-c-header {
+  display: flex;
+  z-index: 2;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  height: 56px;
+  padding: 0 32px;
+  background: rgba(0, 0, 0, 0.8);
+  border-bottom: 1px solid #18181b;
+  backdrop-filter: blur(8px);
+}
+
+.sdb-c-crumb {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: #52525b;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.sdb-c-actions {
+  display: flex;
+  gap: 24px;
+}
+
+.sdb-c-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0;
+  color: #71717a;
+  background: none;
+  border: 0;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  cursor: default;
+}
+
+.sdb-c-body {
+  z-index: 2;
+  flex: 1;
+  padding: 40px;
+  overflow: auto;
+}
+
+.sdb-c-lead {
+  max-width: 72rem;
+  margin: 0 auto;
+}
+
+.sdb-c-title {
+  min-height: 1.2em;
+  margin: 0 0 12px;
+  color: #f4f4f5;
+  font-size: 30px;
+  font-weight: 300;
+  letter-spacing: -0.03em;
+  word-break: break-all;
+}
+
+.sdb-c-lead-claim {
+  max-width: 42rem;
+  min-height: 1.4em;
+  margin: 0 0 32px;
+  color: #71717a;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.sdb-c-stage {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
+  gap: 32px;
+}
+
+.sdb-c-photo {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: #050505;
+  border: 1px solid #27272a;
+}
+
+.sdb-c-photo img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.sdb-c-photo-cap {
+  position: absolute;
+  bottom: 24px;
+  left: 24px;
+  z-index: 2;
+  padding: 4px 8px;
+  color: #71717a;
+  background: #000;
+  border: 1px solid #18181b;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.sdb-c-scans {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  margin-top: 24px;
+}
+
+.sdb-c-scan {
+  display: flex;
+  flex-direction: column;
+  aspect-ratio: 1;
+  padding: 12px;
+  background: #030303;
+  border: 1px solid #18181b;
+}
+
+.sdb-c-scan-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  color: #52525b;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.sdb-c-scan-well {
+  flex: 1;
+  min-height: 48px;
+  background: #09090b;
+  border: 1px solid #18181b;
+}
+
+.sdb-c-side {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.sdb-c-wellbox {
+  padding: 20px;
+  background: #050505;
+  border: 1px solid #27272a;
+}
+
+.sdb-c-wellbox h2 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 16px;
+  color: #71717a;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.sdb-c-dot {
+  width: 6px;
+  height: 6px;
+  background: #3f3f46;
+}
+
+.sdb-c-dl {
+  margin: 0;
+}
+
+.sdb-c-dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding-bottom: 8px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #18181b;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px;
+}
+
+.sdb-c-dl dt {
+  color: #52525b;
+  font-weight: 400;
+}
+
+.sdb-c-dl dd {
+  min-width: 48px;
+  min-height: 1em;
+  margin: 0;
+  color: #d4d4d8;
+}
+
+.sdb-c-log {
+  display: flex;
+  flex-direction: column;
+  min-height: 256px;
+  padding: 20px;
+  background: #000;
+  border: 1px solid #27272a;
+}
+
+.sdb-c-log h2 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 8px;
+  margin: 0 0 16px;
+  color: #52525b;
+  border-bottom: 1px solid #18181b;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.sdb-c-log-body {
+  flex: 1;
+  min-height: 96px;
 }
 
 [data-promote] {

--- a/packages/specimendb/src/ui/dactyl.css
+++ b/packages/specimendb/src/ui/dactyl.css
@@ -1,4 +1,8 @@
-/* Dactyl / AnalogCard grid. Inter + JetBrains. Body #020202. 6px scrollbars. */
+/* Dactyl / AnalogCard grid. Lift of 94e9fc0d HTML. Inter + JetBrains. Body #020202. 6px scrollbars. */
+
+.sdb-file-input {
+  display: none;
+}
 
 .sdb-dactyl {
   box-sizing: border-box;
@@ -7,10 +11,11 @@
   height: 100vh;
   margin: 0;
   overflow: hidden;
+  color: #d1d5db;
   background: #020202;
-  color: #d4d4d4;
   font-family: Inter, ui-sans-serif, system-ui, sans-serif;
   font-size: 13px;
+  -webkit-font-smoothing: antialiased;
 }
 
 .sdb-dactyl *,
@@ -41,95 +46,293 @@
   background: #1a1a1a;
 }
 
+.sdb-dactyl::-webkit-scrollbar-thumb:hover,
+.sdb-dactyl *::-webkit-scrollbar-thumb:hover {
+  background: #2a2a2a;
+}
+
 .sdb-d-intake {
   display: flex;
   flex-direction: column;
   width: 320px;
   min-width: 320px;
   height: 100%;
-  padding: 16px;
-  gap: 16px;
-  border-right: 1px solid #1a1a1a;
-  overflow: auto;
+  overflow: hidden;
+  background: #070707;
+  border-right: 1px solid #151515;
+  box-shadow: 4px 0 24px rgba(0, 0, 0, 0.9);
+}
+
+.sdb-d-brand {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px;
+  border-bottom: 1px solid #151515;
+}
+
+.sdb-d-brand-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sdb-d-brand h1 {
+  margin: 0;
+  color: #e5e7eb;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+}
+
+.sdb-d-brand h1 span {
+  color: #6b7280;
+}
+
+.sdb-d-brand i {
+  color: #06b6d4;
+  font-size: 20px;
+}
+
+.sdb-d-cursor {
+  display: inline-block;
+  width: 6px;
+  height: 12px;
+  margin-left: 4px;
+  background: #06b6d4;
+}
+
+.sdb-d-ver {
+  color: #4b5563;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+}
+
+.sdb-d-zone-wrap {
+  padding: 20px;
+  border-bottom: 1px solid #151515;
 }
 
 .sdb-d-zone {
+  position: relative;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   width: 100%;
-  min-height: 160px;
+  height: 128px;
   margin: 0;
   padding: 12px;
   cursor: pointer;
   color: inherit;
   font: inherit;
   background: #0a0a0a;
-  border: 1px dashed #1a1a1a;
+  border: 1px dashed #2a2a2a;
+}
+
+.sdb-d-zone[data-active='true'] {
+  background: #0d0d0d;
+  border-color: #404040;
+}
+
+.sdb-d-zone i {
+  margin-bottom: 8px;
+  color: #4b5563;
+  font-size: 24px;
+}
+
+.sdb-d-zone-title {
+  color: #9ca3af;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+}
+
+.sdb-d-zone-sub {
+  margin-top: 4px;
+  color: #4b5563;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+}
+
+.sdb-d-corner {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+}
+
+.sdb-d-corner-tl {
+  top: 0;
+  left: 0;
+  border-top: 1px solid #404040;
+  border-left: 1px solid #404040;
+}
+
+.sdb-d-corner-tr {
+  top: 0;
+  right: 0;
+  border-top: 1px solid #404040;
+  border-right: 1px solid #404040;
+}
+
+.sdb-d-corner-bl {
+  bottom: 0;
+  left: 0;
+  border-bottom: 1px solid #404040;
+  border-left: 1px solid #404040;
+}
+
+.sdb-d-corner-br {
+  right: 0;
+  bottom: 0;
+  border-right: 1px solid #404040;
+  border-bottom: 1px solid #404040;
+}
+
+.sdb-d-error {
+  margin: 8px 20px 0;
+  color: #f43f5e;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+}
+
+.sdb-d-queue {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  overflow: auto;
+}
+
+.sdb-d-queue-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px;
+  margin-bottom: 4px;
+  color: #6b7280;
   font-family: 'JetBrains Mono', ui-monospace, monospace;
   font-size: 10px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
 }
 
-.sdb-d-zone[data-active='true'] {
-  border-color: #06b6d4;
-}
-
-.sdb-d-error {
-  margin: 0;
-  color: #f43f5e;
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
-  font-size: 9px;
-}
-
-.sdb-d-queue {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.sdb-d-kicker {
-  color: #71717a;
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
-  font-size: 9px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
+.sdb-d-queue-head span:last-child {
+  color: #4b5563;
 }
 
 .sdb-d-queue-slot {
-  min-height: 36px;
+  min-height: 56px;
+  padding: 12px;
   background: #0a0a0a;
   border: 1px solid #1a1a1a;
 }
 
+.sdb-d-sync {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  color: #4b5563;
+  border-top: 1px solid #151515;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+}
+
+.sdb-d-sync-ok {
+  color: #10b981;
+}
+
 .sdb-d-main {
+  position: relative;
   display: flex;
   flex: 1;
   flex-direction: column;
   min-width: 0;
   height: 100%;
   overflow: hidden;
+  background: #020202;
 }
 
 .sdb-d-head {
-  height: 48px;
+  display: flex;
+  z-index: 1;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  height: 64px;
+  padding: 0 32px;
+  background: #050505;
+  border-bottom: 1px solid #151515;
+}
+
+.sdb-d-head-left {
   display: flex;
   align-items: center;
-  padding: 0 20px;
-  border-bottom: 1px solid #1a1a1a;
+  gap: 16px;
+  color: #6b7280;
   font-family: 'JetBrains Mono', ui-monospace, monospace;
   font-size: 11px;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sdb-d-head-div {
+  width: 1px;
+  height: 16px;
+  background: #2a2a2a;
+}
+
+.sdb-d-viewing {
+  color: #4b5563;
+}
+
+.sdb-d-viewing span {
+  color: #d1d5db;
+}
+
+.sdb-d-query {
+  width: 256px;
+  padding: 6px 12px 6px 32px;
+  color: #d1d5db;
+  background: #0a0a0a;
+  border: 1px solid #1a1a1a;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+}
+
+.sdb-d-query:focus {
+  background: #111;
+  border-color: #404040;
+  outline: none;
+}
+
+.sdb-d-query-wrap {
+  position: relative;
+}
+
+.sdb-d-query-wrap i {
+  position: absolute;
+  top: 50%;
+  left: 10px;
+  color: #4b5563;
+  transform: translateY(-50%);
+}
+
+.sdb-d-grid-wrap {
+  flex: 1;
+  padding: 32px 32px 48px;
+  overflow: auto;
 }
 
 .sdb-d-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 16px;
-  padding: 16px;
-  overflow: auto;
-  flex: 1;
+  gap: 24px;
 }
 
 .sdb-d-card {
@@ -142,8 +345,9 @@
   cursor: pointer;
   color: inherit;
   font: inherit;
-  background: #0a0a0a;
-  border: 1px solid #1a1a1a;
+  background: #0f0f0f;
+  border: 1px solid #1f1f1f;
+  box-shadow: 0 8px 30px rgb(0, 0, 0, 0.8);
 }
 
 button.sdb-d-card {
@@ -160,67 +364,183 @@ button.sdb-d-card {
 }
 
 .sdb-d-well {
-  height: 140px;
-  background: #020202;
-  border-bottom: 1px solid #1a1a1a;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 192px;
+  overflow: hidden;
+  color: #2a2a2a;
+  background-color: #0a0a0a;
+  background-image:
+    linear-gradient(to right, rgba(25, 25, 25, 0.5) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(25, 25, 25, 0.5) 1px, transparent 1px);
+  background-size: 20px 20px;
+  border-bottom: 1px solid #1f1f1f;
+  box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.8);
 }
 
-.sdb-d-card-body {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 12px;
+.sdb-d-well i {
+  font-size: 48px;
 }
 
-.sdb-d-idrow {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 8px;
+.sdb-d-well img {
+  position: absolute;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.sdb-d-chip {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  padding: 2px 8px;
+  border: 1px solid currentColor;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.sdb-d-chip[data-status='raw'] {
+  color: #d97706;
+  background: #451a03;
+  border-color: #78350f;
+}
+
+.sdb-d-chip[data-status='filed'] {
+  color: #06b6d4;
+  background: #083344;
+  border-color: #164e63;
+}
+
+.sdb-d-chip[data-status='working'] {
+  color: #10b981;
+  background: #064e3b;
+  border-color: #047857;
+}
+
+.sdb-d-chip[data-status='dead'] {
+  color: #f43f5e;
+  background: #4c0519;
+  border-color: #881337;
 }
 
 .sdb-d-id {
+  position: absolute;
+  bottom: 8px;
+  left: 12px;
   min-height: 1em;
-  color: #e4e4e7;
+  max-width: calc(100% - 24px);
+  padding: 2px 6px;
+  overflow: hidden;
+  color: #4b5563;
+  background: rgba(5, 5, 5, 0.8);
+  border: 1px solid #1a1a1a;
   font-family: 'JetBrains Mono', ui-monospace, monospace;
   font-size: 10px;
   word-break: break-all;
 }
 
-.sdb-d-chip {
-  padding: 2px 6px;
-  border: 1px solid currentColor;
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
-  font-size: 9px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.sdb-d-chip[data-status='raw'] {
-  color: #f59e0b;
-}
-.sdb-d-chip[data-status='filed'] {
-  color: #06b6d4;
-}
-.sdb-d-chip[data-status='working'] {
-  color: #10b981;
-}
-.sdb-d-chip[data-status='dead'] {
-  color: #f43f5e;
+.sdb-d-card-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  padding: 20px;
+  background: linear-gradient(to bottom, #0f0f0f, #0a0a0a);
 }
 
 .sdb-d-claim {
-  min-height: 1.3em;
-  margin: 0;
-  font-size: 12px;
+  min-height: 2.5em;
+  margin: 0 0 16px;
+  overflow: hidden;
+  color: #e5e7eb;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  line-height: 1.45;
+}
+
+.sdb-d-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.sdb-d-tag {
+  min-width: 48px;
+  min-height: 16px;
+  padding: 2px 8px;
+  color: #9ca3af;
+  background: #050505;
+  border: 1px solid #1a1a1a;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
 }
 
 .sdb-d-locality {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-top: 16px;
+  margin-top: auto;
+  color: #6b7280;
+  border-top: 1px solid #1a1a1a;
   font-family: 'JetBrains Mono', ui-monospace, monospace;
   font-size: 10px;
-  color: #71717a;
+}
+
+.sdb-d-foot {
+  display: flex;
+  z-index: 1;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  height: 32px;
+  padding: 0 16px;
+  color: #4b5563;
+  background: #050505;
+  border-top: 1px solid #151515;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+}
+
+.sdb-d-foot-left {
+  display: flex;
+  gap: 16px;
+}
+
+.sdb-d-foot-count {
+  color: #6b7280;
 }
 
 [data-promote] {
   cursor: pointer;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sdb-d-cursor {
+    animation: none;
+  }
+}
+
+@keyframes sdb-d-blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .sdb-d-cursor {
+    animation: sdb-d-blink 1s step-end infinite;
+  }
 }

--- a/packages/specimendb/test/ui.test.tsx
+++ b/packages/specimendb/test/ui.test.tsx
@@ -510,25 +510,25 @@ describe('six full pages', () => {
       name: 'Assay',
       Page: AssayPage,
       testId: 'working-panel',
-      copy: ['INITIATE_INTAKE_PROTOCOL', 'CURRENT_FOCUS_RECORD', 'WORKING SET', 'CH-01'],
+      copy: ['INITIATE_INTAKE_PROTOCOL', 'CURRENT_FOCUS_RECORD', 'VIEWPORT_01', 'INSTRUMENT_READOUT', 'ENV_CONTEXT', 'OBSERVATION_LOG', 'CH_01_VIS'],
     },
     {
       name: 'Dactyl',
       Page: DactylPage,
       testId: 'dactyl-grid',
-      copy: ['DACTYL // ANALOG CARD', 'ACTIVE QUEUE', 'DROP_FIELD_MEDIA'],
+      copy: ['INITIATE INTAKE', 'Active Queue', 'SYSTEM.CORE'],
     },
     {
       name: 'Catalog',
       Page: CatalogPage,
       testId: 'app-shell',
-      copy: ['SPECIMEN_DB / CATALOG', 'Drop specimen media', 'Catalog'],
+      copy: ['SPECIMEN_DB / CATALOG', 'Intake Drop Zone', 'SPECIMEN_DB'],
     },
     {
       name: 'Accession',
       Page: AccessionPage,
       testId: 'dossier-view',
-      copy: ['PHOTO RAIL', 'Taxonomy', 'Field metrics', 'Spectral grid', 'Observer log'],
+      copy: ['PHOTO RAIL', 'TAXONOMY_DATA', 'FIELD_METRICS', 'SPECTRAL_ANALYSIS', 'OBSERVER_LOG'],
     },
   ];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Four full specimendb testbed pages, each a lift of its Variant layout. New branch from master. Does not write on PR 43 or PR 48. Do not merge.

## Routes

| Route | Page | Component | Source |
|---|---|---|---|
| `/catalog` | Catalog | AppShell | `e90f6c74-5f26-4990-9cb8-0f76ff18f3d8.html` + `run-06.jsx` (PR 44 branch, not copied into this PR) |
| `/assay` | Assay | WorkingPanel | `9b39d6bc-91a3-492e-a9f5-e19f5cfb14b3.html` |
| `/dactyl` | Dactyl | AnalogCard | `94e9fc0d-164a-400c-a6ef-73ee589e1741.html` |
| `/accession` | Accession | DossierView | board stills / journal F-092–105 — no HTML extract exists |

Each route is its own page. Not a mashed shell. Not a generic dashboard.

Testbed: `cd packages/specimendb && bun run testbed` → `https://localhost:4177/catalog` `/assay` `/dactyl` `/accession`.

## Bind

Intake, List, Get on select, Status/Promote, Claim, Media bytes where the page owns the well, locality `unknown` unless EXIF GPS. Query on Dactyl (`QUERY DATABASE...`). Empty card/dossier chrome stays. Specimen is the only type. Existing Intake/Get/List store — no new store, no PGlite rewrite, capture/ untouched.

## Look

HTML is the look. Theater *values* stripped (no SP-/SEQ-/OD-/COL-/coords/taxon%/elev/temp/spectra fill). Wells remain drawn.

- Assay: Inter + JetBrains Mono, 440px rail, dashed `[ INITIATE_INTAKE_PROTOCOL ]`, `CURRENT_FOCUS_RECORD`, `VIEWPORT_01` + channel wells, `INSTRUMENT_READOUT` / `ENV_CONTEXT` / `OBSERVATION_LOG`. 4px overflow bars.
- Dactyl: Inter + JetBrains Mono, w-80 intake, Active Queue chrome, analog card = well / claim / 3 tags / status / locality. 6px scrollbars. Footer `SYSTEM.CORE` + list count.
- Catalog: 380px rail, intake drop, thin `SPECIMEN_DB` / `SYS.09` chrome. Breadcrumbs `SPECIMEN_DB / CATALOG` — not OD-2394 as data. Empty SEM/CT/spectra/metrics/log wells.
- Accession: fat dossier (id, taxonomy table, field-metrics, spectral table, observer log). All empty/unknown except now-slots.

## Could not lift from repo HTML

Accession has no Variant HTML extract on this repo (issue #86). Reconstructed from the attached board stills + journal F-092–105. Catalog/Assay/Dactyl HTML lived on PR 44 (`cursor/variant-board-screenshots-918d`), not on master — read from that branch as look lock, not merged.

`bun test:run` — 34 passing.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f08a660a-6f58-45b5-875c-0be88555ca2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f08a660a-6f58-45b5-875c-0be88555ca2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

