### PR TITLE
feat(specimendb): append-only activity log (#61)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -376,10 +376,10 @@
       "name": "@tmnl/specimendb",
       "version": "0.0.1",
       "dependencies": {
-        "@effect/sql-pglite": "4.0.0-beta.93",
-        "@electric-sql/pglite": "0.4.5",
+        "@effect/sql-pg": "4.0.0-beta.93",
         "@tmnl/stx": "workspace:*",
         "effect": "4.0.0-beta.93",
+        "pg": "^8.23.0",
       },
       "devDependencies": {
         "@effect/vitest": "4.0.0-beta.93",
@@ -1489,8 +1489,6 @@
 
     "@effect/sql-pg": ["@effect/sql-pg@0.50.3", "", { "dependencies": { "pg": "^8.16.3", "pg-connection-string": "2.9.1", "pg-cursor": "^2.15.3", "pg-pool": "^3.10.1", "pg-types": "^4.1.0" }, "peerDependencies": { "@effect/experimental": "^0.58.0", "@effect/platform": "^0.94.4", "@effect/sql": "^0.49.0", "effect": "^3.19.16" } }, "sha512-mKY8+qJFWvmMeX+TA2j1r01XXnI23Z5gu0KI1jDgjLATNImPXWsPIb1bnoZTyUNW5CIUu6X/wFT6M+8sZYLCiA=="],
 
-    "@effect/sql-pglite": ["@effect/sql-pglite@4.0.0-beta.93", "", { "dependencies": { "@electric-sql/pglite": "^0.4.5" }, "peerDependencies": { "effect": "^4.0.0-beta.93" } }, "sha512-PEw/R5htFb16KRDwIbp1uRs6STQpj08HAtOTSH9KyZOTsKxO4Qsn01x7g0bqNWNMnBTOAxogqcnbDLHOA+rNFg=="],
-
     "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@0.50.2", "", { "peerDependencies": { "@effect/experimental": "^0.58.0", "@effect/platform": "^0.94.4", "@effect/sql": "^0.49.0", "effect": "^3.19.16" } }, "sha512-bd+rwFMjZ53OZhOnzQ0Zdef9IK2lgd0xP3M/553Y+aZjqOctMjhZmd3PVi8JjR+pRgSzN5XBu9Gly97t0aPsug=="],
 
     "@effect/sql-sqlite-wasm": ["@effect/sql-sqlite-wasm@0.50.0", "", { "peerDependencies": { "@effect/experimental": "^0.58.0", "@effect/sql": "^0.49.0", "@effect/wa-sqlite": "^0.1.2", "effect": "^3.19.13" } }, "sha512-CsdEsPkA8fJTfPrKuhr0taqRSuDC+qe4m9FvwcTaTG5m+nI3FHF5yqDD+ZyMZp24YhWsvF+epEX50NE6Rri+Mg=="],
@@ -1506,8 +1504,6 @@
     "@electric-sql/client": ["@electric-sql/client@1.5.12", "", { "dependencies": { "@microsoft/fetch-event-source": "^2.0.1" }, "optionalDependencies": { "@rollup/rollup-darwin-arm64": "^4.18.1" }, "bin": { "intent": "bin/intent.mjs" } }, "sha512-mWDEpKog0Zo4WOjReW4x9ELaHsjTthpziLVJkjmSdh/4Y/ZHw5EoY5e9dJX9itPSKVk9GNFz3YfHFv5EAyCOmw=="],
 
     "@electric-sql/d2ts": ["@electric-sql/d2ts@0.1.8", "", { "dependencies": { "@types/murmurhash-js": "^1.0.6", "fractional-indexing": "^3.2.0", "murmurhash-js": "^1.0.0" }, "peerDependencies": { "@electric-sql/client": ">=1.0.0-beta.4", "better-sqlite3": "^11.7.0" }, "optionalPeers": ["@electric-sql/client", "better-sqlite3"] }, "sha512-2cyiDSaq5VxEHOQZ0yvknkdrVA44VADdDhNdeM3MIAVeati7gkiixKnX5osFaKvxM6SeLRKLQcaHSvlvdMDFRQ=="],
-
-    "@electric-sql/pglite": ["@electric-sql/pglite@0.4.5", "", {}, "sha512-aGG2zGEyZzGWKy8P+9ZoNUV0jxt1+hgbeTf+bVAYyxVZZLXg3/9aFlfLxb08AYZVAfAkQlQIysmWjhc5hwDG8g=="],
 
     "@electric-sql/react": ["@electric-sql/react@1.0.36", "", { "dependencies": { "@electric-sql/client": "1.5.7", "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "react": ">=18.3.1 <20.0.0" }, "optionalPeers": ["react"] }, "sha512-vowuzMdyRtyI+ycUoqP9bqd0+hyYLHYZBC2sV2BGaGToQy+1vrZO1pPXDD8gTcajpd6lP9k08OTp8VP+yW4uOw=="],
 
@@ -5975,30 +5971,6 @@
 
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
-    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
-
-    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
-
-    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
-
-    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
-
-    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
-
-    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
-
-    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
-
-    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
-
-    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
-
-    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
-
-    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
-
-    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
-
     "lilconfig": ["lilconfig@2.1.0", "", {}, "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="],
 
     "limiter": ["limiter@2.1.0", "", { "dependencies": { "just-performance": "4.3.0" } }, "sha512-361TYz6iay6n+9KvUUImqdLuFigK+K79qrUtBsXhJTLdH4rIt/r1y8r1iozwh8KbZNpujbFTSh74mJ7bwbAMOw=="],
@@ -6705,9 +6677,9 @@
 
     "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
 
-    "pg": ["pg@8.18.0", "", { "dependencies": { "pg-connection-string": "^2.11.0", "pg-pool": "^3.11.0", "pg-protocol": "^1.11.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ=="],
+    "pg": ["pg@8.23.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.16.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg=="],
 
-    "pg-cloudflare": ["pg-cloudflare@1.3.0", "", {}, "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="],
+    "pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
 
     "pg-connection-string": ["pg-connection-string@2.9.1", "", {}, "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w=="],
 
@@ -6719,7 +6691,7 @@
 
     "pg-pool": ["pg-pool@3.11.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w=="],
 
-    "pg-protocol": ["pg-protocol@1.11.0", "", {}, "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g=="],
+    "pg-protocol": ["pg-protocol@1.16.0", "", {}, "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg=="],
 
     "pg-types": ["pg-types@4.1.0", "", { "dependencies": { "pg-int8": "1.0.1", "pg-numeric": "1.0.2", "postgres-array": "~3.0.1", "postgres-bytea": "~3.0.0", "postgres-date": "~2.1.0", "postgres-interval": "^3.0.0", "postgres-range": "^1.1.1" } }, "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg=="],
 
@@ -8463,6 +8435,8 @@
 
     "@effect/sql/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
+    "@effect/sql-pg/pg": ["pg@8.18.0", "", { "dependencies": { "pg-connection-string": "^2.11.0", "pg-pool": "^3.11.0", "pg-protocol": "^1.11.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ=="],
+
     "@electric-sql/react/@electric-sql/client": ["@electric-sql/client@1.5.7", "", { "dependencies": { "@microsoft/fetch-event-source": "^2.0.1" }, "optionalDependencies": { "@rollup/rollup-darwin-arm64": "^4.18.1" } }, "sha512-jeKLlooV/wIBVkZV6d3opT+eoDLds9qDzHtUYezfl6BzAPY1v5mApgjlG/evbvBBZKYW778wOIBUfq16SMnr7w=="],
 
     "@electron/get/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
@@ -9442,6 +9416,8 @@
     "@tmnl/msh/vitest": ["vitest@4.1.0", "", { "dependencies": { "@vitest/expect": "4.1.0", "@vitest/mocker": "4.1.0", "@vitest/pretty-format": "4.1.0", "@vitest/runner": "4.1.0", "@vitest/snapshot": "4.1.0", "@vitest/spy": "4.1.0", "@vitest/utils": "4.1.0", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.0", "@vitest/browser-preview": "4.1.0", "@vitest/browser-webdriverio": "4.1.0", "@vitest/ui": "4.1.0", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw=="],
 
     "@tmnl/pct/vitest": ["vitest@4.1.0", "", { "dependencies": { "@vitest/expect": "4.1.0", "@vitest/mocker": "4.1.0", "@vitest/pretty-format": "4.1.0", "@vitest/runner": "4.1.0", "@vitest/snapshot": "4.1.0", "@vitest/spy": "4.1.0", "@vitest/utils": "4.1.0", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.0", "@vitest/browser-preview": "4.1.0", "@vitest/browser-webdriverio": "4.1.0", "@vitest/ui": "4.1.0", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw=="],
+
+    "@tmnl/specimendb/@effect/sql-pg": ["@effect/sql-pg@4.0.0-beta.93", "", { "dependencies": { "pg": "^8.20.0", "pg-connection-string": "2.12.0", "pg-cursor": "^2.19.0", "pg-pool": "^3.13.0", "pg-types": "^4.1.0" }, "peerDependencies": { "effect": "^4.0.0-beta.93" } }, "sha512-wpoGGezcmMVGG9p9vumFTR42+LPE2PaaUZ+vTcpo0hyc4TvChSRZiv4uZafrXEnDdYgdUFw7UQzrEO8+pa5crg=="],
 
     "@tmnl/specimendb/@effect/vitest": ["@effect/vitest@4.0.0-beta.93", "", { "peerDependencies": { "effect": "^4.0.0-beta.93", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-gMAnZ9PiMeJMDED9s0jWgCOhc2JccrTCxowhur/KriImsHnHIRj4VG/vK0xLw0Axe4AkTWzXNdRsFrYOjBTl3A=="],
 
@@ -10499,7 +10475,9 @@
 
     "path-scurry/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
-    "pg/pg-connection-string": ["pg-connection-string@2.11.0", "", {}, "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ=="],
+    "pg/pg-connection-string": ["pg-connection-string@2.14.0", "", {}, "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg=="],
+
+    "pg/pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
 
     "pg/pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
 
@@ -11236,6 +11214,14 @@
     "@durable-streams/server-conformance-tests/vitest/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
     "@durable-streams/server-conformance-tests/vitest/tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "@effect/sql-pg/pg/pg-cloudflare": ["pg-cloudflare@1.3.0", "", {}, "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="],
+
+    "@effect/sql-pg/pg/pg-connection-string": ["pg-connection-string@2.11.0", "", {}, "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ=="],
+
+    "@effect/sql-pg/pg/pg-protocol": ["pg-protocol@1.11.0", "", {}, "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g=="],
+
+    "@effect/sql-pg/pg/pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
 
     "@electron/get/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
@@ -12048,6 +12034,12 @@
     "@tmnl/pct/vitest/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
     "@tmnl/pct/vitest/tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "@tmnl/specimendb/@effect/sql-pg/pg-connection-string": ["pg-connection-string@2.12.0", "", {}, "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ=="],
+
+    "@tmnl/specimendb/@effect/sql-pg/pg-cursor": ["pg-cursor@2.22.0", "", { "peerDependencies": { "pg": "^8" } }, "sha512-knzXLKqarTjOvb3qDSW0JiGsazmxwEKXrqHfWRte7XUsOYccQRafn3BLnQobWwInkzFJSyOej8y8cQRh2z3kGw=="],
+
+    "@tmnl/specimendb/@effect/sql-pg/pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
 
     "@tmnl/specimendb/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -13230,6 +13222,14 @@
     "@durable-streams/server-conformance-tests/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "@durable-streams/server-conformance-tests/vitest/@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "@effect/sql-pg/pg/pg-types/postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "@effect/sql-pg/pg/pg-types/postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "@effect/sql-pg/pg/pg-types/postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "@effect/sql-pg/pg/pg-types/postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "@gbg/cms/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 

--- a/packages/specimendb/README.md
+++ b/packages/specimendb/README.md
@@ -57,8 +57,8 @@ Static page in [`capture/`](./capture/), also served at `/capture/` on the testb
 
 ## Versions
 
-Effect pin matches `@tmnl/msh`: `effect@4.0.0-beta.93`. Persistence is `@effect/sql-pg@4.0.0-beta.93` (peers that pin) against ordinary Postgres. Do not take `@effect/sql-pglite`. Do not add DuckDB. The repo talks `SqlClient`. L1 is Postgres. There is no second catalog.
+Effect pin matches `@tmnl/msh`: `effect@4.0.0-beta.93`. Persistence is `@effect/sql-pg@4.0.0-beta.93` (peers that pin). Do not take `@effect/sql-pglite`. Do not add DuckDB. The repo talks `SqlClient`. L1 is Postgres. There is no second catalog.
 
 Activity log tables (`lab_activities`, `lab_used`, `lab_generated`) live in that same catalog. They are append-only.
 
-Catalog tests talk to Postgres (`SPECIMENDB_PG_URL`, default `postgres://specimendb:specimendb@127.0.0.1:5432/specimendb`). A `postgres:16` compose file is at [`docker/docker-compose.yml`](./docker/docker-compose.yml) (host port 5434). The Vite testbed stays in-memory. Capture still does not talk to the database.
+Catalog tests talk to Postgres (`SPECIMENDB_PG_URL`, default `postgres://specimendb:specimendb@127.0.0.1:5433/specimendb`). Compose is a copy of the tmnl iiot lite rig at [`docker/docker-compose.yml`](./docker/docker-compose.yml) (Timescale HA + AGE, host port 5433, data dir `/home/postgres/pgdata/data`). The Vite testbed stays in-memory. Capture still does not talk to the database.

--- a/packages/specimendb/README.md
+++ b/packages/specimendb/README.md
@@ -60,3 +60,5 @@ Static page in [`capture/`](./capture/), also served at `/capture/` on the testb
 Effect pin matches `@tmnl/msh`: `effect@4.0.0-beta.93`. Persistence is `@effect/sql-pg@4.0.0-beta.93` (peers that pin) against ordinary Postgres. Do not take `@effect/sql-pglite`. Do not add DuckDB. The repo talks `SqlClient`. L1 is Postgres. There is no second catalog.
 
 Activity log tables (`lab_activities`, `lab_used`, `lab_generated`) live in that same catalog. They are append-only.
+
+Catalog tests talk to Postgres (`SPECIMENDB_PG_URL`, default `postgres://specimendb:specimendb@127.0.0.1:5432/specimendb`). A `postgres:16` compose file is at [`docker/docker-compose.yml`](./docker/docker-compose.yml) (host port 5434). The Vite testbed stays in-memory. Capture still does not talk to the database.

--- a/packages/specimendb/README.md
+++ b/packages/specimendb/README.md
@@ -12,6 +12,8 @@ Understanding is attaching components later. A JPEG or HEIC with no GPS still fi
 | `Get` | Fetch one specimen by `SpecimenId`. |
 | `List` | List specimens. No required filters. |
 | `Promote` | Write Status one step: `raw → filed → working → dead`. Dead stays dead. Same Specimen type. |
+| `AppendActivity` | Append a `kind=activity` LabEntity (W7 required). Same PGlite. No UPDATE of who/when. Corrections are a new ref that `supersedes`. |
+| `GetByRef` | Activities where the ref is the activity, a used entity, a generated entity, or the row being superseded. Empty list if none. |
 
 ## Components
 
@@ -56,3 +58,5 @@ Static page in [`capture/`](./capture/), also served at `/capture/` on the testb
 ## Versions
 
 Effect pin matches `@tmnl/msh`: `effect@4.0.0-beta.93`. Persistence is `@effect/sql-pglite@4.0.0-beta.93` (peers that pin) plus `@electric-sql/pglite@0.4.5`. Do not take `@effect/sql-pglite@4.0.0-beta.107`; it peers `effect@^4.0.0-beta.107` and would fight msh. The repo talks `SqlClient`. L1 is PGlite. There is no DuckDB driver and no `@effect/sql-duckdb`.
+
+Activity log tables (`lab_activities`, `lab_used`, `lab_generated`) live in that same catalog. They are append-only. There is no second catalog.

--- a/packages/specimendb/README.md
+++ b/packages/specimendb/README.md
@@ -1,6 +1,6 @@
 # @tmnl/specimendb
 
-Experimental. ECS specimen catalog: a branded `SpecimenId` entity plus optional components, persisted in PGlite and exposed as Effect v4 `Rpc.make` / `RpcGroup` procedures.
+Experimental. ECS specimen catalog: a branded `SpecimenId` entity plus optional components, persisted in Postgres and exposed as Effect v4 `Rpc.make` / `RpcGroup` procedures.
 
 Understanding is attaching components later. A JPEG or HEIC with no GPS still files as Status `raw`. Locality is attached as `unknown` unless EXIF GPS or capture-page geo actually arrived. Sidecar JSON is always written next to the original. Taxon is never invented.
 
@@ -12,7 +12,7 @@ Understanding is attaching components later. A JPEG or HEIC with no GPS still fi
 | `Get` | Fetch one specimen by `SpecimenId`. |
 | `List` | List specimens. No required filters. |
 | `Promote` | Write Status one step: `raw → filed → working → dead`. Dead stays dead. Same Specimen type. |
-| `AppendActivity` | Append a `kind=activity` LabEntity (W7 required). Same PGlite. No UPDATE of who/when. Corrections are a new ref that `supersedes`. |
+| `AppendActivity` | Append a `kind=activity` LabEntity (W7 required). Same Postgres. No UPDATE of who/when. Corrections are a new ref that `supersedes`. |
 | `GetByRef` | Activities where the ref is the activity, a used entity, a generated entity, or the row being superseded. Empty list if none. |
 
 ## Components
@@ -57,6 +57,6 @@ Static page in [`capture/`](./capture/), also served at `/capture/` on the testb
 
 ## Versions
 
-Effect pin matches `@tmnl/msh`: `effect@4.0.0-beta.93`. Persistence is `@effect/sql-pglite@4.0.0-beta.93` (peers that pin) plus `@electric-sql/pglite@0.4.5`. Do not take `@effect/sql-pglite@4.0.0-beta.107`; it peers `effect@^4.0.0-beta.107` and would fight msh. The repo talks `SqlClient`. L1 is PGlite. There is no DuckDB driver and no `@effect/sql-duckdb`.
+Effect pin matches `@tmnl/msh`: `effect@4.0.0-beta.93`. Persistence is `@effect/sql-pg@4.0.0-beta.93` (peers that pin) against ordinary Postgres. Do not take `@effect/sql-pglite`. Do not add DuckDB. The repo talks `SqlClient`. L1 is Postgres. There is no second catalog.
 
-Activity log tables (`lab_activities`, `lab_used`, `lab_generated`) live in that same catalog. They are append-only. There is no second catalog.
+Activity log tables (`lab_activities`, `lab_used`, `lab_generated`) live in that same catalog. They are append-only.

--- a/packages/specimendb/docker/docker-compose.yml
+++ b/packages/specimendb/docker/docker-compose.yml
@@ -1,0 +1,28 @@
+# Ordinary Postgres 16 for the specimen catalog. Not PGlite. Not DuckDB.
+# Timescale/AGE copy of the iiot image is #91, not this log cut.
+#
+#   docker compose -f packages/specimendb/docker/docker-compose.yml up -d
+#   SPECIMENDB_PG_URL=postgres://specimendb:specimendb@127.0.0.1:5434/specimendb
+#
+# Connection: postgres://specimendb:specimendb@localhost:5434/specimendb
+
+services:
+  specimendb-pg:
+    image: postgres:16
+    container_name: specimendb_pg
+    ports:
+      - '5434:5432'
+    environment:
+      POSTGRES_USER: specimendb
+      POSTGRES_PASSWORD: specimendb
+      POSTGRES_DB: specimendb
+    volumes:
+      - specimendb-pg-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U specimendb -d specimendb']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  specimendb-pg-data:

--- a/packages/specimendb/docker/docker-compose.yml
+++ b/packages/specimendb/docker/docker-compose.yml
@@ -1,28 +1,59 @@
-# Ordinary Postgres 16 for the specimen catalog. Not PGlite. Not DuckDB.
-# Timescale/AGE copy of the iiot image is #91, not this log cut.
+# =============================================================================
+# specimendb catalog — copied from packages/tmnl/docker/docker-compose.iiot.yml
+# TimescaleDB HA + Apache AGE lite image. Not PGlite. Not DuckDB. Not postgres:16.
 #
+# Usage:
 #   docker compose -f packages/specimendb/docker/docker-compose.yml up -d
-#   SPECIMENDB_PG_URL=postgres://specimendb:specimendb@127.0.0.1:5434/specimendb
+#   docker compose -f packages/specimendb/docker/docker-compose.yml logs -f
+#   docker compose -f packages/specimendb/docker/docker-compose.yml down
+#   docker compose -f packages/specimendb/docker/docker-compose.yml down -v
 #
-# Connection: postgres://specimendb:specimendb@localhost:5434/specimendb
+# Connection (iiot URL shape, renamed):
+#   postgres://specimendb:specimendb@localhost:5433/specimendb
+#   Or: docker exec -it specimendb_pg psql -U specimendb -d specimendb
+#
+# Override tests with SPECIMENDB_PG_URL if the listener is elsewhere.
+# =============================================================================
 
 services:
   specimendb-pg:
-    image: postgres:16
+    build:
+      context: ./iiot-db
+      dockerfile: Dockerfile.lite
     container_name: specimendb_pg
     ports:
-      - '5434:5432'
+      - '5433:5432'
+    volumes:
+      - specimendb-pg-data:/home/postgres/pgdata/data
     environment:
       POSTGRES_USER: specimendb
       POSTGRES_PASSWORD: specimendb
       POSTGRES_DB: specimendb
-    volumes:
-      - specimendb-pg-data:/var/lib/postgresql/data
+      TIMESCALEDB_TELEMETRY: 'off'
+    command:
+      - postgres
+      - -c
+      - wal_level=logical
+      - -c
+      - max_replication_slots=10
+      - -c
+      - max_wal_senders=10
+      - -c
+      - shared_preload_libraries=timescaledb,age
+    restart: unless-stopped
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U specimendb -d specimendb']
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      retries: 10
+      retries: 5
+      start_period: 60s
+    networks:
+      - specimendb
+
+networks:
+  specimendb:
+    driver: bridge
 
 volumes:
   specimendb-pg-data:
+    driver: local

--- a/packages/specimendb/docker/iiot-db/Dockerfile.lite
+++ b/packages/specimendb/docker/iiot-db/Dockerfile.lite
@@ -1,0 +1,100 @@
+# =============================================================================
+# specimendb catalog — PostgreSQL 16 with TimescaleDB + Apache AGE (LITE)
+#
+# Copied from packages/tmnl/docker/iiot-db/Dockerfile.lite.
+# Renamed user/db. Catalog DDL is the Effect migrator, not this image.
+#
+# This LITE image builds on TimescaleDB HA and adds:
+# - Apache AGE (in the image; catalog v1 still queries SQL tables, not Cypher)
+#
+# EXCLUDES pg_lake (DuckDB-powered Iceberg analytics). Do not add DuckDB.
+# Do not copy the full iiot Dockerfile or start-pgduck.sh.
+#
+# SCHEMA MANAGEMENT:
+#   Schema is managed by Effect SQL Migrator, NOT this image.
+#   The init.sql just bootstraps the user - run Migrator separately.
+#   See: packages/specimendb/src/repos/pg.ts
+#
+# Build: docker build -f Dockerfile.lite -t specimendb-pg:lite .
+# =============================================================================
+
+FROM timescale/timescaledb-ha:pg16-ts2.17
+
+# Switch to root for package installation
+USER root
+
+# Build arguments
+ARG AGE_VERSION=1.5.0
+ARG PG_CONFIG=/usr/lib/postgresql/16/bin/pg_config
+
+# =============================================================================
+# Install build dependencies for Apache AGE only
+# =============================================================================
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Basic build tools
+    build-essential \
+    git \
+    # PostgreSQL dev
+    postgresql-server-dev-16 \
+    # AGE dependencies
+    libreadline-dev \
+    zlib1g-dev \
+    flex \
+    bison \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+
+# =============================================================================
+# Build and install Apache AGE
+# =============================================================================
+
+RUN git clone --branch release/PG16/${AGE_VERSION} --depth 1 \
+    https://github.com/apache/age.git age-src \
+    && cd age-src \
+    && make USE_PGXS=1 PG_CONFIG=${PG_CONFIG} install \
+    && cd / && rm -rf /tmp/age-src
+
+# =============================================================================
+# Clean up build dependencies (keep runtime libs)
+# =============================================================================
+
+RUN apt-get remove -y \
+    build-essential \
+    git \
+    flex \
+    bison \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# =============================================================================
+# Copy bootstrap script
+# =============================================================================
+
+# init.sql is minimal - just creates user context
+# All schema DDL is managed by Effect SQL Migrator
+COPY init.sql /docker-entrypoint-initdb.d/10-specimendb-bootstrap.sql
+
+# Switch back to postgres user
+USER postgres
+
+# Set default environment
+ENV POSTGRES_USER=specimendb
+ENV POSTGRES_PASSWORD=specimendb
+ENV POSTGRES_DB=specimendb
+ENV TIMESCALEDB_TELEMETRY=off
+
+# Expose PostgreSQL port
+EXPOSE 5432
+
+# Health check
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=5 \
+    CMD pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB} || exit 1
+
+# Start postgres with extensions preloaded
+# - timescaledb: Time-series hypertables
+# - age: Apache AGE graph queries
+# NOTE: pg_extension_base (pg_lake) NOT included in lite image
+CMD ["postgres", "-c", "shared_preload_libraries=timescaledb,age"]

--- a/packages/specimendb/docker/iiot-db/init.sql
+++ b/packages/specimendb/docker/iiot-db/init.sql
@@ -1,0 +1,29 @@
+-- =============================================================================
+-- specimendb catalog bootstrap
+-- Copied from packages/tmnl/docker/iiot-db/init.sql (minimal).
+-- =============================================================================
+--
+-- This file is minimal by design.
+--
+-- SCHEMA MANAGEMENT:
+--   All schema DDL is managed by Effect SQL Migrator:
+--   - packages/specimendb/src/repos/pg.ts
+--
+-- USER SETUP:
+--   The 'specimendb' user is created by Docker's entrypoint via POSTGRES_USER.
+--   No CREATE ROLE needed here.
+--
+-- =============================================================================
+
+-- This file intentionally left minimal.
+-- All DDL is managed by Effect SQL Migrator.
+
+-- Verify the user exists (for debugging)
+DO $$
+BEGIN
+    RAISE NOTICE 'specimendb database bootstrap complete.';
+    RAISE NOTICE 'User: %', current_user;
+    RAISE NOTICE 'Database: %', current_database();
+    RAISE NOTICE '';
+    RAISE NOTICE 'Next step: Run Effect SQL Migrator to apply schema.';
+END $$;

--- a/packages/specimendb/docs/lab-provenance-stack.md
+++ b/packages/specimendb/docs/lab-provenance-stack.md
@@ -17,7 +17,7 @@ Host for this note: `packages/specimendb/docs/` because the recommended viewer h
 - Do not merge PRs 34 / 36 / 45 / 57 / 58 from this work.
 - Do not replace OCCT `HLRBRep`. SVG already in-tree on PR 58.
 - Doctor does not certify itself. Independent verifier does not generate the report it checks (PR 57 `verify_report.py`).
-- Effect / PGlite pin stays `4.0.0-beta.93`. Do not take `@effect/sql-pglite@4.0.0-beta.107`.
+- Effect pin stays `4.0.0-beta.93`. Catalog SoT is Postgres (`@effect/sql-pg`); PGlite is off the path ([#91](https://github.com/creatifcoding/gbg/issues/91)). Do not take `@effect/sql-pglite`. Do not add DuckDB.
 
 ---
 

--- a/packages/specimendb/docs/lab-provenance-stack.md
+++ b/packages/specimendb/docs/lab-provenance-stack.md
@@ -4,7 +4,7 @@ Research only. No viewer, no minted ids, no UI restyle, no merge.
 
 This note answers issue [#59](https://github.com/creatifcoding/gbg/issues/59) section 9. Requirements stay in that issue; this file picks libraries and hosts. An implementer may mint refs and show W7 **after** these calls land.
 
-Host for this note: `packages/specimendb/docs/` because the recommended viewer host is the specimendb testbed, and because PGlite / Effect `4.0.0-beta.93` already live in this package. Do not file the terrarium as a Specimen.
+Host for this note: `packages/specimendb/docs/` because the recommended viewer host is the specimendb testbed, and because Postgres / Effect `4.0.0-beta.93` already live in this package. Do not file the terrarium as a Specimen.
 
 ---
 
@@ -17,7 +17,7 @@ Host for this note: `packages/specimendb/docs/` because the recommended viewer h
 - Do not merge PRs 34 / 36 / 45 / 57 / 58 from this work.
 - Do not replace OCCT `HLRBRep`. SVG already in-tree on PR 58.
 - Doctor does not certify itself. Independent verifier does not generate the report it checks (PR 57 `verify_report.py`).
-- Effect pin stays `4.0.0-beta.93`. Catalog SoT is Postgres (`@effect/sql-pg`); PGlite is off the path ([#91](https://github.com/creatifcoding/gbg/issues/91)). Do not take `@effect/sql-pglite`. Do not add DuckDB.
+- Effect pin stays `4.0.0-beta.93`. Catalog SoT is Postgres (`@effect/sql-pg`). Do not take `@effect/sql-pglite`. Do not add DuckDB.
 
 ---
 
@@ -27,7 +27,7 @@ Host for this note: `packages/specimendb/docs/` because the recommended viewer h
 |---|---|---|
 | 1. Stable ref | **BUILD** compact `gbg:<kind>:<local>@<rev>` | Issue 59 already named the language; IANA URN registration and OpenLineage naming are the wrong grain. |
 | 2. W7 metadata | **ADOPT** PROV-DM vocabulary, **BUILD** one Effect Schema record | PROV gives entity/activity/agent; kind and honesty class stay fields, not tables. |
-| 3. Log store | **BUILD** append-only tables in the existing PGlite runtime | Same `SqlClient`, not a second catalog; Marquez / EventLog evidence is thin or a second product. |
+| 3. Log store | **BUILD** append-only tables in the existing Postgres catalog | Same `SqlClient`, not a second catalog; Marquez / EventLog evidence is thin or a second product. |
 | 4. Sheet render | **ADOPT** in-tree SVG/PNG; **BUILD** click overlay later | PR 58 already projects HLR; balloons have labels, not `data-ref`. |
 | 5. Viewer host | **ADOPT** specimendb testbed (`bun run testbed`) | Lab app already exists at `https://localhost:4177`; tmnl carries VANTA/testbed chrome this brief forbids restyling. |
 | 6. Doctor bridge | **ADOPT** PR 57 `doctor-report.v1.json` | Reuse the report schema; wrap it as a `report` entity. Do not fork. |
@@ -136,17 +136,17 @@ tmnl `src/lib/ecs/schemas/provenance.ts` is GEOINT ingest audit (`RawAuditRef`, 
 
 ## 3. Append-only log store
 
-**Invariant.** Provenance is append-only. Corrections are new activities that supersede. Query by entity ref (subject or product), agent, issue, SHA, time. PGlite is already specimen SoT. Do not casually add a second catalog.
+**Invariant.** Provenance is append-only. Corrections are new activities that supersede. Query by entity ref (subject or product), agent, issue, SHA, time. Postgres is already specimen SoT. Do not casually add a second catalog.
 
 ### What is already pinned
 
-- `@effect/sql-pglite@4.0.0-beta.93`, `effect@4.0.0-beta.93`, `@electric-sql/pglite@0.4.5` (`packages/specimendb/package.json`, `README.md`, `test/strict-v4.test.ts`).
-- L1: `PgliteClient` + `PgliteMigrator` (`src/repos/pglite.ts`). Tables today: `specimens`, `components`. Migrator table: `specimendb_migrations`.
-- Repo talks `SqlClient`. SpecimenRepo is the only catalog writer. Testbed SPA is **in-memory** (`testbed/memory-client.ts`); PGlite is the persistence pin, not the Vite process.
+- `@effect/sql-pg@4.0.0-beta.93`, `effect@4.0.0-beta.93` (`packages/specimendb/package.json`, `README.md`, `test/strict-v4.test.ts`).
+- L1: `PgClient` + migrator (`src/repos/pg.ts`). Tables today: `specimens`, `components`, plus activity log tables. Migrator table: `specimendb_migrations`.
+- Repo talks `SqlClient`. SpecimenRepo is the only specimen writer. Testbed SPA is **in-memory** (`testbed/memory-client.ts`); Postgres is the persistence pin, not the Vite process.
 
 ### Options
 
-1. **Same PGlite, new tables** (`lab_entities`, `lab_activities`, junction for used/generated). Not rows in `specimens`. Optional `derived-from` / `depicts` link to a `SpecimenId` when a sheet is actually about a filed specimen (issue 59 C6).
+1. **Same Postgres, new tables** (`lab_entities`, `lab_activities`, junction for used/generated). Not rows in `specimens`. Optional `derived-from` / `depicts` link to a `SpecimenId` when a sheet is actually about a filed specimen (issue 59 C6).
 2. **Marquez** ([marquezproject.ai](https://marquezproject.ai/)): OpenLineage HTTP backend, jobs/datasets/runs, its own UI. A second catalog product.
 3. **Git-committed JSON** already on disk: PR 57 `doctor-report.json` under the isolation root; PR 58 `projections/manifest.json` + `SHEETS.md` + `CAD01-STEP-PROVENANCE.md`. Good **seed**, not a query API.
 4. **Effect EventLog** (`@effect/experimental/EventLog`) as used in tmnl IIoT schemas. Not a dependency of specimendb. No evidence it speaks `@effect/sql-pglite@4.0.0-beta.93`.
@@ -155,7 +155,7 @@ tmnl `src/lib/ecs/schemas/provenance.ts` is GEOINT ingest audit (`RawAuditRef`, 
 
 | Own | Inherit |
 |---|---|
-| Activity append API; indexes on ref / agent / issue / SHA; never UPDATE who/when | PGlite `SqlClient` + migrator; PR 57/58 JSON as ingest seeds |
+| Activity append API; indexes on ref / agent / issue / SHA; never UPDATE who/when | Postgres `SqlClient` + migrator; PR 57/58 JSON as ingest seeds |
 
 Promote on specimens today **updates** the Status component in place (`SpecimenRepo.promote`). That is catalog status, not provenance. Do not copy that pattern into the activity log.
 
@@ -163,7 +163,7 @@ Promote on specimens today **updates** the Status component in place (`SpecimenR
 
 Putting sheets into `specimens` creates a second ontology. Standing up Marquez creates a second catalog. EventLog without a pin fight or a dual-write story.
 
-### Call: **BUILD** append-only tables in the existing PGlite runtime
+### Call: **BUILD** append-only tables in the existing Postgres catalog
 
 Same process, different tables, different repo. Ingest seeds from git JSON; do not make git the query SoT. **DEFER** Marquez (second catalog). **DEFER** EventLog until someone proves it on this Effect pin.
 

--- a/packages/specimendb/package.json
+++ b/packages/specimendb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tmnl/specimendb",
   "version": "0.0.1",
-  "description": "ECS specimen catalog — Intake/Get/List/Promote over PGlite (Effect v4)",
+  "description": "ECS specimen catalog — Intake/Get/List/Promote over Postgres (Effect v4)",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -43,10 +43,10 @@
     "prepublishOnly": "bun run clean && bun run build"
   },
   "dependencies": {
-    "@effect/sql-pglite": "4.0.0-beta.93",
-    "@electric-sql/pglite": "0.4.5",
+    "@effect/sql-pg": "4.0.0-beta.93",
     "@tmnl/stx": "workspace:*",
-    "effect": "4.0.0-beta.93"
+    "effect": "4.0.0-beta.93",
+    "pg": "^8.23.0"
   },
   "peerDependencies": {
     "react": ">=18.0.0"
@@ -75,7 +75,7 @@
     "effect-v4",
     "ecs",
     "specimen",
-    "pglite",
+    "postgres",
     "catalog"
   ]
 }

--- a/packages/specimendb/src/index.ts
+++ b/packages/specimendb/src/index.ts
@@ -9,5 +9,10 @@ export * from './models/index.js';
 export * from './media/index.js';
 export * from './repos/index.js';
 export * from './rpc/index.js';
-export { CatalogPersistenceLive, SpecimenCatalogLive, layer } from './layers.js';
+export {
+  CatalogPersistenceLive,
+  SpecimenCatalogLive,
+  ActivityLogLive,
+  layer,
+} from './layers.js';
 export { localityView, specimenSurface, type LocalityView } from './surface.js';

--- a/packages/specimendb/src/layers.ts
+++ b/packages/specimendb/src/layers.ts
@@ -6,7 +6,7 @@
 
 import * as Layer from 'effect/Layer';
 import { AssetStore } from './media/store.js';
-import { CatalogSqlLive } from './repos/pglite.js';
+import { CatalogSqlLive } from './repos/pg.js';
 import { ActivityRepo } from './repos/ActivityRepo.js';
 import { SpecimenRepo } from './repos/SpecimenRepo.js';
 import { ActivityRpcsLive } from './rpc/ActivityRpcs.js';
@@ -25,7 +25,7 @@ export const ActivityLogLive = ActivityRpcsLive.pipe(
 );
 
 /**
- * One PGlite process: specimen RPCs + append-only activity log.
+ * One Postgres process: specimen RPCs + append-only activity log.
  * CatalogSqlLive is provided once so the log is not a second catalog.
  */
 export const layer = (config: CatalogConfig) =>

--- a/packages/specimendb/src/layers.ts
+++ b/packages/specimendb/src/layers.ts
@@ -7,7 +7,9 @@
 import * as Layer from 'effect/Layer';
 import { AssetStore } from './media/store.js';
 import { CatalogSqlLive } from './repos/pglite.js';
+import { ActivityRepo } from './repos/ActivityRepo.js';
 import { SpecimenRepo } from './repos/SpecimenRepo.js';
+import { ActivityRpcsLive } from './rpc/ActivityRpcs.js';
 import { SpecimenRpcsLive } from './rpc/SpecimenRpcs.js';
 import { CatalogConfigLayer, type CatalogConfig } from './schemas/config.js';
 
@@ -18,5 +20,19 @@ export const SpecimenCatalogLive = SpecimenRpcsLive.pipe(
   Layer.provide(CatalogPersistenceLive),
 );
 
+export const ActivityLogLive = ActivityRpcsLive.pipe(
+  Layer.provide(ActivityRepo.layer),
+);
+
+/**
+ * One PGlite process: specimen RPCs + append-only activity log.
+ * CatalogSqlLive is provided once so the log is not a second catalog.
+ */
 export const layer = (config: CatalogConfig) =>
-  SpecimenCatalogLive.pipe(Layer.provide(CatalogConfigLayer(config)));
+  Layer.mergeAll(
+    SpecimenRpcsLive.pipe(Layer.provide(SpecimenRepo.layer)),
+    ActivityRpcsLive.pipe(Layer.provide(ActivityRepo.layer)),
+  ).pipe(
+    Layer.provideMerge(CatalogPersistenceLive),
+    Layer.provide(CatalogConfigLayer(config)),
+  );

--- a/packages/specimendb/src/models/LabEntityModel.ts
+++ b/packages/specimendb/src/models/LabEntityModel.ts
@@ -1,8 +1,9 @@
 /**
  * Persistence-shaped lab entity. Same fields as the provenance record.
  *
- * No `lab_entities` table in this cut (#61). Do not call SqlModel.makeRepository
- * here. Pin stays `@effect/sql-pglite` / `effect` 4.0.0-beta.93.
+ * Activity log tables (`lab_activities` / `lab_used` / `lab_generated`) store
+ * the JSON payload; this model is the row shape, not a SqlModel repository.
+ * Pin stays `@effect/sql-pglite` / `effect` 4.0.0-beta.93.
  *
  * @module @tmnl/specimendb/models/LabEntityModel
  */
@@ -41,6 +42,7 @@ export class LabEntityModel extends Model.Class<LabEntityModel>('LabEntityModel'
   where: Schema.optional(Schema.String),
   why: Schema.optional(Schema.String),
   how: Schema.optional(Schema.String),
+  supersedes: Schema.optional(EntityRef),
   specimenId: Schema.optional(SpecimenId),
   payloadSchemaId: Schema.optional(Schema.String),
   payload: Schema.optional(Schema.Unknown),

--- a/packages/specimendb/src/models/LabEntityModel.ts
+++ b/packages/specimendb/src/models/LabEntityModel.ts
@@ -3,7 +3,7 @@
  *
  * Activity log tables (`lab_activities` / `lab_used` / `lab_generated`) store
  * the JSON payload; this model is the row shape, not a SqlModel repository.
- * Pin stays `@effect/sql-pglite` / `effect` 4.0.0-beta.93.
+ * Pin stays `@effect/sql-pg` / `effect` 4.0.0-beta.93.
  *
  * @module @tmnl/specimendb/models/LabEntityModel
  */

--- a/packages/specimendb/src/models/index.ts
+++ b/packages/specimendb/src/models/index.ts
@@ -1,7 +1,8 @@
 /**
  * Persistence models. Schema is the source of truth; the repo stores these.
  *
- * LabEntityModel is the provenance row shape. No lab_entities table yet (#61).
+ * LabEntityModel is the provenance row shape. The activity log stores JSONB
+ * plus used/generated junctions — not a `lab_entities` table.
  *
  * @module @tmnl/specimendb/models
  */

--- a/packages/specimendb/src/repos/ActivityRepo.ts
+++ b/packages/specimendb/src/repos/ActivityRepo.ts
@@ -1,0 +1,204 @@
+/**
+ * ActivityRepo — append-only provenance log.
+ *
+ * Tables: `lab_activities`, `lab_used`, `lab_generated`. Same PGlite as
+ * specimens. Corrections are new rows; who/when are never updated.
+ *
+ * @module @tmnl/specimendb/repos/ActivityRepo
+ */
+
+import * as Context from 'effect/Context';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import * as Schema from 'effect/Schema';
+import { SqlClient } from 'effect/unstable/sql/SqlClient';
+import type { SqlError } from 'effect/unstable/sql/SqlError';
+import { ActivityAppendError, CatalogError } from '../schemas/errors.js';
+import { type EntityRef } from '../schemas/identifiers.js';
+import { decodeLabEntity, LabEntity } from '../schemas/provenance.js';
+
+export interface ActivityRepoShape {
+  readonly append: (
+    entity: LabEntity,
+  ) => Effect.Effect<LabEntity, CatalogError | ActivityAppendError>;
+  readonly getByRef: (
+    ref: EntityRef,
+  ) => Effect.Effect<ReadonlyArray<LabEntity>, CatalogError>;
+}
+
+const nowIso = () => new Date().toISOString();
+
+const catalogError = (operation: string) => (cause: SqlError) =>
+  new CatalogError({
+    operation,
+    message: cause.message,
+    cause,
+  });
+
+const parsePayload = (raw: unknown): unknown => {
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return raw;
+    }
+  }
+  return raw;
+};
+
+const uniqueRefs = (refs: ReadonlyArray<EntityRef>): ReadonlyArray<EntityRef> => {
+  const seen = new Set<string>();
+  const out: Array<EntityRef> = [];
+  for (const ref of refs) {
+    if (seen.has(ref)) continue;
+    seen.add(ref);
+    out.push(ref);
+  }
+  return out;
+};
+
+const usedOf = (entity: LabEntity): ReadonlyArray<EntityRef> =>
+  uniqueRefs(entity.what?.used ?? entity.used ?? []);
+
+const generatedOf = (entity: LabEntity): ReadonlyArray<EntityRef> =>
+  uniqueRefs(entity.what?.generated ?? entity.generated ?? []);
+
+const isUniqueViolation = (error: SqlError): boolean =>
+  /unique|duplicate key|already exists/i.test(error.message);
+
+const encodeActivity = Schema.encodeUnknownSync(LabEntity);
+
+export class ActivityRepo extends Context.Service<ActivityRepo, ActivityRepoShape>()(
+  '@tmnl/specimendb/ActivityRepo',
+) {
+  static readonly layer = Layer.effect(
+    ActivityRepo,
+    Effect.gen(function* () {
+      const sql = yield* SqlClient;
+
+      const insertUsed = (activityRef: EntityRef, refs: ReadonlyArray<EntityRef>) =>
+        Effect.gen(function* () {
+          for (const entityRef of refs) {
+            yield* sql`
+              INSERT INTO lab_used (activity_ref, entity_ref)
+              VALUES (${activityRef}, ${entityRef})
+            `.pipe(Effect.asVoid, Effect.mapError(catalogError('insertUsed')));
+          }
+        });
+
+      const insertGenerated = (activityRef: EntityRef, refs: ReadonlyArray<EntityRef>) =>
+        Effect.gen(function* () {
+          for (const entityRef of refs) {
+            yield* sql`
+              INSERT INTO lab_generated (activity_ref, entity_ref)
+              VALUES (${activityRef}, ${entityRef})
+            `.pipe(Effect.asVoid, Effect.mapError(catalogError('insertGenerated')));
+          }
+        });
+
+      const append = Effect.fn('@tmnl/specimendb/ActivityRepo.append')(function* (
+        entity: LabEntity,
+      ) {
+        if (entity.kind !== 'activity') {
+          return yield* new ActivityAppendError({
+            message: 'AppendActivity requires kind=activity',
+            ref: entity.ref,
+          });
+        }
+        if (
+          entity.who === undefined ||
+          entity.who.length === 0 ||
+          entity.what === undefined ||
+          entity.when === undefined ||
+          entity.where === undefined ||
+          entity.where.length === 0 ||
+          entity.why === undefined ||
+          entity.why.length === 0 ||
+          entity.how === undefined ||
+          entity.how.length === 0
+        ) {
+          return yield* new ActivityAppendError({
+            message: 'activity entities require W7: who, what, when, where, why, how',
+            ref: entity.ref,
+          });
+        }
+
+        const payload = JSON.stringify(encodeActivity(entity));
+        const gitSha = entity.when.gitSha ?? entity.bytes?.gitSha;
+        const supersedes = entity.supersedes;
+        const appendedAt = nowIso();
+
+        yield* sql`
+          INSERT INTO lab_activities (
+            ref, payload, started_at, git_sha, where_text, why, how, who, supersedes, appended_at
+          ) VALUES (
+            ${entity.ref},
+            ${payload}::jsonb,
+            ${entity.when.startedAt},
+            ${gitSha ?? null},
+            ${entity.where},
+            ${entity.why},
+            ${entity.how},
+            ${JSON.stringify(entity.who)}::jsonb,
+            ${supersedes ?? null},
+            ${appendedAt}
+          )
+        `.pipe(
+          Effect.asVoid,
+          Effect.mapError((cause) => {
+            if (isUniqueViolation(cause)) {
+              return new ActivityAppendError({
+                message: 'activity ref already exists; corrections must append a new ref',
+                ref: entity.ref,
+                cause,
+              });
+            }
+            return catalogError('appendActivity')(cause);
+          }),
+        );
+
+        yield* insertUsed(entity.ref, usedOf(entity));
+        yield* insertGenerated(entity.ref, generatedOf(entity));
+
+        return entity;
+      });
+
+      const getByRef = Effect.fn('@tmnl/specimendb/ActivityRepo.getByRef')(function* (
+        ref: EntityRef,
+      ) {
+        const rows = yield* sql<{ payload: unknown }>`
+          SELECT a.payload
+          FROM lab_activities a
+          WHERE a.ref = ${ref}
+             OR a.supersedes = ${ref}
+             OR EXISTS (
+               SELECT 1 FROM lab_used u
+               WHERE u.activity_ref = a.ref AND u.entity_ref = ${ref}
+             )
+             OR EXISTS (
+               SELECT 1 FROM lab_generated g
+               WHERE g.activity_ref = a.ref AND g.entity_ref = ${ref}
+             )
+          ORDER BY a.appended_seq ASC
+        `.pipe(Effect.mapError(catalogError('getByRef')));
+
+        const activities: Array<LabEntity> = [];
+        for (const row of rows) {
+          const decoded = yield* Effect.try({
+            try: () => decodeLabEntity(parsePayload(row.payload)),
+            catch: (cause) =>
+              new CatalogError({
+                operation: 'decodeActivity',
+                message: 'Failed to decode stored activity',
+                cause,
+              }),
+          });
+          activities.push(decoded);
+        }
+        return activities;
+      });
+
+      return ActivityRepo.of({ append, getByRef });
+    }),
+  );
+}

--- a/packages/specimendb/src/repos/ActivityRepo.ts
+++ b/packages/specimendb/src/repos/ActivityRepo.ts
@@ -1,7 +1,7 @@
 /**
  * ActivityRepo — append-only provenance log.
  *
- * Tables: `lab_activities`, `lab_used`, `lab_generated`. Same PGlite as
+ * Tables: `lab_activities`, `lab_used`, `lab_generated`. Same Postgres as
  * specimens. Corrections are new rows; who/when are never updated.
  *
  * @module @tmnl/specimendb/repos/ActivityRepo

--- a/packages/specimendb/src/repos/ActivityRepo.ts
+++ b/packages/specimendb/src/repos/ActivityRepo.ts
@@ -12,7 +12,7 @@ import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as Schema from 'effect/Schema';
 import { SqlClient } from 'effect/unstable/sql/SqlClient';
-import type { SqlError } from 'effect/unstable/sql/SqlError';
+import { SqlError } from 'effect/unstable/sql/SqlError';
 import { ActivityAppendError, CatalogError } from '../schemas/errors.js';
 import { type EntityRef } from '../schemas/identifiers.js';
 import { decodeLabEntity, LabEntity } from '../schemas/provenance.js';
@@ -64,6 +64,7 @@ const generatedOf = (entity: LabEntity): ReadonlyArray<EntityRef> =>
   uniqueRefs(entity.what?.generated ?? entity.generated ?? []);
 
 const isUniqueViolation = (error: SqlError): boolean =>
+  error.reason._tag === 'UniqueViolation' ||
   /unique|duplicate key|already exists/i.test(error.message);
 
 const encodeActivity = Schema.encodeUnknownSync(LabEntity);

--- a/packages/specimendb/src/repos/SpecimenRepo.ts
+++ b/packages/specimendb/src/repos/SpecimenRepo.ts
@@ -1,7 +1,7 @@
 /**
  * SpecimenRepo — ECS persistence: entity row + attached components.
  *
- * Talks `SqlClient`. L1 is PGlite (`@effect/sql-pglite`).
+ * Talks `SqlClient`. L1 is Postgres (`@effect/sql-pg`).
  *
  * @module @tmnl/specimendb/repos/SpecimenRepo
  */

--- a/packages/specimendb/src/repos/index.ts
+++ b/packages/specimendb/src/repos/index.ts
@@ -1,2 +1,3 @@
 export { CatalogSqlLive, CatalogMigratorLive, PgliteFromConfig } from './pglite.js';
 export { SpecimenRepo, type SpecimenRepoShape } from './SpecimenRepo.js';
+export { ActivityRepo, type ActivityRepoShape } from './ActivityRepo.js';

--- a/packages/specimendb/src/repos/index.ts
+++ b/packages/specimendb/src/repos/index.ts
@@ -1,3 +1,3 @@
-export { CatalogSqlLive, CatalogMigratorLive, PgliteFromConfig } from './pglite.js';
+export { CatalogSqlLive, CatalogMigratorLive, PgFromConfig } from './pg.js';
 export { SpecimenRepo, type SpecimenRepoShape } from './SpecimenRepo.js';
 export { ActivityRepo, type ActivityRepoShape } from './ActivityRepo.js';

--- a/packages/specimendb/src/repos/pg.ts
+++ b/packages/specimendb/src/repos/pg.ts
@@ -1,14 +1,17 @@
 /**
- * PGlite L1 — official `@effect/sql-pglite` client + migrator.
+ * Postgres L1 — `@effect/sql-pg` client + migrator.
  *
  * Provides `SqlClient`. SpecimenRepo and ActivityRepo talk that tag.
+ * Same pin as effect: 4.0.0-beta.93. Not PGlite. Not DuckDB.
  *
- * @module @tmnl/specimendb/repos/pglite
+ * @module @tmnl/specimendb/repos/pg
  */
 
-import { PgliteClient, PgliteMigrator } from '@effect/sql-pglite';
+import { PgClient } from '@effect/sql-pg';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
+import * as Redacted from 'effect/Redacted';
+import * as Migrator from 'effect/unstable/sql/Migrator';
 import { SqlClient } from 'effect/unstable/sql/SqlClient';
 import { CatalogConfigTag } from '../schemas/config.js';
 
@@ -120,16 +123,18 @@ const migrations = {
   }),
 } as const;
 
-export const PgliteFromConfig = Layer.unwrap(
+export const PgFromConfig = Layer.unwrap(
   Effect.gen(function* () {
     const config = yield* CatalogConfigTag;
-    return PgliteClient.layer({ dataDir: config.dataDir });
+    return PgClient.layer({ url: Redacted.make(config.url) });
   }),
 );
 
-export const CatalogMigratorLive = PgliteMigrator.layer({
-  loader: PgliteMigrator.fromRecord(migrations),
-  table: 'specimendb_migrations',
-});
+export const CatalogMigratorLive = Layer.effectDiscard(
+  Migrator.make({})({
+    loader: Migrator.fromRecord(migrations),
+    table: 'specimendb_migrations',
+  }),
+);
 
-export const CatalogSqlLive = CatalogMigratorLive.pipe(Layer.provideMerge(PgliteFromConfig));
+export const CatalogSqlLive = CatalogMigratorLive.pipe(Layer.provideMerge(PgFromConfig));

--- a/packages/specimendb/src/repos/pglite.ts
+++ b/packages/specimendb/src/repos/pglite.ts
@@ -1,7 +1,7 @@
 /**
  * PGlite L1 — official `@effect/sql-pglite` client + migrator.
  *
- * Provides `SqlClient`. SpecimenRepo talks that tag.
+ * Provides `SqlClient`. SpecimenRepo and ActivityRepo talk that tag.
  *
  * @module @tmnl/specimendb/repos/pglite
  */
@@ -36,6 +36,87 @@ const migrations = {
     yield* sql.unsafe(
       `CREATE INDEX IF NOT EXISTS idx_components_specimen_kind ON components(specimen_id, kind)`,
     );
+  }),
+  '0002_lab_activities': Effect.gen(function* () {
+    const sql = yield* SqlClient;
+    yield* sql.unsafe(`
+      CREATE TABLE IF NOT EXISTS lab_activities (
+        ref TEXT PRIMARY KEY,
+        payload JSONB NOT NULL,
+        started_at TEXT NOT NULL,
+        git_sha TEXT,
+        where_text TEXT NOT NULL,
+        why TEXT NOT NULL,
+        how TEXT NOT NULL,
+        who JSONB NOT NULL,
+        supersedes TEXT REFERENCES lab_activities(ref),
+        appended_at TEXT NOT NULL,
+        appended_seq BIGSERIAL NOT NULL
+      )
+    `);
+    yield* sql.unsafe(`
+      CREATE TABLE IF NOT EXISTS lab_used (
+        activity_ref TEXT NOT NULL REFERENCES lab_activities(ref),
+        entity_ref TEXT NOT NULL,
+        PRIMARY KEY (activity_ref, entity_ref)
+      )
+    `);
+    yield* sql.unsafe(`
+      CREATE TABLE IF NOT EXISTS lab_generated (
+        activity_ref TEXT NOT NULL REFERENCES lab_activities(ref),
+        entity_ref TEXT NOT NULL,
+        PRIMARY KEY (activity_ref, entity_ref)
+      )
+    `);
+    yield* sql.unsafe(
+      `CREATE INDEX IF NOT EXISTS idx_lab_used_entity ON lab_used(entity_ref)`,
+    );
+    yield* sql.unsafe(
+      `CREATE INDEX IF NOT EXISTS idx_lab_generated_entity ON lab_generated(entity_ref)`,
+    );
+    yield* sql.unsafe(
+      `CREATE INDEX IF NOT EXISTS idx_lab_activities_started_at ON lab_activities(started_at)`,
+    );
+    yield* sql.unsafe(
+      `CREATE INDEX IF NOT EXISTS idx_lab_activities_git_sha ON lab_activities(git_sha)`,
+    );
+    yield* sql.unsafe(
+      `CREATE INDEX IF NOT EXISTS idx_lab_activities_why ON lab_activities(why)`,
+    );
+    yield* sql.unsafe(
+      `CREATE INDEX IF NOT EXISTS idx_lab_activities_supersedes ON lab_activities(supersedes)`,
+    );
+    yield* sql.unsafe(`
+      CREATE OR REPLACE FUNCTION lab_append_only() RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION '% is append-only', TG_TABLE_NAME;
+      END;
+      $$ LANGUAGE plpgsql
+    `);
+    yield* sql.unsafe(`
+      DROP TRIGGER IF EXISTS lab_activities_no_update ON lab_activities
+    `);
+    yield* sql.unsafe(`
+      CREATE TRIGGER lab_activities_no_update
+        BEFORE UPDATE OR DELETE ON lab_activities
+        FOR EACH ROW EXECUTE FUNCTION lab_append_only()
+    `);
+    yield* sql.unsafe(`
+      DROP TRIGGER IF EXISTS lab_used_no_update ON lab_used
+    `);
+    yield* sql.unsafe(`
+      CREATE TRIGGER lab_used_no_update
+        BEFORE UPDATE OR DELETE ON lab_used
+        FOR EACH ROW EXECUTE FUNCTION lab_append_only()
+    `);
+    yield* sql.unsafe(`
+      DROP TRIGGER IF EXISTS lab_generated_no_update ON lab_generated
+    `);
+    yield* sql.unsafe(`
+      CREATE TRIGGER lab_generated_no_update
+        BEFORE UPDATE OR DELETE ON lab_generated
+        FOR EACH ROW EXECUTE FUNCTION lab_append_only()
+    `);
   }),
 } as const;
 

--- a/packages/specimendb/src/rpc/ActivityRpcs.ts
+++ b/packages/specimendb/src/rpc/ActivityRpcs.ts
@@ -1,5 +1,5 @@
 /**
- * Activity log RPC — AppendActivity / GetByRef. Same PGlite as the specimen catalog.
+ * Activity log RPC — AppendActivity / GetByRef. Same Postgres as the specimen catalog.
  *
  * @module @tmnl/specimendb/rpc/ActivityRpcs
  */

--- a/packages/specimendb/src/rpc/ActivityRpcs.ts
+++ b/packages/specimendb/src/rpc/ActivityRpcs.ts
@@ -1,0 +1,38 @@
+/**
+ * Activity log RPC — AppendActivity / GetByRef. Same PGlite as the specimen catalog.
+ *
+ * @module @tmnl/specimendb/rpc/ActivityRpcs
+ */
+
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import * as Schema from 'effect/Schema';
+import * as Rpc from 'effect/unstable/rpc/Rpc';
+import * as RpcGroup from 'effect/unstable/rpc/RpcGroup';
+import { ActivityAppendError, CatalogError } from '../schemas/errors.js';
+import { GetByRefPayload, LabEntity, LabEntityRecord } from '../schemas/provenance.js';
+import { ActivityRepo } from '../repos/ActivityRepo.js';
+
+export const AppendActivity = Rpc.make('AppendActivity', {
+  payload: LabEntityRecord,
+  success: LabEntity,
+  error: Schema.Union([CatalogError, ActivityAppendError]),
+});
+
+export const GetByRef = Rpc.make('GetByRef', {
+  payload: GetByRefPayload,
+  success: Schema.Array(LabEntity),
+  error: CatalogError,
+});
+
+export class ActivityRpcs extends RpcGroup.make(AppendActivity, GetByRef) {}
+
+export const ActivityRpcsLive = ActivityRpcs.toLayer(
+  Effect.gen(function* () {
+    const repo = yield* ActivityRepo;
+    return ActivityRpcs.of({
+      AppendActivity: (payload) => repo.append(payload),
+      GetByRef: (payload) => repo.getByRef(payload.ref),
+    });
+  }),
+);

--- a/packages/specimendb/src/rpc/index.ts
+++ b/packages/specimendb/src/rpc/index.ts
@@ -1,1 +1,7 @@
 export { Get, Intake, List, Promote, SpecimenRpcs, SpecimenRpcsLive } from './SpecimenRpcs.js';
+export {
+  AppendActivity,
+  GetByRef,
+  ActivityRpcs,
+  ActivityRpcsLive,
+} from './ActivityRpcs.js';

--- a/packages/specimendb/src/schemas/config.ts
+++ b/packages/specimendb/src/schemas/config.ts
@@ -9,8 +9,8 @@ import * as Layer from 'effect/Layer';
 import * as Schema from 'effect/Schema';
 
 export const CatalogConfigSchema = Schema.Struct({
-  /** PGlite data directory, or `memory://` for an in-memory catalog. */
-  dataDir: Schema.String,
+  /** Postgres connection string. Ordinary `@effect/sql-pg`, not PGlite. */
+  url: Schema.String,
   assetsRoot: Schema.String,
 });
 export type CatalogConfig = typeof CatalogConfigSchema.Type;

--- a/packages/specimendb/src/schemas/errors.ts
+++ b/packages/specimendb/src/schemas/errors.ts
@@ -5,7 +5,7 @@
  */
 
 import * as Schema from 'effect/Schema';
-import { SpecimenId } from './identifiers.js';
+import { EntityRef, SpecimenId } from './identifiers.js';
 
 export class CatalogError extends Schema.TaggedErrorClass<CatalogError>(
   '@tmnl/specimendb/CatalogError',
@@ -28,4 +28,13 @@ export class IntakeError extends Schema.TaggedErrorClass<IntakeError>(
   cause: Schema.optional(Schema.Unknown),
 }) {}
 
+export class ActivityAppendError extends Schema.TaggedErrorClass<ActivityAppendError>(
+  '@tmnl/specimendb/ActivityAppendError',
+)('ActivityAppendError', {
+  message: Schema.String,
+  ref: Schema.optional(EntityRef),
+  cause: Schema.optional(Schema.Unknown),
+}) {}
+
 export type SpecimenRpcError = CatalogError | SpecimenNotFoundError | IntakeError;
+export type ActivityRpcError = CatalogError | ActivityAppendError;

--- a/packages/specimendb/src/schemas/provenance.ts
+++ b/packages/specimendb/src/schemas/provenance.ts
@@ -9,7 +9,7 @@
  * W7 (who / what / when / where / why / how) lives on Kind=activity.
  * Honesty class lives on the generated entity. Operations are entities.
  *
- * The activity log (#61) persists these records append-only in PGlite.
+ * The activity log (#61) persists these records append-only in Postgres.
  * EVA bind is a later cut (#76 / #82).
  *
  * @module @tmnl/specimendb/schemas/provenance

--- a/packages/specimendb/src/schemas/provenance.ts
+++ b/packages/specimendb/src/schemas/provenance.ts
@@ -9,7 +9,8 @@
  * W7 (who / what / when / where / why / how) lives on Kind=activity.
  * Honesty class lives on the generated entity. Operations are entities.
  *
- * EVA bind, PGlite tables, and activity-log RPC are later cuts (#61 / #76).
+ * The activity log (#61) persists these records append-only in PGlite.
+ * EVA bind is a later cut (#76 / #82).
  *
  * @module @tmnl/specimendb/schemas/provenance
  */
@@ -140,6 +141,11 @@ const labEntityFields = {
   where: Schema.optional(Schema.String),
   why: Schema.optional(Schema.String),
   how: Schema.optional(Schema.String),
+  /**
+   * Prior activity this record supersedes. Corrections are new rows.
+   * The superseded activity is not updated.
+   */
+  supersedes: Schema.optional(EntityRef),
 
   /** Existing SpecimenId when kind=specimen. Same brand; not a fork. */
   specimenId: Schema.optional(SpecimenId),
@@ -157,9 +163,13 @@ const activityHasW7 = Schema.makeFilter<{
   readonly where?: string;
   readonly why?: string;
   readonly how?: string;
+  readonly supersedes?: EntityRef;
   readonly specimenId?: SpecimenId;
   readonly ref: EntityRef;
 }>((entity) => {
+  if (entity.supersedes !== undefined && entity.kind !== 'activity') {
+    return 'supersedes is only valid on kind=activity';
+  }
   if (entity.kind === 'activity') {
     if (
       entity.who === undefined ||
@@ -199,3 +209,9 @@ export const LabEntityRecord = LabEntity.pipe(Schema.check(activityHasW7));
 
 export const decodeLabEntity = Schema.decodeUnknownSync(LabEntityRecord);
 export const decodeDoctorReportPayload = Schema.decodeUnknownSync(DoctorReportPayload);
+
+/** Get-by-ref query: activity itself, used edge, generated edge, or supersedes. */
+export const GetByRefPayload = Schema.Struct({
+  ref: EntityRef,
+});
+export type GetByRefPayload = typeof GetByRefPayload.Type;

--- a/packages/specimendb/test/activity-log.test.ts
+++ b/packages/specimendb/test/activity-log.test.ts
@@ -10,7 +10,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import * as Effect from 'effect/Effect';
-import * as Either from 'effect/Either';
+import * as Result from 'effect/Result';
 import * as RpcTest from 'effect/unstable/rpc/RpcTest';
 import { SqlClient } from 'effect/unstable/sql/SqlClient';
 import { layer } from '../src/layers.js';
@@ -165,10 +165,10 @@ describe('AppendActivity / GetByRef', () => {
       Effect.gen(function* () {
         const client = yield* RpcTest.makeClient(ActivityRpcs);
         yield* client.AppendActivity(originalActivity());
-        const dup = yield* Effect.either(client.AppendActivity(originalActivity()));
-        expect(Either.isLeft(dup)).toBe(true);
-        if (Either.isLeft(dup)) {
-          expect(dup.left._tag).toBe('ActivityAppendError');
+        const dup = yield* Effect.result(client.AppendActivity(originalActivity()));
+        expect(Result.isFailure(dup)).toBe(true);
+        if (Result.isFailure(dup)) {
+          expect(dup.failure._tag).toBe('ActivityAppendError');
         }
       }) as Effect.Effect<unknown, unknown, never>,
     );
@@ -179,10 +179,10 @@ describe('AppendActivity / GetByRef', () => {
       Effect.gen(function* () {
         const client = yield* RpcTest.makeClient(ActivityRpcs);
         const sheet = decodeLabEntity(load('sheet-s01-pr58.json'));
-        const result = yield* Effect.either(client.AppendActivity(sheet));
-        expect(Either.isLeft(result)).toBe(true);
-        if (Either.isLeft(result)) {
-          expect(result.left._tag).toBe('ActivityAppendError');
+        const result = yield* Effect.result(client.AppendActivity(sheet));
+        expect(Result.isFailure(result)).toBe(true);
+        if (Result.isFailure(result)) {
+          expect(result.failure._tag).toBe('ActivityAppendError');
         }
       }) as Effect.Effect<unknown, unknown, never>,
     );
@@ -207,12 +207,12 @@ describe('AppendActivity / GetByRef', () => {
         const original = originalActivity();
         yield* client.AppendActivity(original);
         const sql = yield* SqlClient;
-        const update = yield* Effect.either(
+        const update = yield* Effect.result(
           sql.unsafe(`UPDATE lab_activities SET why = 'tampered'`),
         );
-        expect(Either.isLeft(update)).toBe(true);
-        const del = yield* Effect.either(sql.unsafe(`DELETE FROM lab_activities`));
-        expect(Either.isLeft(del)).toBe(true);
+        expect(Result.isFailure(update)).toBe(true);
+        const del = yield* Effect.result(sql.unsafe(`DELETE FROM lab_activities`));
+        expect(Result.isFailure(del)).toBe(true);
 
         const still = yield* client.GetByRef({ ref: original.ref });
         expect(still).toHaveLength(1);

--- a/packages/specimendb/test/activity-log.test.ts
+++ b/packages/specimendb/test/activity-log.test.ts
@@ -1,5 +1,5 @@
 /**
- * Append-only activity log (#61): AppendActivity / GetByRef over existing PGlite.
+ * Append-only activity log (#61): AppendActivity / GetByRef over Postgres.
  * Tiny fixtures only — not seed ingest (#62), not shop, not EVA.
  */
 
@@ -13,10 +13,10 @@ import * as Effect from 'effect/Effect';
 import * as Result from 'effect/Result';
 import * as RpcTest from 'effect/unstable/rpc/RpcTest';
 import { SqlClient } from 'effect/unstable/sql/SqlClient';
-import { layer } from '../src/layers.js';
 import { ActivityRpcs } from '../src/rpc/ActivityRpcs.js';
 import { decodeLabEntity } from '../src/schemas/provenance.js';
 import { trustEntityRef } from '../src/schemas/identifiers.js';
+import { runCatalog } from './catalog-pg.js';
 
 const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'provenance');
 
@@ -30,16 +30,7 @@ const correctionActivity = () =>
 const runLog = async (program: Effect.Effect<unknown, unknown, never>) => {
   const root = await mkdtemp(join(tmpdir(), 'specimendb-log-'));
   try {
-    await Effect.runPromise(
-      Effect.scoped(program).pipe(
-        Effect.provide(
-          layer({
-            dataDir: 'memory://',
-            assetsRoot: join(root, 'assets'),
-          }),
-        ),
-      ) as Effect.Effect<unknown>,
-    );
+    await runCatalog(join(root, 'assets'), program);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/specimendb/test/activity-log.test.ts
+++ b/packages/specimendb/test/activity-log.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Append-only activity log (#61): AppendActivity / GetByRef over existing PGlite.
+ * Tiny fixtures only — not seed ingest (#62), not shop, not EVA.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import * as Effect from 'effect/Effect';
+import * as Either from 'effect/Either';
+import * as RpcTest from 'effect/unstable/rpc/RpcTest';
+import { SqlClient } from 'effect/unstable/sql/SqlClient';
+import { layer } from '../src/layers.js';
+import { ActivityRpcs } from '../src/rpc/ActivityRpcs.js';
+import { decodeLabEntity } from '../src/schemas/provenance.js';
+import { trustEntityRef } from '../src/schemas/identifiers.js';
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'provenance');
+
+const load = (name: string): unknown =>
+  JSON.parse(readFileSync(join(fixturesDir, name), 'utf8')) as unknown;
+
+const originalActivity = () => decodeLabEntity(load('activity-freecad-part-occt.json'));
+const correctionActivity = () =>
+  decodeLabEntity(load('activity-freecad-part-occt-corrected.json'));
+
+const runLog = async (program: Effect.Effect<unknown, unknown, never>) => {
+  const root = await mkdtemp(join(tmpdir(), 'specimendb-log-'));
+  try {
+    await Effect.runPromise(
+      Effect.scoped(program).pipe(
+        Effect.provide(
+          layer({
+            dataDir: 'memory://',
+            assetsRoot: join(root, 'assets'),
+          }),
+        ),
+      ) as Effect.Effect<unknown>,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+};
+
+describe('AppendActivity / GetByRef', () => {
+  it('appends an activity and gets it by its ref and by generated ref', async () => {
+    await runLog(
+      Effect.gen(function* () {
+        const client = yield* RpcTest.makeClient(ActivityRpcs);
+        const activity = originalActivity();
+        const appended = yield* client.AppendActivity(activity);
+        expect(appended.ref).toBe('gbg:activity:freecad-part-occt@fe8f875a');
+        expect(appended.how).toBe('freecad-part-occt');
+        expect(appended.who?.[0]?.label).toBe('freecad-part-occt');
+        expect(appended.when?.startedAt).toBe('2026-08-20T10:05:07Z');
+
+        const byActivity = yield* client.GetByRef({
+          ref: trustEntityRef('gbg:activity:freecad-part-occt@fe8f875a'),
+        });
+        expect(byActivity).toHaveLength(1);
+        expect(byActivity[0]?.ref).toBe(activity.ref);
+        expect(byActivity[0]?.who).toEqual(activity.who);
+        expect(byActivity[0]?.when).toEqual(activity.when);
+        expect(byActivity[0]?.where).toBe('unknown');
+        expect(byActivity[0]?.why).toBe('#28');
+        expect(byActivity[0]?.how).toBe('freecad-part-occt');
+
+        const byGenerated = yield* client.GetByRef({
+          ref: trustEntityRef('gbg:step:B01@fe8f875a'),
+        });
+        expect(byGenerated).toHaveLength(1);
+        expect(byGenerated[0]?.ref).toBe(activity.ref);
+        expect(byGenerated[0]?.what?.generated).toContain('gbg:step:B01@fe8f875a');
+      }) as Effect.Effect<unknown, unknown, never>,
+    );
+  });
+
+  it('gets activities that used a ref', async () => {
+    await runLog(
+      Effect.gen(function* () {
+        const client = yield* RpcTest.makeClient(ActivityRpcs);
+        yield* client.AppendActivity(originalActivity());
+        const projector = decodeLabEntity({
+          _tag: 'LabEntity',
+          ref: 'gbg:activity:project-s01@pr58',
+          kind: 'activity',
+          label: 'project S01',
+          class: 'projected',
+          who: [
+            {
+              _tag: 'Agent',
+              agentType: 'software',
+              label: 'project_step.py',
+            },
+          ],
+          what: {
+            used: ['gbg:step:B01@fe8f875a'],
+            generated: ['gbg:sheet:S01@pr58'],
+          },
+          when: { startedAt: '2026-08-20T12:00:00Z' },
+          where: 'unknown',
+          why: '#41',
+          how: 'project_step.py → HLRBRep',
+          used: ['gbg:step:B01@fe8f875a'],
+          generated: ['gbg:sheet:S01@pr58'],
+        });
+        yield* client.AppendActivity(projector);
+
+        const byUsed = yield* client.GetByRef({
+          ref: trustEntityRef('gbg:step:B01@fe8f875a'),
+        });
+        expect(byUsed.map((row) => row.ref)).toEqual([
+          'gbg:activity:freecad-part-occt@fe8f875a',
+          'gbg:activity:project-s01@pr58',
+        ]);
+
+        const bySheet = yield* client.GetByRef({
+          ref: trustEntityRef('gbg:sheet:S01@pr58'),
+        });
+        expect(bySheet).toHaveLength(1);
+        expect(bySheet[0]?.how).toBe('project_step.py → HLRBRep');
+      }) as Effect.Effect<unknown, unknown, never>,
+    );
+  });
+
+  it('corrections append; original who/when are not rewritten', async () => {
+    await runLog(
+      Effect.gen(function* () {
+        const client = yield* RpcTest.makeClient(ActivityRpcs);
+        const original = originalActivity();
+        yield* client.AppendActivity(original);
+        yield* client.AppendActivity(correctionActivity());
+
+        const history = yield* client.GetByRef({
+          ref: trustEntityRef('gbg:activity:freecad-part-occt@fe8f875a'),
+        });
+        expect(history).toHaveLength(2);
+        expect(history[0]?.ref).toBe(original.ref);
+        expect(history[0]?.who).toEqual(original.who);
+        expect(history[0]?.when).toEqual(original.when);
+        expect(history[0]?.why).toBe('#28');
+        expect(history[1]?.ref).toBe('gbg:activity:freecad-part-occt-corrected@fe8f875a');
+        expect(history[1]?.supersedes).toBe(original.ref);
+        expect(history[1]?.who?.[0]?.label).toBe('creatifcoding');
+        expect(history[1]?.when?.startedAt).toBe('2026-08-21T01:00:00Z');
+
+        const bySolid = yield* client.GetByRef({
+          ref: trustEntityRef('gbg:step:B01@fe8f875a'),
+        });
+        expect(bySolid.map((row) => row.ref)).toEqual([
+          original.ref,
+          'gbg:activity:freecad-part-occt-corrected@fe8f875a',
+        ]);
+        expect(bySolid[0]?.who).toEqual(original.who);
+        expect(bySolid[0]?.when?.startedAt).toBe('2026-08-20T10:05:07Z');
+      }) as Effect.Effect<unknown, unknown, never>,
+    );
+  });
+
+  it('rejects a second append of the same ref', async () => {
+    await runLog(
+      Effect.gen(function* () {
+        const client = yield* RpcTest.makeClient(ActivityRpcs);
+        yield* client.AppendActivity(originalActivity());
+        const dup = yield* Effect.either(client.AppendActivity(originalActivity()));
+        expect(Either.isLeft(dup)).toBe(true);
+        if (Either.isLeft(dup)) {
+          expect(dup.left._tag).toBe('ActivityAppendError');
+        }
+      }) as Effect.Effect<unknown, unknown, never>,
+    );
+  });
+
+  it('rejects appending a non-activity entity', async () => {
+    await runLog(
+      Effect.gen(function* () {
+        const client = yield* RpcTest.makeClient(ActivityRpcs);
+        const sheet = decodeLabEntity(load('sheet-s01-pr58.json'));
+        const result = yield* Effect.either(client.AppendActivity(sheet));
+        expect(Either.isLeft(result)).toBe(true);
+        if (Either.isLeft(result)) {
+          expect(result.left._tag).toBe('ActivityAppendError');
+        }
+      }) as Effect.Effect<unknown, unknown, never>,
+    );
+  });
+
+  it('returns an empty list for an unknown ref', async () => {
+    await runLog(
+      Effect.gen(function* () {
+        const client = yield* RpcTest.makeClient(ActivityRpcs);
+        const rows = yield* client.GetByRef({
+          ref: trustEntityRef('gbg:sheet:missing@none'),
+        });
+        expect(rows).toEqual([]);
+      }) as Effect.Effect<unknown, unknown, never>,
+    );
+  });
+
+  it('rejects UPDATE of who/when on lab_activities', async () => {
+    await runLog(
+      Effect.gen(function* () {
+        const client = yield* RpcTest.makeClient(ActivityRpcs);
+        const original = originalActivity();
+        yield* client.AppendActivity(original);
+        const sql = yield* SqlClient;
+        const update = yield* Effect.either(
+          sql.unsafe(`UPDATE lab_activities SET why = 'tampered'`),
+        );
+        expect(Either.isLeft(update)).toBe(true);
+        const del = yield* Effect.either(sql.unsafe(`DELETE FROM lab_activities`));
+        expect(Either.isLeft(del)).toBe(true);
+
+        const still = yield* client.GetByRef({ ref: original.ref });
+        expect(still).toHaveLength(1);
+        expect(still[0]?.who).toEqual(original.who);
+        expect(still[0]?.when).toEqual(original.when);
+        expect(still[0]?.why).toBe('#28');
+      }) as Effect.Effect<unknown, unknown, never>,
+    );
+  });
+});

--- a/packages/specimendb/test/catalog-pg.ts
+++ b/packages/specimendb/test/catalog-pg.ts
@@ -1,6 +1,7 @@
 /**
  * Per-test Postgres catalog. Real Postgres, not PGlite, not DuckDB.
- * Default: postgres://specimendb:specimendb@127.0.0.1:5432/specimendb
+ * Default matches the copied iiot compose URL:
+ *   postgres://specimendb:specimendb@127.0.0.1:5433/specimendb
  * Override with SPECIMENDB_PG_URL.
  */
 
@@ -11,7 +12,7 @@ import { layer } from '../src/layers.js';
 
 export const catalogAdminUrl =
   process.env['SPECIMENDB_PG_URL'] ??
-  'postgres://specimendb:specimendb@127.0.0.1:5432/specimendb';
+  'postgres://specimendb:specimendb@127.0.0.1:5433/specimendb';
 
 const dbUrl = (name: string): string => {
   const url = new URL(catalogAdminUrl);

--- a/packages/specimendb/test/catalog-pg.ts
+++ b/packages/specimendb/test/catalog-pg.ts
@@ -1,0 +1,61 @@
+/**
+ * Per-test Postgres catalog. Real Postgres, not PGlite, not DuckDB.
+ * Default: postgres://specimendb:specimendb@127.0.0.1:5432/specimendb
+ * Override with SPECIMENDB_PG_URL.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { Client } from 'pg';
+import * as Effect from 'effect/Effect';
+import { layer } from '../src/layers.js';
+
+export const catalogAdminUrl =
+  process.env['SPECIMENDB_PG_URL'] ??
+  'postgres://specimendb:specimendb@127.0.0.1:5432/specimendb';
+
+const dbUrl = (name: string): string => {
+  const url = new URL(catalogAdminUrl);
+  url.pathname = `/${name}`;
+  return url.toString();
+};
+
+const ident = (name: string): string => {
+  if (!/^s_[a-f0-9]{8,32}$/.test(name)) {
+    throw new Error(`refusing to create database ${name}`);
+  }
+  return name;
+};
+
+export const runCatalog = async <A>(
+  assetsRoot: string,
+  program: Effect.Effect<A, unknown, never>,
+): Promise<A> => {
+  const name = ident(`s_${randomUUID().replaceAll('-', '').slice(0, 16)}`);
+  const admin = new Client({ connectionString: catalogAdminUrl });
+  await admin.connect();
+  try {
+    await admin.query(`CREATE DATABASE ${name}`);
+  } finally {
+    await admin.end();
+  }
+  try {
+    return await Effect.runPromise(
+      Effect.scoped(program).pipe(
+        Effect.provide(
+          layer({
+            url: dbUrl(name),
+            assetsRoot,
+          }),
+        ),
+      ) as Effect.Effect<A>,
+    );
+  } finally {
+    const drop = new Client({ connectionString: catalogAdminUrl });
+    await drop.connect();
+    try {
+      await drop.query(`DROP DATABASE IF EXISTS ${name} WITH (FORCE)`);
+    } finally {
+      await drop.end();
+    }
+  }
+};

--- a/packages/specimendb/test/evidence-eat-file.ts
+++ b/packages/specimendb/test/evidence-eat-file.ts
@@ -9,64 +9,56 @@ import { join } from 'node:path';
 import * as Effect from 'effect/Effect';
 import * as RpcTest from 'effect/unstable/rpc/RpcTest';
 import { jpegWithGps, jpegWithoutGps } from './fixtures.js';
-import { layer } from '../src/layers.js';
 import { SpecimenRpcs } from '../src/rpc/SpecimenRpcs.js';
 import { exifOf, localityOf, mediaOf, statusOf } from '../src/schemas/specimen.js';
 import { specimenSurface } from '../src/surface.js';
+import { runCatalog } from './catalog-pg.js';
 
 const root = await mkdtemp(join(tmpdir(), 'specimendb-evidence-'));
 const assetsRoot = join(root, 'assets');
 const outDir = process.env['SPECIMENDB_EVIDENCE_DIR'] ?? join(root, 'evidence');
 await mkdir(outDir, { recursive: true });
 
-const report = await Effect.runPromise(
-  Effect.scoped(
-    Effect.gen(function* () {
-      const client = yield* RpcTest.makeClient(SpecimenRpcs);
-      const noGps = yield* client.Intake({
-        bytes: jpegWithoutGps(),
-        filename: 'field.jpg',
-      });
-      const withGps = yield* client.Intake({
-        bytes: jpegWithGps(),
-        filename: 'located.jpg',
-      });
-      const got = yield* client.Get({ specimenId: noGps.specimenId });
-      const listed = yield* client.List();
-      const sidecarPath = exifOf(noGps)?.sidecarPath;
-      const sidecar = sidecarPath
-        ? JSON.parse(yield* Effect.tryPromise(() => readFile(sidecarPath, 'utf8')))
-        : null;
-      return {
-        catalogRoot: root,
-        noGps: {
-          specimenId: noGps.specimenId,
-          status: statusOf(noGps),
-          locality: localityOf(noGps),
-          surface: specimenSurface(noGps),
-          original: mediaOf(noGps)?.assetPath,
-          sidecarPath,
-          sidecar,
-          getStatus: statusOf(got),
-          getLocality: localityOf(got)?.state,
-          listed: listed.some((s) => s.id === noGps.specimenId),
-        },
-        withGps: {
-          specimenId: withGps.specimenId,
-          status: statusOf(withGps),
-          locality: localityOf(withGps),
-          surface: specimenSurface(withGps),
-        },
-      };
-    }),
-  ).pipe(
-    Effect.provide(
-      layer({
-        dataDir: 'memory://',
-        assetsRoot,
-      }),
-    ),
-  ),
+const report = await runCatalog(
+  assetsRoot,
+  Effect.gen(function* () {
+    const client = yield* RpcTest.makeClient(SpecimenRpcs);
+    const noGps = yield* client.Intake({
+      bytes: jpegWithoutGps(),
+      filename: 'field.jpg',
+    });
+    const withGps = yield* client.Intake({
+      bytes: jpegWithGps(),
+      filename: 'located.jpg',
+    });
+    const got = yield* client.Get({ specimenId: noGps.specimenId });
+    const listed = yield* client.List();
+    const sidecarPath = exifOf(noGps)?.sidecarPath;
+    const sidecar = sidecarPath
+      ? JSON.parse(yield* Effect.tryPromise(() => readFile(sidecarPath, 'utf8')))
+      : null;
+    return {
+      catalogRoot: root,
+      noGps: {
+        specimenId: noGps.specimenId,
+        status: statusOf(noGps),
+        locality: localityOf(noGps),
+        surface: specimenSurface(noGps),
+        original: mediaOf(noGps)?.assetPath,
+        sidecarPath,
+        sidecar,
+        getStatus: statusOf(got),
+        getLocality: localityOf(got)?.state,
+        listed: listed.some((s) => s.id === noGps.specimenId),
+      },
+      withGps: {
+        specimenId: withGps.specimenId,
+        status: statusOf(withGps),
+        locality: localityOf(withGps),
+        surface: specimenSurface(withGps),
+      },
+    };
+  }) as Effect.Effect<unknown, unknown, never>,
 );
 
 const jsonPath = join(outDir, 'eat-file-evidence.json');

--- a/packages/specimendb/test/fixtures/provenance/activity-freecad-part-occt-corrected.json
+++ b/packages/specimendb/test/fixtures/provenance/activity-freecad-part-occt-corrected.json
@@ -1,0 +1,41 @@
+{
+  "_tag": "LabEntity",
+  "ref": "gbg:activity:freecad-part-occt-corrected@fe8f875a",
+  "kind": "activity",
+  "label": "CAD-01 STEP export correction",
+  "class": "draft-measured",
+  "bytes": {
+    "gitSha": "fe8f875a80b37a1003f05f3a0190fbe2f0417842"
+  },
+  "who": [
+    {
+      "_tag": "Agent",
+      "agentType": "person",
+      "label": "creatifcoding",
+      "ref": "github:creatifcoding"
+    }
+  ],
+  "what": {
+    "used": [],
+    "generated": ["gbg:step:B01@fe8f875a"]
+  },
+  "when": {
+    "startedAt": "2026-08-21T01:00:00Z",
+    "gitSha": "fe8f875a80b37a1003f05f3a0190fbe2f0417842"
+  },
+  "where": "unknown",
+  "why": "#28 correction",
+  "how": "freecad-part-occt (who restated)",
+  "used": [],
+  "generated": ["gbg:step:B01@fe8f875a"],
+  "supersedes": "gbg:activity:freecad-part-occt@fe8f875a",
+  "wasDerivedFrom": ["gbg:activity:freecad-part-occt@fe8f875a"],
+  "wasAssociatedWith": [
+    {
+      "_tag": "Agent",
+      "agentType": "person",
+      "label": "creatifcoding",
+      "ref": "github:creatifcoding"
+    }
+  ]
+}

--- a/packages/specimendb/test/intake.test.ts
+++ b/packages/specimendb/test/intake.test.ts
@@ -1,5 +1,5 @@
 /**
- * Intake / Get / List over PGlite.
+ * Intake / Get / List over Postgres.
  * JPEG/HEIC without GPS file as raw, locality unknown, sidecar always written.
  */
 
@@ -13,22 +13,13 @@ import { heicWithoutGps, jpegWithGps, jpegWithoutGps } from './fixtures.js';
 import { gpsFromExif, extractExifTags } from '../src/media/exif.js';
 import { exifOf, localityOf, localityStateOf, mediaOf, nextStatus, statusOf } from '../src/schemas/specimen.js';
 import { specimenSurface } from '../src/surface.js';
-import { layer } from '../src/layers.js';
 import { SpecimenRpcs } from '../src/rpc/SpecimenRpcs.js';
+import { runCatalog as runPg } from './catalog-pg.js';
 
 const runCatalog = async (program: Effect.Effect<unknown, unknown, never>) => {
   const root = await mkdtemp(join(tmpdir(), 'specimendb-'));
   try {
-    await Effect.runPromise(
-      Effect.scoped(program).pipe(
-        Effect.provide(
-          layer({
-            dataDir: 'memory://',
-            assetsRoot: join(root, 'assets'),
-          }),
-        ),
-      ) as Effect.Effect<unknown>,
-    );
+    await runPg(join(root, 'assets'), program);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/specimendb/test/provenance.test.ts
+++ b/packages/specimendb/test/provenance.test.ts
@@ -106,6 +106,14 @@ describe('LabEntity fixtures', () => {
     expect(entity.where).toBe('unknown');
   });
 
+  it('parses a correction activity that supersedes the STEP export', () => {
+    const entity = decodeLabEntity(load('activity-freecad-part-occt-corrected.json'));
+    expect(entity.ref).toBe('gbg:activity:freecad-part-occt-corrected@fe8f875a');
+    expect(entity.supersedes).toBe('gbg:activity:freecad-part-occt@fe8f875a');
+    expect(entity.who?.[0]?.label).toBe('creatifcoding');
+    expect(entity.when?.startedAt).toBe('2026-08-21T01:00:00Z');
+  });
+
   it('wraps PR 57 doctor-report.v1.json without forking it', () => {
     const entity = decodeLabEntity(load('run-doctor-pr57.json'));
     expect(entity.ref).toBe('gbg:run:doctor:pr57-fixture');
@@ -145,6 +153,16 @@ describe('LabEntity fixtures', () => {
         kind: 'activity',
         label: 'export_carriage_step.py',
         class: 'theoretical',
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects supersedes on a non-activity', () => {
+    const sheet = load('sheet-s01-pr58.json') as Record<string, unknown>;
+    expect(
+      decodeFails({
+        ...sheet,
+        supersedes: 'gbg:activity:freecad-part-occt@fe8f875a',
       }),
     ).toBe(true);
   });

--- a/packages/specimendb/test/strict-v4.test.ts
+++ b/packages/specimendb/test/strict-v4.test.ts
@@ -44,7 +44,11 @@ describe('strict Effect v4 package guardrails', () => {
         }
         if (
           relative(packageRoot, file).startsWith('src/') &&
-          (line.includes('@duckdb/') || line.includes("from 'duckdb'") || line.includes('from "duckdb"'))
+          (line.includes('@duckdb/') ||
+            line.includes("from 'duckdb'") ||
+            line.includes('from "duckdb"') ||
+            line.includes('@effect/sql-pglite') ||
+            line.includes('@electric-sql/pglite'))
         ) {
           violations.push(`${relative(packageRoot, file)}:${index + 1}: ${line.trim()}`);
         }
@@ -61,7 +65,9 @@ describe('strict Effect v4 package guardrails', () => {
     expect(pkg.dependencies.effect).toBe('4.0.0-beta.93');
     expect(pkg.devDependencies['@effect/vitest']).toBe('4.0.0-beta.93');
     expect(pkg.dependencies.effect?.startsWith('3.')).toBe(false);
-    expect(pkg.dependencies['@effect/sql-pglite']).toBe('4.0.0-beta.93');
+    expect(pkg.dependencies['@effect/sql-pg']).toBe('4.0.0-beta.93');
+    expect(pkg.dependencies['@effect/sql-pglite']).toBeUndefined();
+    expect(pkg.dependencies['@electric-sql/pglite']).toBeUndefined();
     expect(pkg.dependencies['@duckdb/node-api']).toBeUndefined();
     expect(pkg.dependencies.duckdb).toBeUndefined();
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes nothing. Implements #61. Not #91. Catalog SoT is Postgres. Refs #59 #60. Schema already on master (PR 87).

Write-capable draft. Do not merge unless checks are green and this PR is the log (plus the driver and docker URL the log needs).

## Log

Append-only tables in the **Postgres** catalog (`@effect/sql-pg` / `effect` `4.0.0-beta.93`). Not PGlite. Not DuckDB. Not a second catalog. Not `4.0.0-beta.107`.

- Driver: `src/repos/pg.ts` (`PgClient` + migrator). `sql-pglite` / `@electric-sql/pglite` removed.
- `lab_activities` / `lab_used` / `lab_generated`
- Triggers reject UPDATE/DELETE (who/when cannot be rewritten)
- RPC: `AppendActivity` + `GetByRef` (activity ref, used, generated, or superseded)
- Corrections are new activities with `supersedes`. Original row stays.

Uses `LabEntity` / `EntityRef` / W7 from `packages/specimendb/src/schemas/provenance.ts`.

## Postgres URL

Copied iiot lite rig under `packages/specimendb/docker/` (`Dockerfile.lite` + `init.sql` from `packages/tmnl/docker/iiot-db`, compose from `docker-compose.iiot.yml`). Timescale HA + AGE. No pg_lake, no `start-pgduck.sh`, no geoint SQL.

```
postgres://specimendb:specimendb@localhost:5433/specimendb
```

Override with `SPECIMENDB_PG_URL`. Vite testbed stays in-memory. Capture still does not talk to PG.

## Out

Shop viewer. EVA adapter (#82). Seed ingest (#62) except the tiny correction fixture. Terminal/Workbench restyle. Merge of 34/45/57/58. DuckDB. A second catalog. A second #91 PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afc508f1-c1af-4a72-8b13-9e29b6b99a2e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afc508f1-c1af-4a72-8b13-9e29b6b99a2e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

