### PR TITLE
feat(specimendb): Timescale+AGE docker rig for catalog SoT (#91)

### DIFF
--- a/packages/specimendb/docker/README.md
+++ b/packages/specimendb/docker/README.md
@@ -1,0 +1,28 @@
+# specimendb Postgres (Timescale + AGE)
+
+Local catalog SoT container. Copied from `packages/tmnl/docker/docker-compose.iiot.yml` and `packages/tmnl/docker/iiot-db/`. Renamed container / database / volume so it does not collide with IIoT on 5433.
+
+TimescaleDB + Apache AGE. Compose builds `Dockerfile.lite`. The full `Dockerfile` is the iiot-db copy. No geoint init SQL. Catalog tables are not created here — that is the Effect migrator.
+
+The static capture page (`packages/specimendb/capture/`) does not talk to this container, RPC, or Intake.
+
+## Start
+
+```sh
+cd packages/specimendb/docker
+docker compose up -d
+```
+
+## Connection
+
+```
+postgresql://specimen:specimen_dev@localhost:5434/specimendb
+```
+
+| | IIoT (source) | specimendb |
+|---|---|---|
+| Container | `tmnl_iiot_db` | `specimendb_pg` |
+| Database | `iiot_mock` | `specimendb` |
+| User | `iiot` | `specimen` |
+| Port | `5433` | `5434` |
+| Volume | `iiot-db-data` | `specimendb-pg-data` |

--- a/packages/specimendb/docker/docker-compose.yml
+++ b/packages/specimendb/docker/docker-compose.yml
@@ -1,0 +1,61 @@
+# =============================================================================
+# specimendb catalog database
+# PostgreSQL 16 with TimescaleDB + Apache AGE
+#
+# Copied from packages/tmnl/docker/docker-compose.iiot.yml and rebranded.
+# No geoint init SQL. Compose uses the lite Timescale+AGE image.
+# Catalog DDL is the Effect migrator. The capture page does not talk to this container.
+#
+# Usage (from this directory):
+#   docker compose up -d
+#   docker compose logs -f
+#   docker compose down
+#   docker compose down -v
+#
+# Connection:
+#   psql postgres://specimen:specimen_dev@localhost:5434/specimendb
+#   Or: docker exec -it specimendb_pg psql -U specimen -d specimendb
+# =============================================================================
+
+services:
+  specimendb-db:
+    build:
+      context: ./iiot-db
+      dockerfile: Dockerfile.lite
+    container_name: specimendb_pg
+    ports:
+      - '5434:5432'
+    volumes:
+      - specimendb-pg-data:/home/postgres/pgdata/data
+    environment:
+      POSTGRES_USER: specimen
+      POSTGRES_PASSWORD: specimen_dev
+      POSTGRES_DB: specimendb
+      TIMESCALEDB_TELEMETRY: 'off'
+    command:
+      - postgres
+      - -c
+      - wal_level=logical
+      - -c
+      - max_replication_slots=10
+      - -c
+      - max_wal_senders=10
+      - -c
+      - shared_preload_libraries=timescaledb,age
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U specimen -d specimendb']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+    networks:
+      - specimendb
+
+networks:
+  specimendb:
+    driver: bridge
+
+volumes:
+  specimendb-pg-data:
+    driver: local

--- a/packages/specimendb/docker/iiot-db/Dockerfile
+++ b/packages/specimendb/docker/iiot-db/Dockerfile
@@ -1,0 +1,158 @@
+# =============================================================================
+# specimendb catalog database — PostgreSQL 16 with TimescaleDB + Apache AGE + pg_lake
+#
+# Copied from packages/tmnl/docker/iiot-db/Dockerfile and rebranded.
+# Compose uses Dockerfile.lite (Timescale + AGE, no pg_lake). This full image
+# is the iiot-db copy. Catalog SoT is Postgres SQL tables, not DuckDB.
+#
+# SCHEMA MANAGEMENT:
+#   Catalog DDL is the Effect SQL Migrator, NOT this image.
+#   init.sql only bootstraps the role/database context.
+#
+# Build: docker build -t specimendb-pg:latest .
+# =============================================================================
+
+FROM timescale/timescaledb-ha:pg16-ts2.17
+
+# Switch to root for package installation
+USER root
+
+# Build arguments
+ARG AGE_VERSION=1.5.0
+ARG PG_CONFIG=/usr/lib/postgresql/16/bin/pg_config
+
+# =============================================================================
+# Install ALL build dependencies upfront
+# =============================================================================
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Basic build tools
+    build-essential \
+    git \
+    cmake \
+    ninja-build \
+    pkg-config \
+    # PostgreSQL dev
+    postgresql-server-dev-16 \
+    # AGE dependencies
+    libreadline-dev \
+    zlib1g-dev \
+    flex \
+    bison \
+    # pg_lake / DuckDB dependencies
+    libssl-dev \
+    libcurl4-openssl-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    libicu-dev \
+    liblz4-dev \
+    libzstd-dev \
+    liblzma-dev \
+    libsnappy-dev \
+    libjansson-dev \
+    uuid-dev \
+    libjson-c-dev \
+    libkrb5-dev \
+    # vcpkg dependencies
+    curl \
+    zip \
+    unzip \
+    tar \
+    wget \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+
+# =============================================================================
+# Build and install Apache AGE
+# =============================================================================
+
+RUN git clone --branch release/PG16/${AGE_VERSION} --depth 1 \
+    https://github.com/apache/age.git age-src \
+    && cd age-src \
+    && make USE_PGXS=1 PG_CONFIG=${PG_CONFIG} install \
+    && cd / && rm -rf /tmp/age-src
+
+# =============================================================================
+# Install vcpkg for pg_lake Azure SDK dependencies
+# =============================================================================
+
+ENV VCPKG_ROOT=/opt/vcpkg
+ENV VCPKG_TOOLCHAIN_PATH=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
+
+RUN git clone --depth 1 https://github.com/microsoft/vcpkg.git ${VCPKG_ROOT} \
+    && ${VCPKG_ROOT}/bootstrap-vcpkg.sh -disableMetrics \
+    && ${VCPKG_ROOT}/vcpkg install \
+        azure-identity-cpp \
+        azure-storage-blobs-cpp \
+        azure-storage-files-datalake-cpp \
+        openssl \
+    && rm -rf ${VCPKG_ROOT}/buildtrees ${VCPKG_ROOT}/downloads ${VCPKG_ROOT}/packages
+
+# =============================================================================
+# Build and install pg_lake (DuckDB-powered Iceberg analytics)
+# =============================================================================
+
+ENV PATH="${PG_CONFIG%/*}:${PATH}"
+
+RUN git clone --recurse-submodules --depth 1 \
+    https://github.com/Snowflake-Labs/pg_lake.git pg_lake-src \
+    && cd pg_lake-src \
+    && make install \
+    && cd / && rm -rf /tmp/pg_lake-src
+
+# Copy pgduck_server to a stable location
+RUN mkdir -p /usr/local/bin \
+    && cp /usr/lib/postgresql/16/bin/pgduck_server /usr/local/bin/ 2>/dev/null || true
+
+# =============================================================================
+# Clean up build dependencies (keep runtime libs)
+# =============================================================================
+
+RUN apt-get remove -y \
+    build-essential \
+    cmake \
+    ninja-build \
+    git \
+    flex \
+    bison \
+    pkg-config \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf ${VCPKG_ROOT}
+
+# =============================================================================
+# Copy bootstrap script
+# =============================================================================
+
+# init.sql is minimal - just creates user context
+# All schema DDL is managed by Effect SQL Migrator
+COPY init.sql /docker-entrypoint-initdb.d/10-specimendb-bootstrap.sql
+
+# Switch back to postgres user
+USER postgres
+
+# Set default environment
+ENV POSTGRES_USER=specimen
+ENV POSTGRES_PASSWORD=specimen_dev
+ENV POSTGRES_DB=specimendb
+ENV TIMESCALEDB_TELEMETRY=off
+
+# pgduck_server config
+ENV PGDUCK_SOCKET_DIR=/tmp
+ENV PGDUCK_PORT=5332
+
+# Expose PostgreSQL port
+EXPOSE 5432
+
+# Health check
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=5 \
+    CMD pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB} || exit 1
+
+# Start postgres with extensions preloaded
+# - timescaledb: Time-series hypertables
+# - age: Apache AGE graph queries
+# - pg_extension_base: Required for pg_lake
+CMD ["postgres", "-c", "shared_preload_libraries=timescaledb,age,pg_extension_base"]

--- a/packages/specimendb/docker/iiot-db/Dockerfile.lite
+++ b/packages/specimendb/docker/iiot-db/Dockerfile.lite
@@ -1,0 +1,63 @@
+# =============================================================================
+# specimendb catalog database — PostgreSQL 16 with TimescaleDB + Apache AGE
+#
+# Copied from packages/tmnl/docker/iiot-db/Dockerfile.lite and rebranded.
+# TimescaleDB HA + Apache AGE. No pg_lake. No DuckDB.
+#
+# SCHEMA MANAGEMENT:
+#   Catalog DDL is the Effect SQL Migrator, NOT this image.
+#   init.sql only bootstraps the role/database context.
+#
+# Build: docker build -f Dockerfile.lite -t specimendb-pg:lite .
+# =============================================================================
+
+FROM timescale/timescaledb-ha:pg16-ts2.17
+
+USER root
+
+ARG AGE_VERSION=1.5.0
+ARG PG_CONFIG=/usr/lib/postgresql/16/bin/pg_config
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    postgresql-server-dev-16 \
+    libreadline-dev \
+    zlib1g-dev \
+    flex \
+    bison \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+
+RUN git clone --branch release/PG16/${AGE_VERSION} --depth 1 \
+    https://github.com/apache/age.git age-src \
+    && cd age-src \
+    && make USE_PGXS=1 PG_CONFIG=${PG_CONFIG} install \
+    && cd / && rm -rf /tmp/age-src
+
+RUN apt-get remove -y \
+    build-essential \
+    git \
+    flex \
+    bison \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Bootstrap only. Specimens/components tables come from the Effect migrator.
+COPY init.sql /docker-entrypoint-initdb.d/10-specimendb-bootstrap.sql
+
+USER postgres
+
+ENV POSTGRES_USER=specimen
+ENV POSTGRES_PASSWORD=specimen_dev
+ENV POSTGRES_DB=specimendb
+ENV TIMESCALEDB_TELEMETRY=off
+
+EXPOSE 5432
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=5 \
+    CMD pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB} || exit 1
+
+CMD ["postgres", "-c", "shared_preload_libraries=timescaledb,age"]

--- a/packages/specimendb/docker/iiot-db/init.sql
+++ b/packages/specimendb/docker/iiot-db/init.sql
@@ -1,0 +1,25 @@
+-- =============================================================================
+-- specimendb catalog database bootstrap
+-- =============================================================================
+--
+-- Minimal by design. Copied from packages/tmnl/docker/iiot-db/init.sql.
+--
+-- SCHEMA MANAGEMENT:
+--   Catalog DDL is the Effect SQL Migrator in packages/specimendb.
+--   Do not create specimens / components / lab_entities here.
+--   Do not load geoint init SQL.
+--
+-- USER SETUP:
+--   The 'specimen' user is created by Docker's entrypoint via POSTGRES_USER.
+--   No CREATE ROLE needed here.
+--
+-- =============================================================================
+
+DO $$
+BEGIN
+    RAISE NOTICE 'specimendb database bootstrap complete.';
+    RAISE NOTICE 'User: %', current_user;
+    RAISE NOTICE 'Database: %', current_database();
+    RAISE NOTICE '';
+    RAISE NOTICE 'Next step: run the Effect SQL Migrator to apply catalog schema.';
+END $$;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs #91. Docker rig only. Driver cut lives on #95.

Copy of `packages/tmnl/docker/docker-compose.iiot.yml` and `packages/tmnl/docker/iiot-db/` (`Dockerfile`, `Dockerfile.lite`, `init.sql`) into `packages/specimendb/docker/`.

- TimescaleDB HA pg16 + Apache AGE
- Compose uses `Dockerfile.lite`
- Renamed container `specimendb_pg`, database `specimendb`, volume `specimendb-pg-data`, port **5434**
- User `specimen` / password `specimen_dev`
- `init.sql` is bootstrap only. Catalog DDL stays the Effect migrator.
- No geoint init SQL. No `start-pgduck.sh`.

```
postgresql://specimen:specimen_dev@localhost:5434/specimendb
```

```sh
cd packages/specimendb/docker
docker compose up -d
```

Capture (`packages/specimendb/capture/`) is not wired to this container.

## Out

Driver swap (`repos/pglite.ts` → `repos/pg.ts`), package pins, layers, CI, Viewer, EVA, shop, GPS. That is #95.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f44d1ce0-c207-4784-8bea-93362b9dba9e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f44d1ce0-c207-4784-8bea-93362b9dba9e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

