### PR TITLE
feat(mantis-assistant): A3 dynamic-workflow laboratory (draft)

### DIFF
--- a/.github/workflows/mantis-workflow-lab-ci.yml
+++ b/.github/workflows/mantis-workflow-lab-ci.yml
@@ -1,0 +1,48 @@
+# A3 workflow-lab. JSON admit/fixtures only. Does not start Mastra or CopilotKit.
+name: Mantis A3 workflow-lab
+
+on:
+  push:
+    branches: [master, main, feat/mantis-biomemetics-lab]
+    paths:
+      - 'projects/biomemetics/labs/mantis/assistant/workflows/**'
+      - 'projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/**'
+      - '.github/workflows/mantis-workflow-lab-ci.yml'
+  pull_request:
+    paths:
+      - 'projects/biomemetics/labs/mantis/assistant/workflows/**'
+      - 'projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/**'
+      - '.github/workflows/mantis-workflow-lab-ci.yml'
+  workflow_dispatch:
+
+env:
+  WORKING_DIR: projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab
+
+jobs:
+  catalog:
+    name: Admit fixtures
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: ${{ env.WORKING_DIR }}/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ${{ env.WORKING_DIR }}
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: ${{ env.WORKING_DIR }}
+        run: npm run typecheck
+
+      - name: Test
+        working-directory: ${{ env.WORKING_DIR }}
+        run: npm test
+
+      - name: Catalog
+        working-directory: ${{ env.WORKING_DIR }}
+        run: npm run catalog

--- a/projects/biomemetics/labs/mantis/assistant/workflows/definitions/care-source-comparison.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/definitions/care-source-comparison.v1.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "DynamicWorkflowDefinition",
+  "definitionId": "wf.care-source-comparison",
+  "version": "1.0.0",
+  "description": "Compare two admitted care-source reads and summarize disagreements.",
+  "capabilityClass": "P0",
+  "author": "workflow-composer-fixture",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic"
+    ]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "result": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "result"
+    ]
+  },
+  "stateSchema": {
+    "type": "object"
+  },
+  "graph": [
+    {
+      "type": "tool",
+      "id": "src-a",
+      "toolId": "care-source-read"
+    },
+    {
+      "type": "tool",
+      "id": "src-b",
+      "toolId": "care-source-read"
+    },
+    {
+      "type": "mapping",
+      "id": "compare",
+      "mapping": "zip-summarize"
+    }
+  ],
+  "referencedPrimitives": [
+    {
+      "kind": "tool",
+      "id": "care-source-read",
+      "version": "1.0.0",
+      "assayId": "assay.care-source-read.v1"
+    }
+  ],
+  "prohibited": {
+    "deviceCommand": true,
+    "browserMutation": true,
+    "secrets": true,
+    "directCanonicalMutation": true,
+    "specimenDbWrite": true
+  },
+  "digest": "e56442b151492dcd6ae7d4cb68bef33c1d308df6795aca3c839e0d4cb2809a72"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/definitions/composer-self-admit.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/definitions/composer-self-admit.v1.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "DynamicWorkflowDefinition",
+  "definitionId": "wf.composer-self-admit",
+  "version": "1.0.0",
+  "description": "Valid P0 graph used to prove composer cannot admit own output.",
+  "capabilityClass": "P0",
+  "author": "workflow-composer-fixture",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic"
+    ]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "result": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "result"
+    ]
+  },
+  "stateSchema": {
+    "type": "object"
+  },
+  "graph": [
+    {
+      "type": "tool",
+      "id": "lookup",
+      "toolId": "care-source-read"
+    }
+  ],
+  "referencedPrimitives": [
+    {
+      "kind": "tool",
+      "id": "care-source-read",
+      "version": "1.0.0",
+      "assayId": "assay.care-source-read.v1"
+    }
+  ],
+  "prohibited": {
+    "deviceCommand": true,
+    "browserMutation": true,
+    "secrets": true,
+    "directCanonicalMutation": true,
+    "specimenDbWrite": true
+  },
+  "digest": "0b4df07cf093de9ff3910cf125dd471f65b4aea64f1d9c840a70c6a98311eebf"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/definitions/device-command-graph.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/definitions/device-command-graph.v1.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "DynamicWorkflowDefinition",
+  "definitionId": "wf.malicious-device-command",
+  "version": "1.0.0",
+  "description": "Malicious graph that attempts a device command.",
+  "capabilityClass": "P0",
+  "author": "workflow-composer-fixture",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic"
+    ]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "result": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "result"
+    ]
+  },
+  "stateSchema": {
+    "type": "object"
+  },
+  "graph": [
+    {
+      "type": "tool",
+      "id": "move",
+      "toolId": "device-command"
+    }
+  ],
+  "referencedPrimitives": [
+    {
+      "kind": "tool",
+      "id": "device-command",
+      "version": "0.0.0",
+      "assayId": "assay.missing"
+    }
+  ],
+  "prohibited": {
+    "deviceCommand": true,
+    "browserMutation": true,
+    "secrets": true,
+    "directCanonicalMutation": true,
+    "specimenDbWrite": true
+  },
+  "digest": "ff0ec4ce29d153b58b9eeacb617034feddad12ef70b60b0dbb5268115f19b71a"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/definitions/evidence-draft-completeness.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/definitions/evidence-draft-completeness.v1.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "DynamicWorkflowDefinition",
+  "definitionId": "wf.evidence-draft-completeness",
+  "version": "1.0.0",
+  "description": "Check an evidence draft for completeness. Does not write SpecimenDB.",
+  "capabilityClass": "P1",
+  "author": "workflow-composer-fixture",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic"
+    ]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "result": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "result"
+    ]
+  },
+  "stateSchema": {
+    "type": "object"
+  },
+  "graph": [
+    {
+      "type": "tool",
+      "id": "check",
+      "toolId": "evidence-completeness-read"
+    }
+  ],
+  "referencedPrimitives": [
+    {
+      "kind": "tool",
+      "id": "evidence-completeness-read",
+      "version": "1.0.0",
+      "assayId": "assay.evidence-completeness-read.v1"
+    }
+  ],
+  "prohibited": {
+    "deviceCommand": true,
+    "browserMutation": true,
+    "secrets": true,
+    "directCanonicalMutation": true,
+    "specimenDbWrite": true
+  },
+  "digest": "b96a5a5717e60c0d1416081ca580909b7df8c5fccbc80a7c222a67516c524135"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/definitions/feeding-removal-reminder.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/definitions/feeding-removal-reminder.v1.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "DynamicWorkflowDefinition",
+  "definitionId": "wf.feeding-removal-reminder",
+  "version": "1.0.0",
+  "description": "Plan a feeding-removal reminder. Sleep emits a reminder signal only.",
+  "capabilityClass": "P1",
+  "author": "workflow-composer-fixture",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic"
+    ]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "result": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "result"
+    ]
+  },
+  "stateSchema": {
+    "type": "object"
+  },
+  "graph": [
+    {
+      "type": "tool",
+      "id": "sources",
+      "toolId": "care-source-read"
+    },
+    {
+      "type": "tool",
+      "id": "plan",
+      "toolId": "reminder-plan-read"
+    },
+    {
+      "type": "mapping",
+      "id": "wait",
+      "mapping": "sleep",
+      "durationMs": 3600000,
+      "signal": "reminder"
+    }
+  ],
+  "referencedPrimitives": [
+    {
+      "kind": "tool",
+      "id": "care-source-read",
+      "version": "1.0.0",
+      "assayId": "assay.care-source-read.v1"
+    },
+    {
+      "kind": "tool",
+      "id": "reminder-plan-read",
+      "version": "1.0.0",
+      "assayId": "assay.reminder-plan-read.v1"
+    }
+  ],
+  "prohibited": {
+    "deviceCommand": true,
+    "browserMutation": true,
+    "secrets": true,
+    "directCanonicalMutation": true,
+    "specimenDbWrite": true
+  },
+  "digest": "3d84a201ea36e3cb14b23c7dd36dbb8b572b7d764d44bf426f01aee5154876a9"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/definitions/hidden-unassayed-mcp.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/definitions/hidden-unassayed-mcp.v1.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "DynamicWorkflowDefinition",
+  "definitionId": "wf.hidden-unassayed-mcp",
+  "version": "1.0.0",
+  "description": "References an unassayed MCP tool.",
+  "capabilityClass": "P2",
+  "author": "workflow-composer-fixture",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic"
+    ]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "result": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "result"
+    ]
+  },
+  "stateSchema": {
+    "type": "object"
+  },
+  "graph": [
+    {
+      "type": "tool",
+      "id": "browse",
+      "toolId": "mcp.hidden-browser"
+    }
+  ],
+  "referencedPrimitives": [
+    {
+      "kind": "tool",
+      "id": "mcp.hidden-browser",
+      "version": "1.0.0",
+      "assayId": "assay.missing"
+    }
+  ],
+  "prohibited": {
+    "deviceCommand": true,
+    "browserMutation": true,
+    "secrets": true,
+    "directCanonicalMutation": true,
+    "specimenDbWrite": true
+  },
+  "digest": "62c6af04ba0708ba122d86e383d4e35b047022ee62db70022c29c086b8f4ed79"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/definitions/observation-packet.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/definitions/observation-packet.v1.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "DynamicWorkflowDefinition",
+  "definitionId": "wf.observation-packet",
+  "version": "1.0.0",
+  "description": "Assemble an observation packet from selected media annotations.",
+  "capabilityClass": "P1",
+  "author": "workflow-composer-fixture",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic"
+    ]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "result": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "result"
+    ]
+  },
+  "stateSchema": {
+    "type": "object"
+  },
+  "graph": [
+    {
+      "type": "tool",
+      "id": "read-obs",
+      "toolId": "observation-packet-read"
+    },
+    {
+      "type": "mapping",
+      "id": "assemble",
+      "mapping": "assemble-packet"
+    }
+  ],
+  "referencedPrimitives": [
+    {
+      "kind": "tool",
+      "id": "observation-packet-read",
+      "version": "1.0.0",
+      "assayId": "assay.observation-packet-read.v1"
+    }
+  ],
+  "prohibited": {
+    "deviceCommand": true,
+    "browserMutation": true,
+    "secrets": true,
+    "directCanonicalMutation": true,
+    "specimenDbWrite": true
+  },
+  "digest": "b9a92af286c0e25bf43b698b03f8ec93938a8f4bef2ba9f2b20a9998256deee1"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/definitions/replay-nominal-write.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/definitions/replay-nominal-write.v1.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "DynamicWorkflowDefinition",
+  "definitionId": "wf.replay-nominal-write",
+  "version": "1.0.0",
+  "description": "Replay-unsafe canonical write.",
+  "capabilityClass": "P1",
+  "author": "workflow-composer-fixture",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic"
+    ]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "result": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "result"
+    ]
+  },
+  "stateSchema": {
+    "type": "object"
+  },
+  "graph": [
+    {
+      "type": "tool",
+      "id": "append",
+      "toolId": "canonical-event-append"
+    }
+  ],
+  "referencedPrimitives": [
+    {
+      "kind": "tool",
+      "id": "canonical-event-append",
+      "version": "1.0.0",
+      "assayId": "assay.canonical-event-append.v1"
+    }
+  ],
+  "prohibited": {
+    "deviceCommand": true,
+    "browserMutation": true,
+    "secrets": true,
+    "directCanonicalMutation": true,
+    "specimenDbWrite": true
+  },
+  "digest": "72a3e09f0690ebbb07169e69f473ed52dd6d00aac76273230a0cece8e0835ccd"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/definitions/research-source-triage.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/definitions/research-source-triage.v1.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "DynamicWorkflowDefinition",
+  "definitionId": "wf.research-source-triage",
+  "version": "1.0.0",
+  "description": "Triage reviewed research sources for a care question.",
+  "capabilityClass": "P2",
+  "author": "workflow-composer-fixture",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic"
+    ]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "result": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "result"
+    ]
+  },
+  "stateSchema": {
+    "type": "object"
+  },
+  "graph": [
+    {
+      "type": "tool",
+      "id": "lookup",
+      "toolId": "research-triage-read"
+    },
+    {
+      "type": "mapping",
+      "id": "rank",
+      "mapping": "rank-sources"
+    }
+  ],
+  "referencedPrimitives": [
+    {
+      "kind": "tool",
+      "id": "research-triage-read",
+      "version": "1.0.0",
+      "assayId": "assay.research-triage-read.v1"
+    }
+  ],
+  "prohibited": {
+    "deviceCommand": true,
+    "browserMutation": true,
+    "secrets": true,
+    "directCanonicalMutation": true,
+    "specimenDbWrite": true
+  },
+  "digest": "06bdc902bb5dafa4ed2faa3e41622e23947747878effdbb09e3c1e4557ddd2b6"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/definitions/unbounded-loop.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/definitions/unbounded-loop.v1.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "DynamicWorkflowDefinition",
+  "definitionId": "wf.unbounded-loop",
+  "version": "1.0.0",
+  "description": "Foreach without a bound explodes cost.",
+  "capabilityClass": "P0",
+  "author": "workflow-composer-fixture",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "topic": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "topic"
+    ]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "result": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "result"
+    ]
+  },
+  "stateSchema": {
+    "type": "object"
+  },
+  "graph": [
+    {
+      "type": "tool",
+      "id": "lookup",
+      "toolId": "care-source-read"
+    },
+    {
+      "type": "mapping",
+      "id": "loop",
+      "mapping": "foreach"
+    }
+  ],
+  "referencedPrimitives": [
+    {
+      "kind": "tool",
+      "id": "care-source-read",
+      "version": "1.0.0",
+      "assayId": "assay.care-source-read.v1"
+    }
+  ],
+  "prohibited": {
+    "deviceCommand": true,
+    "browserMutation": true,
+    "secrets": true,
+    "directCanonicalMutation": true,
+    "specimenDbWrite": true
+  },
+  "digest": "3fd740196bff9c9406a7662a212f90c98a9e2ee859ff7500ad936477bee5c2db"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/canonical-event-append.admission.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/canonical-event-append.admission.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ToolAdmission",
+  "admissionId": "admit-tool.canonical-event-append.v1",
+  "toolId": "canonical-event-append",
+  "assayId": "assay.canonical-event-append.v1",
+  "state": "quarantined",
+  "admittedAt": "2026-08-21T12:00:00Z",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "assessor": "tool-assessor-fixture",
+  "reviewer": "independent-reviewer-fixture",
+  "notes": "A3 fixture. Assessor did not admit this record."
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/canonical-event-append.input.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/canonical-event-append.input.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "topic": {
+      "type": "string"
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/canonical-event-append.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/canonical-event-append.json
@@ -1,0 +1,95 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ToolAssayRecord",
+  "assayId": "assay.canonical-event-append.v1",
+  "recordedAt": "2026-08-21T12:00:00Z",
+  "identity": {
+    "id": "canonical-event-append",
+    "version": "1.0.0",
+    "provider": "mantis-workflow-lab-fixture",
+    "license": "UNLICENSED-fixture",
+    "digest": "1046d8634b64b073733213d85ada59a734048f67f597f48e737e1500c02991e2"
+  },
+  "contract": {
+    "inputSchemaRef": "assistant/workflows/fixture-catalog/assays/canonical-event-append.input.json",
+    "outputSchemaRef": "assistant/workflows/fixture-catalog/assays/canonical-event-append.output.json",
+    "errors": [
+      "not-found",
+      "timeout"
+    ],
+    "timeoutMs": 2000,
+    "streaming": false,
+    "determinism": "non-deterministic"
+  },
+  "effects": {
+    "read": false,
+    "write": true,
+    "execute": false,
+    "externalMutation": true,
+    "deviceImpact": false,
+    "rollback": "none"
+  },
+  "authority": {
+    "actor": "assistant",
+    "category": "external-write",
+    "allowedModes": [
+      "care",
+      "research",
+      "review",
+      "observe"
+    ],
+    "allowedAgents": [
+      "workflow-composer"
+    ],
+    "llmExposed": true
+  },
+  "data": {
+    "privacyClass": "public",
+    "retention": "run-scoped",
+    "networkEgress": false,
+    "secrets": false,
+    "location": "none",
+    "media": "none"
+  },
+  "behavior": {
+    "idempotent": false,
+    "retrySafe": false,
+    "cancellation": "unsafe",
+    "concurrency": "unknown"
+  },
+  "evidence": {
+    "sourceClassProduced": "none",
+    "provenanceFields": [
+      "sourceId"
+    ],
+    "simulator": true,
+    "fixtures": [
+      "assistant/workflows/fixture-catalog/assays/canonical-event-append.json"
+    ]
+  },
+  "safety": {
+    "staleStatePolicy": "not-applicable",
+    "approvalTier": "none",
+    "physicalInterlocks": false
+  },
+  "verification": {
+    "staticLint": true,
+    "sandboxSmoke": true,
+    "negativeTests": [
+      "unknown-id-denied"
+    ],
+    "adversarialTests": [
+      "prompt-injection-ignored"
+    ]
+  },
+  "review": {
+    "assessor": "tool-assessor-fixture",
+    "independentReviewer": "adversarial-reviewer-fixture",
+    "disposition": "quarantined",
+    "expiry": "2027-08-21T00:00:00Z",
+    "reAssayTriggers": [
+      "schema-change",
+      "provider-version-change"
+    ]
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/canonical-event-append.output.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/canonical-event-append.output.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/evidence-completeness-read.admission.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/evidence-completeness-read.admission.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ToolAdmission",
+  "admissionId": "admit-tool.evidence-completeness-read.v1",
+  "toolId": "evidence-completeness-read",
+  "assayId": "assay.evidence-completeness-read.v1",
+  "state": "admitted-read",
+  "admittedAt": "2026-08-21T12:00:00Z",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "assessor": "tool-assessor-fixture",
+  "reviewer": "independent-reviewer-fixture",
+  "notes": "A3 fixture. Assessor did not admit this record."
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/evidence-completeness-read.input.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/evidence-completeness-read.input.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "topic": {
+      "type": "string"
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/evidence-completeness-read.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/evidence-completeness-read.json
@@ -1,0 +1,96 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ToolAssayRecord",
+  "assayId": "assay.evidence-completeness-read.v1",
+  "recordedAt": "2026-08-21T12:00:00Z",
+  "identity": {
+    "id": "evidence-completeness-read",
+    "version": "1.0.0",
+    "provider": "mantis-workflow-lab-fixture",
+    "license": "UNLICENSED-fixture",
+    "digest": "9f86e973ba09ff83199333365797b12d8cd051058bf4a4c77abcef4cb70f4528"
+  },
+  "contract": {
+    "inputSchemaRef": "assistant/workflows/fixture-catalog/assays/evidence-completeness-read.input.json",
+    "outputSchemaRef": "assistant/workflows/fixture-catalog/assays/evidence-completeness-read.output.json",
+    "errors": [
+      "not-found",
+      "timeout"
+    ],
+    "timeoutMs": 2000,
+    "streaming": false,
+    "determinism": "deterministic"
+  },
+  "effects": {
+    "read": true,
+    "write": false,
+    "execute": false,
+    "externalMutation": false,
+    "deviceImpact": false,
+    "rollback": "none"
+  },
+  "authority": {
+    "actor": "assistant",
+    "category": "draft-local",
+    "allowedModes": [
+      "care",
+      "research",
+      "review",
+      "observe"
+    ],
+    "allowedAgents": [
+      "evidence-curator",
+      "workflow-composer"
+    ],
+    "llmExposed": true
+  },
+  "data": {
+    "privacyClass": "public",
+    "retention": "run-scoped",
+    "networkEgress": false,
+    "secrets": false,
+    "location": "none",
+    "media": "none"
+  },
+  "behavior": {
+    "idempotent": true,
+    "retrySafe": true,
+    "cancellation": "safe",
+    "concurrency": "safe"
+  },
+  "evidence": {
+    "sourceClassProduced": "external-source",
+    "provenanceFields": [
+      "sourceId"
+    ],
+    "simulator": true,
+    "fixtures": [
+      "assistant/workflows/fixture-catalog/assays/evidence-completeness-read.json"
+    ]
+  },
+  "safety": {
+    "staleStatePolicy": "not-applicable",
+    "approvalTier": "none",
+    "physicalInterlocks": false
+  },
+  "verification": {
+    "staticLint": true,
+    "sandboxSmoke": true,
+    "negativeTests": [
+      "unknown-id-denied"
+    ],
+    "adversarialTests": [
+      "prompt-injection-ignored"
+    ]
+  },
+  "review": {
+    "assessor": "tool-assessor-fixture",
+    "independentReviewer": "adversarial-reviewer-fixture",
+    "disposition": "admitted-read",
+    "expiry": "2027-08-21T00:00:00Z",
+    "reAssayTriggers": [
+      "schema-change",
+      "provider-version-change"
+    ]
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/evidence-completeness-read.output.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/evidence-completeness-read.output.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/observation-packet-read.admission.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/observation-packet-read.admission.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ToolAdmission",
+  "admissionId": "admit-tool.observation-packet-read.v1",
+  "toolId": "observation-packet-read",
+  "assayId": "assay.observation-packet-read.v1",
+  "state": "admitted-read",
+  "admittedAt": "2026-08-21T12:00:00Z",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "assessor": "tool-assessor-fixture",
+  "reviewer": "independent-reviewer-fixture",
+  "notes": "A3 fixture. Assessor did not admit this record."
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/observation-packet-read.input.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/observation-packet-read.input.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "topic": {
+      "type": "string"
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/observation-packet-read.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/observation-packet-read.json
@@ -1,0 +1,96 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ToolAssayRecord",
+  "assayId": "assay.observation-packet-read.v1",
+  "recordedAt": "2026-08-21T12:00:00Z",
+  "identity": {
+    "id": "observation-packet-read",
+    "version": "1.0.0",
+    "provider": "mantis-workflow-lab-fixture",
+    "license": "UNLICENSED-fixture",
+    "digest": "be0fde01ddc1c25ea01767dfb06ce2668e9d8ea04faee1c0359e586381eda6ed"
+  },
+  "contract": {
+    "inputSchemaRef": "assistant/workflows/fixture-catalog/assays/observation-packet-read.input.json",
+    "outputSchemaRef": "assistant/workflows/fixture-catalog/assays/observation-packet-read.output.json",
+    "errors": [
+      "not-found",
+      "timeout"
+    ],
+    "timeoutMs": 2000,
+    "streaming": false,
+    "determinism": "deterministic"
+  },
+  "effects": {
+    "read": true,
+    "write": false,
+    "execute": false,
+    "externalMutation": false,
+    "deviceImpact": false,
+    "rollback": "none"
+  },
+  "authority": {
+    "actor": "assistant",
+    "category": "read-private",
+    "allowedModes": [
+      "care",
+      "research",
+      "review",
+      "observe"
+    ],
+    "allowedAgents": [
+      "observation-extractor",
+      "workflow-composer"
+    ],
+    "llmExposed": true
+  },
+  "data": {
+    "privacyClass": "public",
+    "retention": "run-scoped",
+    "networkEgress": false,
+    "secrets": false,
+    "location": "none",
+    "media": "none"
+  },
+  "behavior": {
+    "idempotent": true,
+    "retrySafe": true,
+    "cancellation": "safe",
+    "concurrency": "safe"
+  },
+  "evidence": {
+    "sourceClassProduced": "external-source",
+    "provenanceFields": [
+      "sourceId"
+    ],
+    "simulator": true,
+    "fixtures": [
+      "assistant/workflows/fixture-catalog/assays/observation-packet-read.json"
+    ]
+  },
+  "safety": {
+    "staleStatePolicy": "not-applicable",
+    "approvalTier": "none",
+    "physicalInterlocks": false
+  },
+  "verification": {
+    "staticLint": true,
+    "sandboxSmoke": true,
+    "negativeTests": [
+      "unknown-id-denied"
+    ],
+    "adversarialTests": [
+      "prompt-injection-ignored"
+    ]
+  },
+  "review": {
+    "assessor": "tool-assessor-fixture",
+    "independentReviewer": "adversarial-reviewer-fixture",
+    "disposition": "admitted-read",
+    "expiry": "2027-08-21T00:00:00Z",
+    "reAssayTriggers": [
+      "schema-change",
+      "provider-version-change"
+    ]
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/observation-packet-read.output.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/observation-packet-read.output.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/reminder-plan-read.admission.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/reminder-plan-read.admission.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ToolAdmission",
+  "admissionId": "admit-tool.reminder-plan-read.v1",
+  "toolId": "reminder-plan-read",
+  "assayId": "assay.reminder-plan-read.v1",
+  "state": "admitted-read",
+  "admittedAt": "2026-08-21T12:00:00Z",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "assessor": "tool-assessor-fixture",
+  "reviewer": "independent-reviewer-fixture",
+  "notes": "A3 fixture. Assessor did not admit this record."
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/reminder-plan-read.input.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/reminder-plan-read.input.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "topic": {
+      "type": "string"
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/reminder-plan-read.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/reminder-plan-read.json
@@ -1,0 +1,96 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ToolAssayRecord",
+  "assayId": "assay.reminder-plan-read.v1",
+  "recordedAt": "2026-08-21T12:00:00Z",
+  "identity": {
+    "id": "reminder-plan-read",
+    "version": "1.0.0",
+    "provider": "mantis-workflow-lab-fixture",
+    "license": "UNLICENSED-fixture",
+    "digest": "606580fd1aa94a9a3cda96d026212df9a6f6f0fd8a08903e6ba33bd7300c5bf2"
+  },
+  "contract": {
+    "inputSchemaRef": "assistant/workflows/fixture-catalog/assays/reminder-plan-read.input.json",
+    "outputSchemaRef": "assistant/workflows/fixture-catalog/assays/reminder-plan-read.output.json",
+    "errors": [
+      "not-found",
+      "timeout"
+    ],
+    "timeoutMs": 2000,
+    "streaming": false,
+    "determinism": "deterministic"
+  },
+  "effects": {
+    "read": true,
+    "write": false,
+    "execute": false,
+    "externalMutation": false,
+    "deviceImpact": false,
+    "rollback": "none"
+  },
+  "authority": {
+    "actor": "assistant",
+    "category": "draft-local",
+    "allowedModes": [
+      "care",
+      "research",
+      "review",
+      "observe"
+    ],
+    "allowedAgents": [
+      "care-source",
+      "workflow-composer"
+    ],
+    "llmExposed": true
+  },
+  "data": {
+    "privacyClass": "public",
+    "retention": "run-scoped",
+    "networkEgress": false,
+    "secrets": false,
+    "location": "none",
+    "media": "none"
+  },
+  "behavior": {
+    "idempotent": true,
+    "retrySafe": true,
+    "cancellation": "safe",
+    "concurrency": "safe"
+  },
+  "evidence": {
+    "sourceClassProduced": "external-source",
+    "provenanceFields": [
+      "sourceId"
+    ],
+    "simulator": true,
+    "fixtures": [
+      "assistant/workflows/fixture-catalog/assays/reminder-plan-read.json"
+    ]
+  },
+  "safety": {
+    "staleStatePolicy": "not-applicable",
+    "approvalTier": "none",
+    "physicalInterlocks": false
+  },
+  "verification": {
+    "staticLint": true,
+    "sandboxSmoke": true,
+    "negativeTests": [
+      "unknown-id-denied"
+    ],
+    "adversarialTests": [
+      "prompt-injection-ignored"
+    ]
+  },
+  "review": {
+    "assessor": "tool-assessor-fixture",
+    "independentReviewer": "adversarial-reviewer-fixture",
+    "disposition": "admitted-read",
+    "expiry": "2027-08-21T00:00:00Z",
+    "reAssayTriggers": [
+      "schema-change",
+      "provider-version-change"
+    ]
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/reminder-plan-read.output.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/reminder-plan-read.output.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/research-triage-read.admission.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/research-triage-read.admission.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ToolAdmission",
+  "admissionId": "admit-tool.research-triage-read.v1",
+  "toolId": "research-triage-read",
+  "assayId": "assay.research-triage-read.v1",
+  "state": "admitted-read",
+  "admittedAt": "2026-08-21T12:00:00Z",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "assessor": "tool-assessor-fixture",
+  "reviewer": "independent-reviewer-fixture",
+  "notes": "A3 fixture. Assessor did not admit this record."
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/research-triage-read.input.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/research-triage-read.input.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "topic": {
+      "type": "string"
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/research-triage-read.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/research-triage-read.json
@@ -1,0 +1,96 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ToolAssayRecord",
+  "assayId": "assay.research-triage-read.v1",
+  "recordedAt": "2026-08-21T12:00:00Z",
+  "identity": {
+    "id": "research-triage-read",
+    "version": "1.0.0",
+    "provider": "mantis-workflow-lab-fixture",
+    "license": "UNLICENSED-fixture",
+    "digest": "21206e697876a74b58deb6268b42626bc422c3a8ef1808af427501567bc3036e"
+  },
+  "contract": {
+    "inputSchemaRef": "assistant/workflows/fixture-catalog/assays/research-triage-read.input.json",
+    "outputSchemaRef": "assistant/workflows/fixture-catalog/assays/research-triage-read.output.json",
+    "errors": [
+      "not-found",
+      "timeout"
+    ],
+    "timeoutMs": 2000,
+    "streaming": false,
+    "determinism": "deterministic"
+  },
+  "effects": {
+    "read": true,
+    "write": false,
+    "execute": false,
+    "externalMutation": false,
+    "deviceImpact": false,
+    "rollback": "none"
+  },
+  "authority": {
+    "actor": "assistant",
+    "category": "read-public",
+    "allowedModes": [
+      "care",
+      "research",
+      "review",
+      "observe"
+    ],
+    "allowedAgents": [
+      "care-source",
+      "workflow-composer"
+    ],
+    "llmExposed": true
+  },
+  "data": {
+    "privacyClass": "public",
+    "retention": "run-scoped",
+    "networkEgress": false,
+    "secrets": false,
+    "location": "none",
+    "media": "none"
+  },
+  "behavior": {
+    "idempotent": true,
+    "retrySafe": true,
+    "cancellation": "safe",
+    "concurrency": "safe"
+  },
+  "evidence": {
+    "sourceClassProduced": "external-source",
+    "provenanceFields": [
+      "sourceId"
+    ],
+    "simulator": true,
+    "fixtures": [
+      "assistant/workflows/fixture-catalog/assays/research-triage-read.json"
+    ]
+  },
+  "safety": {
+    "staleStatePolicy": "not-applicable",
+    "approvalTier": "none",
+    "physicalInterlocks": false
+  },
+  "verification": {
+    "staticLint": true,
+    "sandboxSmoke": true,
+    "negativeTests": [
+      "unknown-id-denied"
+    ],
+    "adversarialTests": [
+      "prompt-injection-ignored"
+    ]
+  },
+  "review": {
+    "assessor": "tool-assessor-fixture",
+    "independentReviewer": "adversarial-reviewer-fixture",
+    "disposition": "admitted-read",
+    "expiry": "2027-08-21T00:00:00Z",
+    "reAssayTriggers": [
+      "schema-change",
+      "provider-version-change"
+    ]
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/research-triage-read.output.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/assays/research-triage-read.output.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/catalog.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/catalog.json
@@ -1,0 +1,52 @@
+{
+  "kind": "WorkflowFixtureCatalog",
+  "schemaVersion": "1.0.0",
+  "mastraCorePin": "1.61.0",
+  "clock": "2026-08-21T12:00:00Z",
+  "a0Owned": [
+    "assistant/workflows/definitions/research-summary.v1.json",
+    "assistant/workflows/admissions/research-summary.v1.json"
+  ],
+  "cases": [
+    {
+      "id": "care-source-comparison.v1",
+      "expect": "admit"
+    },
+    {
+      "id": "feeding-removal-reminder.v1",
+      "expect": "admit"
+    },
+    {
+      "id": "observation-packet.v1",
+      "expect": "admit"
+    },
+    {
+      "id": "research-source-triage.v1",
+      "expect": "admit"
+    },
+    {
+      "id": "evidence-draft-completeness.v1",
+      "expect": "admit"
+    },
+    {
+      "id": "device-command-graph.v1",
+      "expect": "reject"
+    },
+    {
+      "id": "hidden-unassayed-mcp.v1",
+      "expect": "reject"
+    },
+    {
+      "id": "unbounded-loop.v1",
+      "expect": "reject"
+    },
+    {
+      "id": "replay-nominal-write.v1",
+      "expect": "reject"
+    },
+    {
+      "id": "composer-self-admit.v1",
+      "expect": "reject-identity"
+    }
+  ]
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/negative/composer-self-admit.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/negative/composer-self-admit.v1.json
@@ -1,0 +1,11 @@
+{
+  "id": "composer-self-admit.v1",
+  "expect": "reject-identity",
+  "definition": "assistant/workflows/definitions/composer-self-admit.v1.json",
+  "envelope": "assistant/workflows/laboratory/envelopes/composer-self-admit.v1.json",
+  "composer": "workflow-composer-fixture",
+  "assessor": "tool-assessor-fixture",
+  "adversary": "adversarial-reviewer-fixture",
+  "governor": "workflow-composer-fixture",
+  "diagnosticPath": "/reviewer"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/negative/device-command-graph.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/negative/device-command-graph.v1.json
@@ -1,0 +1,11 @@
+{
+  "id": "device-command-graph.v1",
+  "expect": "reject",
+  "definition": "assistant/workflows/definitions/device-command-graph.v1.json",
+  "envelope": "assistant/workflows/laboratory/envelopes/device-command-graph.v1.json",
+  "composer": "workflow-composer-fixture",
+  "assessor": "tool-assessor-fixture",
+  "adversary": "adversarial-reviewer-fixture",
+  "governor": "human-governor-fixture",
+  "diagnosticPath": "/graph/0/toolId"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/negative/hidden-unassayed-mcp.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/negative/hidden-unassayed-mcp.v1.json
@@ -1,0 +1,11 @@
+{
+  "id": "hidden-unassayed-mcp.v1",
+  "expect": "reject",
+  "definition": "assistant/workflows/definitions/hidden-unassayed-mcp.v1.json",
+  "envelope": "assistant/workflows/laboratory/envelopes/hidden-unassayed-mcp.v1.json",
+  "composer": "workflow-composer-fixture",
+  "assessor": "tool-assessor-fixture",
+  "adversary": "adversarial-reviewer-fixture",
+  "governor": "human-governor-fixture",
+  "diagnosticPath": "/graph/0/toolId"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/negative/replay-nominal-write.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/negative/replay-nominal-write.v1.json
@@ -1,0 +1,11 @@
+{
+  "id": "replay-nominal-write.v1",
+  "expect": "reject",
+  "definition": "assistant/workflows/definitions/replay-nominal-write.v1.json",
+  "envelope": "assistant/workflows/laboratory/envelopes/replay-nominal-write.v1.json",
+  "composer": "workflow-composer-fixture",
+  "assessor": "tool-assessor-fixture",
+  "adversary": "adversarial-reviewer-fixture",
+  "governor": "human-governor-fixture",
+  "diagnosticPath": "/graph/0/toolId"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/negative/unbounded-loop.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/negative/unbounded-loop.v1.json
@@ -1,0 +1,11 @@
+{
+  "id": "unbounded-loop.v1",
+  "expect": "reject",
+  "definition": "assistant/workflows/definitions/unbounded-loop.v1.json",
+  "envelope": "assistant/workflows/laboratory/envelopes/unbounded-loop.v1.json",
+  "composer": "workflow-composer-fixture",
+  "assessor": "tool-assessor-fixture",
+  "adversary": "adversarial-reviewer-fixture",
+  "governor": "human-governor-fixture",
+  "diagnosticPath": "/graph/1"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/positive/care-source-comparison.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/positive/care-source-comparison.v1.json
@@ -1,0 +1,10 @@
+{
+  "id": "care-source-comparison.v1",
+  "expect": "admit",
+  "definition": "assistant/workflows/definitions/care-source-comparison.v1.json",
+  "envelope": "assistant/workflows/laboratory/envelopes/care-source-comparison.v1.json",
+  "composer": "workflow-composer-fixture",
+  "assessor": "tool-assessor-fixture",
+  "adversary": "adversarial-reviewer-fixture",
+  "governor": "human-governor-fixture"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/positive/evidence-draft-completeness.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/positive/evidence-draft-completeness.v1.json
@@ -1,0 +1,10 @@
+{
+  "id": "evidence-draft-completeness.v1",
+  "expect": "admit",
+  "definition": "assistant/workflows/definitions/evidence-draft-completeness.v1.json",
+  "envelope": "assistant/workflows/laboratory/envelopes/evidence-draft-completeness.v1.json",
+  "composer": "workflow-composer-fixture",
+  "assessor": "tool-assessor-fixture",
+  "adversary": "adversarial-reviewer-fixture",
+  "governor": "human-governor-fixture"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/positive/feeding-removal-reminder.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/positive/feeding-removal-reminder.v1.json
@@ -1,0 +1,10 @@
+{
+  "id": "feeding-removal-reminder.v1",
+  "expect": "admit",
+  "definition": "assistant/workflows/definitions/feeding-removal-reminder.v1.json",
+  "envelope": "assistant/workflows/laboratory/envelopes/feeding-removal-reminder.v1.json",
+  "composer": "workflow-composer-fixture",
+  "assessor": "tool-assessor-fixture",
+  "adversary": "adversarial-reviewer-fixture",
+  "governor": "human-governor-fixture"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/positive/observation-packet.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/positive/observation-packet.v1.json
@@ -1,0 +1,10 @@
+{
+  "id": "observation-packet.v1",
+  "expect": "admit",
+  "definition": "assistant/workflows/definitions/observation-packet.v1.json",
+  "envelope": "assistant/workflows/laboratory/envelopes/observation-packet.v1.json",
+  "composer": "workflow-composer-fixture",
+  "assessor": "tool-assessor-fixture",
+  "adversary": "adversarial-reviewer-fixture",
+  "governor": "human-governor-fixture"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/positive/research-source-triage.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/fixture-catalog/positive/research-source-triage.v1.json
@@ -1,0 +1,10 @@
+{
+  "id": "research-source-triage.v1",
+  "expect": "admit",
+  "definition": "assistant/workflows/definitions/research-source-triage.v1.json",
+  "envelope": "assistant/workflows/laboratory/envelopes/research-source-triage.v1.json",
+  "composer": "workflow-composer-fixture",
+  "assessor": "tool-assessor-fixture",
+  "adversary": "adversarial-reviewer-fixture",
+  "governor": "human-governor-fixture"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/README.md
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/README.md
@@ -1,0 +1,47 @@
+# Dynamic workflow laboratory (A3)
+
+Governed admission for Mastra JSON workflow definitions. CopilotKit/AG-UI is
+the later keeper surface. This directory is the JSON laboratory, not that
+surface.
+
+This slice does not call a live CopilotKit URL or a remote Mastra server. A0
+already pinned Mastra 1.61.0 and proved `addDynamicWorkflow` on
+`wf.research-summary`. This slice consumes those contracts by read. It does
+not rewrite them.
+
+## Pipeline
+
+`draft` → schema/graph validation → primitive resolution → tool-assay closure →
+static policy lint → simulator → adversarial eval → human approval → signed
+immutable version → `active`. Revocation and expiry follow. Running jobs keep
+the content digest they started with.
+
+P0–P2 only. Device command, SpecimenDB writes, browser mutation, secrets, and
+direct canonical mutation fail closed with path diagnostics.
+
+The workflow composer cannot register, approve, or activate its own output.
+The assessor cannot admit. The adversarial reviewer is read-only.
+
+## Layout
+
+`imported-a0/` holds read-only copies of A0 schemas and the two admitted
+read-tool assays so this PR verifies before A0 merges. Prefer live
+`assistant/contracts/` and `assistant/tools/` when those files exist.
+
+`envelopes/` holds budgets, request-context schema, and sleep policy. A0's
+`DynamicWorkflowDefinition` schema sets `additionalProperties` to false, so
+those fields cannot live on the definition document.
+
+`../definitions/` holds A3 graphs. It does not own
+`research-summary.v1.json`. That file belongs to A0 PR 100.
+
+`../fixture-catalog/` is the positive and negative corpus.
+
+`../linter/rules.json` and `../simulator/harness.json` are data for the
+TypeScript package `@tmnl/mantis-workflow-lab`.
+
+## Digest
+
+A3 content-hashes the definition with the `digest` field omitted, using
+sorted JSON and compact separators. A0's research-summary fixture uses
+`sha256(definitionId + "@" + version)`. Do not rewrite that fixture to match.

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/care-source-comparison.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/care-source-comparison.v1.json
@@ -1,0 +1,34 @@
+{
+  "kind": "LaboratoryEnvelope",
+  "schemaVersion": "1.0.0",
+  "definitionId": "wf.care-source-comparison",
+  "requestContextSchema": {
+    "type": "object",
+    "properties": {
+      "principalId": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "principalId"
+    ]
+  },
+  "budgets": {
+    "wallTimeMs": 8000,
+    "maxSteps": 8,
+    "maxParallel": 2,
+    "maxLoopIterations": 4,
+    "maxTokens": 4000,
+    "maxToolCalls": 8,
+    "maxCostUsd": 0.05,
+    "cancellable": true
+  },
+  "sleepPolicy": {
+    "allowedSignals": [
+      "reminder",
+      "revalidation"
+    ]
+  },
+  "capabilityClass": "P0",
+  "mastraCorePin": "1.61.0"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/composer-self-admit.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/composer-self-admit.v1.json
@@ -1,0 +1,34 @@
+{
+  "kind": "LaboratoryEnvelope",
+  "schemaVersion": "1.0.0",
+  "definitionId": "wf.composer-self-admit",
+  "requestContextSchema": {
+    "type": "object",
+    "properties": {
+      "principalId": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "principalId"
+    ]
+  },
+  "budgets": {
+    "wallTimeMs": 8000,
+    "maxSteps": 8,
+    "maxParallel": 2,
+    "maxLoopIterations": 4,
+    "maxTokens": 4000,
+    "maxToolCalls": 8,
+    "maxCostUsd": 0.05,
+    "cancellable": true
+  },
+  "sleepPolicy": {
+    "allowedSignals": [
+      "reminder",
+      "revalidation"
+    ]
+  },
+  "capabilityClass": "P0",
+  "mastraCorePin": "1.61.0"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/device-command-graph.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/device-command-graph.v1.json
@@ -1,0 +1,34 @@
+{
+  "kind": "LaboratoryEnvelope",
+  "schemaVersion": "1.0.0",
+  "definitionId": "wf.malicious-device-command",
+  "requestContextSchema": {
+    "type": "object",
+    "properties": {
+      "principalId": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "principalId"
+    ]
+  },
+  "budgets": {
+    "wallTimeMs": 8000,
+    "maxSteps": 8,
+    "maxParallel": 2,
+    "maxLoopIterations": 4,
+    "maxTokens": 4000,
+    "maxToolCalls": 8,
+    "maxCostUsd": 0.05,
+    "cancellable": true
+  },
+  "sleepPolicy": {
+    "allowedSignals": [
+      "reminder",
+      "revalidation"
+    ]
+  },
+  "capabilityClass": "P0",
+  "mastraCorePin": "1.61.0"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/evidence-draft-completeness.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/evidence-draft-completeness.v1.json
@@ -1,0 +1,34 @@
+{
+  "kind": "LaboratoryEnvelope",
+  "schemaVersion": "1.0.0",
+  "definitionId": "wf.evidence-draft-completeness",
+  "requestContextSchema": {
+    "type": "object",
+    "properties": {
+      "principalId": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "principalId"
+    ]
+  },
+  "budgets": {
+    "wallTimeMs": 8000,
+    "maxSteps": 8,
+    "maxParallel": 2,
+    "maxLoopIterations": 4,
+    "maxTokens": 4000,
+    "maxToolCalls": 8,
+    "maxCostUsd": 0.05,
+    "cancellable": true
+  },
+  "sleepPolicy": {
+    "allowedSignals": [
+      "reminder",
+      "revalidation"
+    ]
+  },
+  "capabilityClass": "P1",
+  "mastraCorePin": "1.61.0"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/feeding-removal-reminder.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/feeding-removal-reminder.v1.json
@@ -1,0 +1,34 @@
+{
+  "kind": "LaboratoryEnvelope",
+  "schemaVersion": "1.0.0",
+  "definitionId": "wf.feeding-removal-reminder",
+  "requestContextSchema": {
+    "type": "object",
+    "properties": {
+      "principalId": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "principalId"
+    ]
+  },
+  "budgets": {
+    "wallTimeMs": 8000,
+    "maxSteps": 8,
+    "maxParallel": 2,
+    "maxLoopIterations": 4,
+    "maxTokens": 4000,
+    "maxToolCalls": 8,
+    "maxCostUsd": 0.05,
+    "cancellable": true
+  },
+  "sleepPolicy": {
+    "allowedSignals": [
+      "reminder",
+      "revalidation"
+    ]
+  },
+  "capabilityClass": "P1",
+  "mastraCorePin": "1.61.0"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/hidden-unassayed-mcp.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/hidden-unassayed-mcp.v1.json
@@ -1,0 +1,34 @@
+{
+  "kind": "LaboratoryEnvelope",
+  "schemaVersion": "1.0.0",
+  "definitionId": "wf.hidden-unassayed-mcp",
+  "requestContextSchema": {
+    "type": "object",
+    "properties": {
+      "principalId": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "principalId"
+    ]
+  },
+  "budgets": {
+    "wallTimeMs": 8000,
+    "maxSteps": 8,
+    "maxParallel": 2,
+    "maxLoopIterations": 4,
+    "maxTokens": 4000,
+    "maxToolCalls": 8,
+    "maxCostUsd": 0.05,
+    "cancellable": true
+  },
+  "sleepPolicy": {
+    "allowedSignals": [
+      "reminder",
+      "revalidation"
+    ]
+  },
+  "capabilityClass": "P2",
+  "mastraCorePin": "1.61.0"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/observation-packet.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/observation-packet.v1.json
@@ -1,0 +1,34 @@
+{
+  "kind": "LaboratoryEnvelope",
+  "schemaVersion": "1.0.0",
+  "definitionId": "wf.observation-packet",
+  "requestContextSchema": {
+    "type": "object",
+    "properties": {
+      "principalId": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "principalId"
+    ]
+  },
+  "budgets": {
+    "wallTimeMs": 8000,
+    "maxSteps": 8,
+    "maxParallel": 2,
+    "maxLoopIterations": 4,
+    "maxTokens": 4000,
+    "maxToolCalls": 8,
+    "maxCostUsd": 0.05,
+    "cancellable": true
+  },
+  "sleepPolicy": {
+    "allowedSignals": [
+      "reminder",
+      "revalidation"
+    ]
+  },
+  "capabilityClass": "P1",
+  "mastraCorePin": "1.61.0"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/replay-nominal-write.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/replay-nominal-write.v1.json
@@ -1,0 +1,34 @@
+{
+  "kind": "LaboratoryEnvelope",
+  "schemaVersion": "1.0.0",
+  "definitionId": "wf.replay-nominal-write",
+  "requestContextSchema": {
+    "type": "object",
+    "properties": {
+      "principalId": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "principalId"
+    ]
+  },
+  "budgets": {
+    "wallTimeMs": 8000,
+    "maxSteps": 8,
+    "maxParallel": 2,
+    "maxLoopIterations": 4,
+    "maxTokens": 4000,
+    "maxToolCalls": 8,
+    "maxCostUsd": 0.05,
+    "cancellable": true
+  },
+  "sleepPolicy": {
+    "allowedSignals": [
+      "reminder",
+      "revalidation"
+    ]
+  },
+  "capabilityClass": "P1",
+  "mastraCorePin": "1.61.0"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/research-source-triage.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/research-source-triage.v1.json
@@ -1,0 +1,34 @@
+{
+  "kind": "LaboratoryEnvelope",
+  "schemaVersion": "1.0.0",
+  "definitionId": "wf.research-source-triage",
+  "requestContextSchema": {
+    "type": "object",
+    "properties": {
+      "principalId": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "principalId"
+    ]
+  },
+  "budgets": {
+    "wallTimeMs": 8000,
+    "maxSteps": 8,
+    "maxParallel": 2,
+    "maxLoopIterations": 4,
+    "maxTokens": 4000,
+    "maxToolCalls": 8,
+    "maxCostUsd": 0.05,
+    "cancellable": true
+  },
+  "sleepPolicy": {
+    "allowedSignals": [
+      "reminder",
+      "revalidation"
+    ]
+  },
+  "capabilityClass": "P2",
+  "mastraCorePin": "1.61.0"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/unbounded-loop.v1.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/envelopes/unbounded-loop.v1.json
@@ -1,0 +1,34 @@
+{
+  "kind": "LaboratoryEnvelope",
+  "schemaVersion": "1.0.0",
+  "definitionId": "wf.unbounded-loop",
+  "requestContextSchema": {
+    "type": "object",
+    "properties": {
+      "principalId": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "principalId"
+    ]
+  },
+  "budgets": {
+    "wallTimeMs": 8000,
+    "maxSteps": 8,
+    "maxParallel": 2,
+    "maxLoopIterations": 4,
+    "maxTokens": 4000,
+    "maxToolCalls": 8,
+    "maxCostUsd": 0.05,
+    "cancellable": true
+  },
+  "sleepPolicy": {
+    "allowedSignals": [
+      "reminder",
+      "revalidation"
+    ]
+  },
+  "capabilityClass": "P0",
+  "mastraCorePin": "1.61.0"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/SOURCE.txt
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/SOURCE.txt
@@ -1,0 +1,4 @@
+Read-only copies of A0 (PR 100, branch cursor/mantis-assistant-a0-9bdb, b383dfe43fb6fb7d0774bab11a20f777c6951a6b).
+A3 consumes these contracts by read. Do not treat this directory as schema authority once assistant/contracts/ exists on the same checkout. Prefer live A0 paths at runtime; fall back here so this slice verifies without merging A0.
+Do not rewrite A0 files. Do not add research-summary.v1 here as an owned definition.
+Mastra core pin recorded from A0 src/pins.ts: 1.61.0

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/admit.care-source-read.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/admit.care-source-read.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ToolAdmission",
+  "admissionId": "admit-tool.care-source-read.v1",
+  "toolId": "care-source-read",
+  "assayId": "assay.care-source-read.v1",
+  "state": "admitted-read",
+  "admittedAt": "2026-08-21T00:10:00Z",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "assessor": "tool-assessor-fixture",
+  "reviewer": "independent-reviewer-fixture",
+  "notes": "Read-only reviewed-source fixture. Assessor did not admit this record."
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/admit.supply-transit-read.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/admit.supply-transit-read.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ToolAdmission",
+  "admissionId": "admit-tool.supply-transit-read.v1",
+  "toolId": "supply-transit-read",
+  "assayId": "assay.supply-transit-read.v1",
+  "state": "admitted-read",
+  "admittedAt": "2026-08-21T00:10:00Z",
+  "expiresAt": "2027-08-21T00:00:00Z",
+  "assessor": "tool-assessor-fixture",
+  "reviewer": "independent-reviewer-fixture",
+  "notes": "Ephemeral coarse-location fixture. Exact address must not be retained."
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/assay.care-source-read.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/assay.care-source-read.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ToolAssayRecord",
+  "assayId": "assay.care-source-read.v1",
+  "recordedAt": "2026-08-21T00:00:00Z",
+  "identity": {
+    "id": "care-source-read",
+    "version": "1.0.0",
+    "provider": "mantis-assistant-fixture",
+    "digest": "1b50f71d448dbd18f6d19ac675e09f6d36a834b920edc19fa0898d5f32b46e20",
+    "license": "UNLICENSED-fixture"
+  },
+  "contract": {
+    "inputSchemaRef": "assistant/tools/assays/care-source-read.input.json",
+    "outputSchemaRef": "assistant/tools/assays/care-source-read.output.json",
+    "errors": ["not-found", "timeout"],
+    "timeoutMs": 2000,
+    "streaming": false,
+    "determinism": "deterministic"
+  },
+  "effects": {
+    "read": true,
+    "write": false,
+    "execute": false,
+    "externalMutation": false,
+    "deviceImpact": false,
+    "rollback": "none"
+  },
+  "authority": {
+    "actor": "assistant",
+    "category": "read-public",
+    "allowedModes": ["care", "research", "review"],
+    "allowedAgents": ["care-source", "mantis-coordinator"],
+    "llmExposed": true
+  },
+  "data": {
+    "privacyClass": "public",
+    "retention": "run-scoped",
+    "networkEgress": false,
+    "secrets": false,
+    "location": "none",
+    "media": "none"
+  },
+  "behavior": {
+    "idempotent": true,
+    "retrySafe": true,
+    "cancellation": "safe",
+    "concurrency": "safe"
+  },
+  "evidence": {
+    "sourceClassProduced": "external-source",
+    "provenanceFields": ["sourceId", "retrievedAt"],
+    "simulator": true,
+    "fixtures": ["assistant/fixtures/tools/care-source-read.json"]
+  },
+  "safety": {
+    "staleStatePolicy": "not-applicable",
+    "approvalTier": "none",
+    "physicalInterlocks": false
+  },
+  "verification": {
+    "staticLint": true,
+    "sandboxSmoke": true,
+    "negativeTests": ["unknown-source-id-denied"],
+    "adversarialTests": ["prompt-injection-ignored"]
+  },
+  "review": {
+    "assessor": "tool-assessor-fixture",
+    "independentReviewer": "adversarial-reviewer-fixture",
+    "disposition": "assayed",
+    "expiry": "2027-08-21T00:00:00Z",
+    "reAssayTriggers": ["schema-change", "provider-version-change"]
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/assay.supply-transit-read.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/assay.supply-transit-read.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ToolAssayRecord",
+  "assayId": "assay.supply-transit-read.v1",
+  "recordedAt": "2026-08-21T00:00:00Z",
+  "identity": {
+    "id": "supply-transit-read",
+    "version": "1.0.0",
+    "provider": "mantis-assistant-fixture",
+    "digest": "940782223134602c58bb195a8600799d0e9778865a4b0b9ea5e348a8e2e70c26",
+    "license": "UNLICENSED-fixture"
+  },
+  "contract": {
+    "inputSchemaRef": "assistant/tools/assays/supply-transit-read.input.json",
+    "outputSchemaRef": "assistant/tools/assays/supply-transit-read.output.json",
+    "errors": ["location-expired", "timeout"],
+    "timeoutMs": 3000,
+    "streaming": false,
+    "determinism": "idempotent"
+  },
+  "effects": {
+    "read": true,
+    "write": false,
+    "execute": false,
+    "externalMutation": false,
+    "deviceImpact": false,
+    "rollback": "none"
+  },
+  "authority": {
+    "actor": "assistant",
+    "category": "read-private",
+    "allowedModes": ["care", "research"],
+    "allowedAgents": ["supply-transit"],
+    "llmExposed": true
+  },
+  "data": {
+    "privacyClass": "ephemeral-location",
+    "retention": "per-use",
+    "networkEgress": false,
+    "secrets": false,
+    "location": "ephemeral-coarse",
+    "media": "none"
+  },
+  "behavior": {
+    "idempotent": true,
+    "retrySafe": true,
+    "cancellation": "safe",
+    "concurrency": "safe"
+  },
+  "evidence": {
+    "sourceClassProduced": "external-source",
+    "provenanceFields": ["retrievedAt", "freshness"],
+    "simulator": true,
+    "fixtures": ["assistant/fixtures/tools/supply-transit-read.json"]
+  },
+  "safety": {
+    "staleStatePolicy": "fail-closed",
+    "approvalTier": "ask",
+    "physicalInterlocks": false
+  },
+  "verification": {
+    "staticLint": true,
+    "sandboxSmoke": true,
+    "negativeTests": ["exact-address-stripped", "expired-token-denied"],
+    "adversarialTests": ["retain-address-forbidden"]
+  },
+  "review": {
+    "assessor": "tool-assessor-fixture",
+    "independentReviewer": "adversarial-reviewer-fixture",
+    "disposition": "assayed",
+    "expiry": "2027-08-21T00:00:00Z",
+    "reAssayTriggers": ["credential-scope-change"]
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/dynamic-workflow-definition.schema.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/dynamic-workflow-definition.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:specimendb:biomemetics:mantis:assistant:contracts:dynamic-workflow-definition:v1",
+  "title": "Mantis dynamic workflow definition",
+  "description": "JSON graph for a candidate Mastra dynamic workflow. P0-P2 research/analysis only. Device command, browser mutation, secrets, and canonical/SpecimenDB writes are prohibited.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "definitionId",
+    "version",
+    "digest",
+    "capabilityClass",
+    "author",
+    "inputSchema",
+    "outputSchema",
+    "graph",
+    "referencedPrimitives",
+    "prohibited"
+  ],
+  "properties": {
+    "$schema": { "type": "string" },
+    "schemaVersion": { "const": "1.0.0" },
+    "kind": { "const": "DynamicWorkflowDefinition" },
+    "definitionId": {
+      "type": "string",
+      "pattern": "^wf\\.[a-z][a-z0-9.-]*$"
+    },
+    "version": { "type": "string", "minLength": 1 },
+    "digest": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "description": { "type": "string" },
+    "capabilityClass": { "enum": ["P0", "P1", "P2"] },
+    "author": { "type": "string", "minLength": 1 },
+    "sourcePrompt": { "type": "string" },
+    "modelRun": { "type": "string" },
+    "expiresAt": { "type": "string", "format": "date-time" },
+    "inputSchema": { "type": "object" },
+    "outputSchema": { "type": "object" },
+    "stateSchema": { "type": "object" },
+    "graph": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["type", "id"],
+        "properties": {
+          "type": {
+            "enum": ["tool", "agent", "workflow", "mapping"]
+          },
+          "id": { "type": "string", "minLength": 1 },
+          "toolId": { "type": "string" },
+          "agentId": { "type": "string" },
+          "workflowId": { "type": "string" }
+        }
+      }
+    },
+    "referencedPrimitives": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "id", "version", "assayId"],
+        "properties": {
+          "kind": { "enum": ["tool", "agent", "workflow"] },
+          "id": { "type": "string", "minLength": 1 },
+          "version": { "type": "string", "minLength": 1 },
+          "assayId": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "prohibited": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "deviceCommand",
+        "browserMutation",
+        "secrets",
+        "directCanonicalMutation",
+        "specimenDbWrite"
+      ],
+      "properties": {
+        "deviceCommand": { "const": true },
+        "browserMutation": { "const": true },
+        "secrets": { "const": true },
+        "directCanonicalMutation": { "const": true },
+        "specimenDbWrite": { "const": true }
+      }
+    }
+  },
+  "unevaluatedProperties": false
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/forbidden-tools.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/forbidden-tools.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "ForbiddenToolCatalog",
+  "description": "Tools that must remain invisible to the model. They are not assayed for LLM exposure and default to deny.",
+  "tools": [
+    {
+      "id": "device-command",
+      "category": "device-command",
+      "llmExposed": false,
+      "reason": "Live actuation is disabled. The model never receives a command tool."
+    },
+    {
+      "id": "admin",
+      "category": "admin",
+      "llmExposed": false,
+      "reason": "Administrative authority is host-only."
+    },
+    {
+      "id": "specimen-db-write",
+      "category": "admin",
+      "llmExposed": false,
+      "reason": "Direct SpecimenDB writes are prohibited. A1/A5 own any governed preview later."
+    },
+    {
+      "id": "live-catalog-write",
+      "category": "admin",
+      "llmExposed": false,
+      "reason": "Live catalog mutation is outside A0."
+    },
+    {
+      "id": "browser-mutate",
+      "category": "external-write",
+      "llmExposed": false,
+      "reason": "Browser mutation is quarantined."
+    }
+  ]
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/tool-admission.schema.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/tool-admission.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:specimendb:biomemetics:mantis:assistant:contracts:tool-admission:v1",
+  "title": "Mantis tool admission",
+  "description": "Admission registry entry. The assessor cannot admit its own tool. Unknown or changed tools remain denied.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "admissionId",
+    "toolId",
+    "assayId",
+    "state",
+    "admittedAt",
+    "assessor",
+    "reviewer"
+  ],
+  "properties": {
+    "$schema": { "type": "string" },
+    "schemaVersion": { "const": "1.0.0" },
+    "kind": { "const": "ToolAdmission" },
+    "admissionId": {
+      "type": "string",
+      "pattern": "^admit-tool\\.[a-z][a-z0-9.-]*$"
+    },
+    "toolId": { "type": "string", "minLength": 1 },
+    "assayId": {
+      "type": "string",
+      "pattern": "^assay\\.[a-z][a-z0-9.-]*$"
+    },
+    "state": {
+      "enum": [
+        "discovered",
+        "quarantined",
+        "assayed",
+        "simulated",
+        "admitted-read",
+        "admitted-write",
+        "revoked"
+      ]
+    },
+    "admittedAt": { "type": "string", "format": "date-time" },
+    "expiresAt": { "type": "string", "format": "date-time" },
+    "assessor": { "type": "string", "minLength": 1 },
+    "reviewer": { "type": "string", "minLength": 1 },
+    "notes": { "type": "string" }
+  },
+  "unevaluatedProperties": false
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/tool-assay-record.schema.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/tool-assay-record.schema.json
@@ -1,0 +1,241 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:specimendb:biomemetics:mantis:assistant:contracts:tool-assay-record:v1",
+  "title": "Mantis tool assay record",
+  "description": "Versioned inspection of a candidate tool or MCP primitive. Discovery does not grant visibility. device-command and admin tools are never assayed for LLM exposure.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "assayId",
+    "recordedAt",
+    "identity",
+    "contract",
+    "effects",
+    "authority",
+    "data",
+    "behavior",
+    "evidence",
+    "safety",
+    "verification",
+    "review"
+  ],
+  "properties": {
+    "$schema": { "type": "string" },
+    "schemaVersion": { "const": "1.0.0" },
+    "kind": { "const": "ToolAssayRecord" },
+    "assayId": {
+      "type": "string",
+      "pattern": "^assay\\.[a-z][a-z0-9.-]*$"
+    },
+    "recordedAt": { "type": "string", "format": "date-time" },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version", "provider", "digest", "license"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "provider": { "type": "string", "minLength": 1 },
+        "sourceUrl": { "type": "string" },
+        "digest": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "license": { "type": "string", "minLength": 1 }
+      }
+    },
+    "contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["inputSchemaRef", "outputSchemaRef", "errors", "timeoutMs", "streaming", "determinism"],
+      "properties": {
+        "inputSchemaRef": { "type": "string", "minLength": 1 },
+        "outputSchemaRef": { "type": "string", "minLength": 1 },
+        "errors": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "timeoutMs": { "type": "integer", "minimum": 1 },
+        "streaming": { "type": "boolean" },
+        "determinism": { "enum": ["deterministic", "idempotent", "non-deterministic"] }
+      }
+    },
+    "effects": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["read", "write", "execute", "externalMutation", "deviceImpact", "rollback"],
+      "properties": {
+        "read": { "type": "boolean" },
+        "write": { "type": "boolean" },
+        "execute": { "type": "boolean" },
+        "externalMutation": { "type": "boolean" },
+        "deviceImpact": { "type": "boolean" },
+        "rollback": { "enum": ["none", "compensating", "native"] }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actor", "category", "allowedModes", "allowedAgents", "llmExposed"],
+      "properties": {
+        "actor": { "enum": ["assistant", "keeper", "edge", "service"] },
+        "category": {
+          "enum": [
+            "read-public",
+            "read-private",
+            "draft-local",
+            "external-write",
+            "device-intent",
+            "device-command",
+            "admin"
+          ]
+        },
+        "credential": { "type": "string" },
+        "allowedModes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "care",
+              "observe",
+              "research",
+              "terrarium-read",
+              "review",
+              "service-sim"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "allowedAgents": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "llmExposed": { "type": "boolean" }
+      }
+    },
+    "data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["privacyClass", "networkEgress", "secrets", "location", "media"],
+      "properties": {
+        "privacyClass": { "enum": ["public", "private", "secret", "ephemeral-location"] },
+        "retention": { "type": "string" },
+        "networkEgress": { "type": "boolean" },
+        "secrets": { "type": "boolean" },
+        "location": { "enum": ["none", "ephemeral-coarse", "forbidden-exact"] },
+        "media": { "enum": ["none", "digest-only", "selected-annotation"] }
+      }
+    },
+    "behavior": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["idempotent", "retrySafe", "cancellation", "concurrency"],
+      "properties": {
+        "idempotent": { "type": "boolean" },
+        "retrySafe": { "type": "boolean" },
+        "cancellation": { "enum": ["safe", "unsafe", "unknown"] },
+        "concurrency": { "enum": ["safe", "exclusive", "unknown"] },
+        "rateLimit": { "type": "string" },
+        "costLimit": { "type": "string" }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sourceClassProduced", "simulator", "fixtures"],
+      "properties": {
+        "sourceClassProduced": {
+          "enum": ["none", "observed", "calculated", "external-source", "unverified"]
+        },
+        "provenanceFields": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "simulator": { "type": "boolean" },
+        "fixtures": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["staleStatePolicy", "approvalTier", "physicalInterlocks"],
+      "properties": {
+        "staleStatePolicy": { "enum": ["fail-closed", "refresh", "not-applicable"] },
+        "preconditions": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "approvalTier": { "enum": ["none", "ask", "human-local", "never"] },
+        "physicalInterlocks": { "type": "boolean" }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["staticLint", "sandboxSmoke", "negativeTests", "adversarialTests"],
+      "properties": {
+        "staticLint": { "type": "boolean" },
+        "sandboxSmoke": { "type": "boolean" },
+        "negativeTests": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
+        },
+        "adversarialTests": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["assessor", "disposition"],
+      "properties": {
+        "assessor": { "type": "string", "minLength": 1 },
+        "independentReviewer": { "type": "string" },
+        "disposition": {
+          "enum": [
+            "discovered",
+            "quarantined",
+            "assayed",
+            "simulated",
+            "admitted-read",
+            "admitted-write",
+            "revoked"
+          ]
+        },
+        "expiry": { "type": "string", "format": "date-time" },
+        "reAssayTriggers": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "authority": {
+            "properties": {
+              "category": { "enum": ["device-command", "admin"] }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "authority": {
+            "properties": {
+              "llmExposed": { "const": false }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "unevaluatedProperties": false
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/workflow-admission.schema.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/workflow-admission.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:specimendb:biomemetics:mantis:assistant:contracts:workflow-admission:v1",
+  "title": "Mantis dynamic workflow admission",
+  "description": "Admission of a signed immutable dynamic-workflow version. Running jobs retain the graph version they started with.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "admissionId",
+    "definitionId",
+    "definitionVersion",
+    "digest",
+    "state",
+    "reviewer",
+    "admittedAt"
+  ],
+  "properties": {
+    "$schema": { "type": "string" },
+    "schemaVersion": { "const": "1.0.0" },
+    "kind": { "const": "WorkflowAdmission" },
+    "admissionId": {
+      "type": "string",
+      "pattern": "^admit-wf\\.[a-z][a-z0-9.-]*$"
+    },
+    "definitionId": {
+      "type": "string",
+      "pattern": "^wf\\.[a-z][a-z0-9.-]*$"
+    },
+    "definitionVersion": { "type": "string", "minLength": 1 },
+    "digest": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "state": {
+      "enum": [
+        "draft",
+        "schema-validated",
+        "primitives-resolved",
+        "assay-closed",
+        "policy-linted",
+        "simulated",
+        "adversarially-evaluated",
+        "human-approved",
+        "signed-immutable",
+        "active",
+        "revoked"
+      ]
+    },
+    "reviewer": { "type": "string", "minLength": 1 },
+    "admittedAt": { "type": "string", "format": "date-time" },
+    "signature": { "type": "string" },
+    "notes": { "type": "string" }
+  },
+  "unevaluatedProperties": false
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/workflow-run-receipt.schema.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/imported-a0/workflow-run-receipt.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:specimendb:biomemetics:mantis:assistant:contracts:workflow-run-receipt:v1",
+  "title": "Mantis workflow run receipt",
+  "description": "Receipt for a workflow execution bound to the immutable graph version it started with. Durable recovery must not duplicate external side effects.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "runId",
+    "definitionId",
+    "definitionVersion",
+    "digest",
+    "startedAt",
+    "status",
+    "sideEffectClass",
+    "replaySafe"
+  ],
+  "properties": {
+    "$schema": { "type": "string" },
+    "schemaVersion": { "const": "1.0.0" },
+    "kind": { "const": "WorkflowRunReceipt" },
+    "runId": {
+      "type": "string",
+      "pattern": "^wfrun\\.[a-z][a-z0-9.-]*$"
+    },
+    "definitionId": {
+      "type": "string",
+      "pattern": "^wf\\.[a-z][a-z0-9.-]*$"
+    },
+    "definitionVersion": { "type": "string", "minLength": 1 },
+    "digest": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "startedAt": { "type": "string", "format": "date-time" },
+    "endedAt": { "type": "string", "format": "date-time" },
+    "status": {
+      "enum": ["running", "suspended", "success", "failed", "cancelled"]
+    },
+    "sideEffectClass": {
+      "enum": ["read-only", "proven-idempotent", "external-mutation"]
+    },
+    "replaySafe": { "type": "boolean" },
+    "externalEffectCount": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "sideEffectClass": { "const": "external-mutation" }
+        },
+        "required": ["sideEffectClass"]
+      },
+      "then": {
+        "properties": {
+          "replaySafe": { "const": false }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "sideEffectClass": { "enum": ["read-only", "proven-idempotent"] }
+        },
+        "required": ["sideEffectClass"]
+      },
+      "then": {
+        "properties": {
+          "replaySafe": { "const": true }
+        }
+      }
+    }
+  ],
+  "unevaluatedProperties": false
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/primitive-snapshot.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/laboratory/primitive-snapshot.json
@@ -1,0 +1,71 @@
+{
+  "kind": "PrimitiveCapabilitySnapshot",
+  "schemaVersion": "1.0.0",
+  "mastraCorePin": "1.61.0",
+  "recordedAt": "2026-08-21T12:00:00Z",
+  "tools": [
+    {
+      "id": "care-source-read",
+      "version": "1.0.0",
+      "assayId": "assay.care-source-read.v1",
+      "admission": "admitted-read",
+      "source": "imported-a0"
+    },
+    {
+      "id": "supply-transit-read",
+      "version": "1.0.0",
+      "assayId": "assay.supply-transit-read.v1",
+      "admission": "admitted-read",
+      "source": "imported-a0"
+    },
+    {
+      "id": "observation-packet-read",
+      "version": "1.0.0",
+      "assayId": "assay.observation-packet-read.v1",
+      "admission": "admitted-read",
+      "source": "fixture-catalog"
+    },
+    {
+      "id": "research-triage-read",
+      "version": "1.0.0",
+      "assayId": "assay.research-triage-read.v1",
+      "admission": "admitted-read",
+      "source": "fixture-catalog"
+    },
+    {
+      "id": "evidence-completeness-read",
+      "version": "1.0.0",
+      "assayId": "assay.evidence-completeness-read.v1",
+      "admission": "admitted-read",
+      "source": "fixture-catalog"
+    },
+    {
+      "id": "reminder-plan-read",
+      "version": "1.0.0",
+      "assayId": "assay.reminder-plan-read.v1",
+      "admission": "admitted-read",
+      "source": "fixture-catalog"
+    }
+  ],
+  "forbidden": [
+    "device-command",
+    "admin",
+    "specimen-db-write",
+    "live-catalog-write",
+    "browser-mutate"
+  ],
+  "mappingKinds": [
+    "zip-summarize",
+    "sleep",
+    "conditional",
+    "foreach",
+    "parallel",
+    "assemble-packet",
+    "rank-sources"
+  ],
+  "sleepSignals": [
+    "reminder",
+    "revalidation"
+  ],
+  "digest": "3051ec360bb69ce01555fedc1dba1f36d67c3b74876b0d58a63003610b6dcb2b"
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/linter/rules.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/linter/rules.json
@@ -1,0 +1,33 @@
+{
+  "kind": "WorkflowStaticLintRules",
+  "schemaVersion": "1.0.0",
+  "maxCapability": "P2",
+  "forbiddenToolIds": [
+    "device-command",
+    "admin",
+    "specimen-db-write",
+    "live-catalog-write",
+    "browser-mutate"
+  ],
+  "forbiddenCategories": [
+    "device-command",
+    "admin",
+    "external-write",
+    "device-intent"
+  ],
+  "requireAssayClosed": true,
+  "requireAdmittedReadOrIdempotent": true,
+  "sleepSignals": [
+    "reminder",
+    "revalidation"
+  ],
+  "requireLoopBound": true,
+  "requireParallelBound": true,
+  "denySecrets": true,
+  "denyReplayUnsafeWrites": true,
+  "distinctIdentities": {
+    "composerCannotAdmit": true,
+    "assessorCannotAdmit": true,
+    "adversaryCannotAdmit": true
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/workflows/simulator/harness.json
+++ b/projects/biomemetics/labs/mantis/assistant/workflows/simulator/harness.json
@@ -1,0 +1,8 @@
+{
+  "kind": "WorkflowSimulatorHarness",
+  "schemaVersion": "1.0.0",
+  "clock": "2026-08-21T12:00:00Z",
+  "sideEffects": "disabled",
+  "replay": "disabled-for-external-mutation",
+  "notes": "Deterministic in-process walk of the JSON graph. Does not call Mastra or CopilotKit."
+}

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/README.md
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/README.md
@@ -1,62 +1,22 @@
 # `@tmnl/mantis-workflow-lab`
 
-Local admission laboratory for Mastra dynamic-workflow JSON (gbg#53 / A3).
-Composer output is a branded `DraftDefinition`. Assessor and adversarial
-review evaluate read-only. Only a `HumanGovernor` can approve, sign, activate,
-or revoke.
+A3 admission laboratory for Mastra dynamic-workflow JSON (gbg#53). CopilotKit
+is the later keeper surface. This package does not start a CopilotKit URL or a
+Mastra server. A0 already pinned Mastra 1.61.0 and proved
+`addDynamicWorkflow`. This package records that pin and does not depend on
+`@mastra/core`.
 
-This package does not call live CopilotKit or a remote Mastra server. It does
-not depend on `@mastra/core` or `@tmnl/mantis-assistant`. It records
-`mastraCore: "1.61.0"` as a read of A0's pin.
+Composer output is a draft. Assessor and adversarial reviewer are read-only.
+Only a human governor can approve, sign, activate, or revoke.
 
-## Install
+## Commands
 
-```bash
-npm install
+```text
+npm ci
 npm test
 npm run typecheck
 npm run catalog
 ```
 
-## Quickstart
-
-```ts
-import {
-  openLaboratory,
-  asComposer,
-  asAssessor,
-  asAdversarialReviewer,
-  asHumanGovernor,
-} from "@tmnl/mantis-workflow-lab";
-
-const lab = await openLaboratory();
-const composer = asComposer("workflow-composer-fixture");
-const assessor = asAssessor("tool-assessor-fixture");
-const adversary = asAdversarialReviewer("adversarial-reviewer-fixture");
-const governor = asHumanGovernor("human-governor-fixture");
-
-const draft = await lab.loadDraft(
-  composer,
-  "assistant/workflows/definitions/care-source-comparison.v1.json",
-  "assistant/workflows/laboratory/envelopes/care-source-comparison.v1.json",
-);
-const evaluation = await lab.evaluate(assessor, draft, { adversary });
-const packet = lab.present(evaluation);
-const signed = await lab.approve(governor, packet);
-const active = await lab.activate(governor, signed);
-const receipt = await lab.bindRun(active, { topic: "nymph feeding" });
-```
-
-## Lever
-
-`npm run catalog` walks `fixture-catalog/catalog.json` and exits 0 only when
-every case matches its `admit` / `reject` / `reject-identity` expectation.
-
-## Layout
-
-- `src/pipeline.ts` owns the private stage table. `reduce` is not exported.
-- Envelope fields (budgets, requestContextSchema, sleepPolicy) sit beside the
-  A0 definition because A0 `DynamicWorkflowDefinition` sets
-  `additionalProperties: false`.
-- A3 digest is sha256 of canonical JSON with `digest` omitted.
-- Do not create or edit `definitions/research-summary.v1.json`.
+`npm run catalog` walks `assistant/workflows/fixture-catalog/catalog.json` and
+exits 0 only when every case matches `admit`, `reject`, or `reject-identity`.

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/README.md
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/README.md
@@ -1,0 +1,62 @@
+# `@tmnl/mantis-workflow-lab`
+
+Local admission laboratory for Mastra dynamic-workflow JSON (gbg#53 / A3).
+Composer output is a branded `DraftDefinition`. Assessor and adversarial
+review evaluate read-only. Only a `HumanGovernor` can approve, sign, activate,
+or revoke.
+
+This package does not call live CopilotKit or a remote Mastra server. It does
+not depend on `@mastra/core` or `@tmnl/mantis-assistant`. It records
+`mastraCore: "1.61.0"` as a read of A0's pin.
+
+## Install
+
+```bash
+npm install
+npm test
+npm run typecheck
+npm run catalog
+```
+
+## Quickstart
+
+```ts
+import {
+  openLaboratory,
+  asComposer,
+  asAssessor,
+  asAdversarialReviewer,
+  asHumanGovernor,
+} from "@tmnl/mantis-workflow-lab";
+
+const lab = await openLaboratory();
+const composer = asComposer("workflow-composer-fixture");
+const assessor = asAssessor("tool-assessor-fixture");
+const adversary = asAdversarialReviewer("adversarial-reviewer-fixture");
+const governor = asHumanGovernor("human-governor-fixture");
+
+const draft = await lab.loadDraft(
+  composer,
+  "assistant/workflows/definitions/care-source-comparison.v1.json",
+  "assistant/workflows/laboratory/envelopes/care-source-comparison.v1.json",
+);
+const evaluation = await lab.evaluate(assessor, draft, { adversary });
+const packet = lab.present(evaluation);
+const signed = await lab.approve(governor, packet);
+const active = await lab.activate(governor, signed);
+const receipt = await lab.bindRun(active, { topic: "nymph feeding" });
+```
+
+## Lever
+
+`npm run catalog` walks `fixture-catalog/catalog.json` and exits 0 only when
+every case matches its `admit` / `reject` / `reject-identity` expectation.
+
+## Layout
+
+- `src/pipeline.ts` owns the private stage table. `reduce` is not exported.
+- Envelope fields (budgets, requestContextSchema, sleepPolicy) sit beside the
+  A0 definition because A0 `DynamicWorkflowDefinition` sets
+  `additionalProperties: false`.
+- A3 digest is sha256 of canonical JSON with `digest` omitted.
+- Do not create or edit `definitions/research-summary.v1.json`.

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/README.md
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/README.md
@@ -20,3 +20,6 @@ npm run catalog
 
 `npm run catalog` walks `assistant/workflows/fixture-catalog/catalog.json` and
 exits 0 only when every case matches `admit`, `reject`, or `reject-identity`.
+
+`.github/workflows/mantis-workflow-lab-ci.yml` runs those three commands on the
+A3 write-set. JSON fixtures only. No live Mastra.

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/package-lock.json
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/package-lock.json
@@ -1,0 +1,125 @@
+{
+  "name": "@tmnl/mantis-workflow-lab",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@tmnl/mantis-workflow-lab",
+      "version": "0.1.0",
+      "dependencies": {
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1"
+      },
+      "devDependencies": {
+        "@types/node": "22.18.0",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=22.14.0",
+        "npm": ">=10.9.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
+      "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/package.json
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@tmnl/mantis-workflow-lab",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "A3 admitted Mastra dynamic-workflow laboratory. JSON admission pipeline only. Not the A0 harness, not a keeper PWA, not shop-release.",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node --test --experimental-strip-types test/*.test.ts",
+    "typecheck": "tsc --noEmit",
+    "catalog": "node --experimental-strip-types src/cli.ts"
+  },
+  "engines": {
+    "node": ">=22.14.0",
+    "npm": ">=10.9.0"
+  },
+  "packageManager": "npm@10.9.7",
+  "dependencies": {
+    "ajv": "8.20.0",
+    "ajv-formats": "3.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "22.18.0",
+    "typescript": "5.9.3"
+  }
+}

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/scripts/emit-fixtures.py
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/scripts/emit-fixtures.py
@@ -1,0 +1,634 @@
+#!/usr/bin/env python3
+"""Emit A3 workflow laboratory fixtures with content digests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+ROOT = Path("/workspace/projects/biomemetics/labs/mantis/assistant/workflows")
+CATALOG = ROOT / "fixture-catalog"
+DEFS = ROOT / "definitions"
+LAB = ROOT / "laboratory"
+LINTER = ROOT / "linter"
+SIM = ROOT / "simulator"
+
+CLOCK = "2026-08-21T12:00:00Z"
+EXPIRES = "2027-08-21T00:00:00Z"
+
+
+def canonical(obj: object) -> bytes:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode()
+
+
+def sha256(obj: object) -> str:
+    return hashlib.sha256(canonical(obj)).hexdigest()
+
+
+def write(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, indent=2) + "\n")
+
+
+def definition(
+    *,
+    definition_id: str,
+    version: str,
+    description: str,
+    capability: str,
+    author: str,
+    graph: list,
+    primitives: list,
+) -> dict:
+    body = {
+        "schemaVersion": "1.0.0",
+        "kind": "DynamicWorkflowDefinition",
+        "definitionId": definition_id,
+        "version": version,
+        "description": description,
+        "capabilityClass": capability,
+        "author": author,
+        "expiresAt": EXPIRES,
+        "inputSchema": {
+            "type": "object",
+            "properties": {"topic": {"type": "string"}},
+            "required": ["topic"],
+        },
+        "outputSchema": {
+            "type": "object",
+            "properties": {"result": {"type": "string"}},
+            "required": ["result"],
+        },
+        "stateSchema": {"type": "object"},
+        "graph": graph,
+        "referencedPrimitives": primitives,
+        "prohibited": {
+            "deviceCommand": True,
+            "browserMutation": True,
+            "secrets": True,
+            "directCanonicalMutation": True,
+            "specimenDbWrite": True,
+        },
+    }
+    digest = sha256({k: v for k, v in body.items()})
+    body["digest"] = digest
+    return body
+
+
+def primitive(kind: str, ident: str, version: str, assay_id: str) -> dict:
+    return {"kind": kind, "id": ident, "version": version, "assayId": assay_id}
+
+
+def assay(
+    *,
+    assay_id: str,
+    tool_id: str,
+    category: str,
+    read: bool,
+    write: bool,
+    external_mutation: bool,
+    device_impact: bool,
+    idempotent: bool,
+    llm_exposed: bool,
+    secrets: bool,
+    disposition: str,
+    allowed_agents: list[str],
+) -> dict:
+    identity_core = {
+        "id": tool_id,
+        "version": "1.0.0",
+        "provider": "mantis-workflow-lab-fixture",
+        "license": "UNLICENSED-fixture",
+    }
+    identity = {**identity_core, "digest": sha256(identity_core)}
+    return {
+        "schemaVersion": "1.0.0",
+        "kind": "ToolAssayRecord",
+        "assayId": assay_id,
+        "recordedAt": CLOCK,
+        "identity": identity,
+        "contract": {
+            "inputSchemaRef": f"assistant/workflows/fixture-catalog/assays/{tool_id}.input.json",
+            "outputSchemaRef": f"assistant/workflows/fixture-catalog/assays/{tool_id}.output.json",
+            "errors": ["not-found", "timeout"],
+            "timeoutMs": 2000,
+            "streaming": False,
+            "determinism": "deterministic" if idempotent else "non-deterministic",
+        },
+        "effects": {
+            "read": read,
+            "write": write,
+            "execute": False,
+            "externalMutation": external_mutation,
+            "deviceImpact": device_impact,
+            "rollback": "none",
+        },
+        "authority": {
+            "actor": "assistant",
+            "category": category,
+            "allowedModes": ["care", "research", "review", "observe"],
+            "allowedAgents": allowed_agents,
+            "llmExposed": llm_exposed,
+        },
+        "data": {
+            "privacyClass": "secret" if secrets else "public",
+            "retention": "run-scoped",
+            "networkEgress": False,
+            "secrets": secrets,
+            "location": "none",
+            "media": "none",
+        },
+        "behavior": {
+            "idempotent": idempotent,
+            "retrySafe": idempotent,
+            "cancellation": "safe" if idempotent else "unsafe",
+            "concurrency": "safe" if idempotent else "unknown",
+        },
+        "evidence": {
+            "sourceClassProduced": "external-source" if read else "none",
+            "provenanceFields": ["sourceId"],
+            "simulator": True,
+            "fixtures": [f"assistant/workflows/fixture-catalog/assays/{tool_id}.json"],
+        },
+        "safety": {
+            "staleStatePolicy": "fail-closed" if device_impact else "not-applicable",
+            "approvalTier": "never" if device_impact else "none",
+            "physicalInterlocks": device_impact,
+        },
+        "verification": {
+            "staticLint": True,
+            "sandboxSmoke": True,
+            "negativeTests": ["unknown-id-denied"],
+            "adversarialTests": ["prompt-injection-ignored"],
+        },
+        "review": {
+            "assessor": "tool-assessor-fixture",
+            "independentReviewer": "adversarial-reviewer-fixture",
+            "disposition": disposition,
+            "expiry": EXPIRES,
+            "reAssayTriggers": ["schema-change", "provider-version-change"],
+        },
+    }
+
+
+def admit_tool(tool_id: str, assay_id: str, state: str) -> dict:
+    return {
+        "schemaVersion": "1.0.0",
+        "kind": "ToolAdmission",
+        "admissionId": f"admit-tool.{tool_id}.v1",
+        "toolId": tool_id,
+        "assayId": assay_id,
+        "state": state,
+        "admittedAt": CLOCK,
+        "expiresAt": EXPIRES,
+        "assessor": "tool-assessor-fixture",
+        "reviewer": "independent-reviewer-fixture",
+        "notes": "A3 fixture. Assessor did not admit this record.",
+    }
+
+
+def envelope(*, definition_id: str, capability: str, extra: dict | None = None) -> dict:
+    body = {
+        "kind": "LaboratoryEnvelope",
+        "schemaVersion": "1.0.0",
+        "definitionId": definition_id,
+        "requestContextSchema": {
+            "type": "object",
+            "properties": {"principalId": {"type": "string"}},
+            "required": ["principalId"],
+        },
+        "budgets": {
+            "wallTimeMs": 8000,
+            "maxSteps": 8,
+            "maxParallel": 2,
+            "maxLoopIterations": 4,
+            "maxTokens": 4000,
+            "maxToolCalls": 8,
+            "maxCostUsd": 0.05,
+            "cancellable": True,
+        },
+        "sleepPolicy": {"allowedSignals": ["reminder", "revalidation"]},
+        "capabilityClass": capability,
+        "mastraCorePin": "1.61.0",
+    }
+    if extra:
+        body.update(extra)
+    return body
+
+
+CARE = primitive("tool", "care-source-read", "1.0.0", "assay.care-source-read.v1")
+OBS = primitive("tool", "observation-packet-read", "1.0.0", "assay.observation-packet-read.v1")
+TRIAGE = primitive("tool", "research-triage-read", "1.0.0", "assay.research-triage-read.v1")
+EVIDENCE = primitive(
+    "tool", "evidence-completeness-read", "1.0.0", "assay.evidence-completeness-read.v1"
+)
+REMINDER = primitive("tool", "reminder-plan-read", "1.0.0", "assay.reminder-plan-read.v1")
+
+
+def main() -> None:
+    for path in (CATALOG / "positive", CATALOG / "negative", CATALOG / "assays", DEFS, LAB / "envelopes", LINTER, SIM):
+        path.mkdir(parents=True, exist_ok=True)
+
+    assays = {
+        "observation-packet-read": assay(
+            assay_id="assay.observation-packet-read.v1",
+            tool_id="observation-packet-read",
+            category="read-private",
+            read=True,
+            write=False,
+            external_mutation=False,
+            device_impact=False,
+            idempotent=True,
+            llm_exposed=True,
+            secrets=False,
+            disposition="admitted-read",
+            allowed_agents=["observation-extractor", "workflow-composer"],
+        ),
+        "research-triage-read": assay(
+            assay_id="assay.research-triage-read.v1",
+            tool_id="research-triage-read",
+            category="read-public",
+            read=True,
+            write=False,
+            external_mutation=False,
+            device_impact=False,
+            idempotent=True,
+            llm_exposed=True,
+            secrets=False,
+            disposition="admitted-read",
+            allowed_agents=["care-source", "workflow-composer"],
+        ),
+        "evidence-completeness-read": assay(
+            assay_id="assay.evidence-completeness-read.v1",
+            tool_id="evidence-completeness-read",
+            category="draft-local",
+            read=True,
+            write=False,
+            external_mutation=False,
+            device_impact=False,
+            idempotent=True,
+            llm_exposed=True,
+            secrets=False,
+            disposition="admitted-read",
+            allowed_agents=["evidence-curator", "workflow-composer"],
+        ),
+        "reminder-plan-read": assay(
+            assay_id="assay.reminder-plan-read.v1",
+            tool_id="reminder-plan-read",
+            category="draft-local",
+            read=True,
+            write=False,
+            external_mutation=False,
+            device_impact=False,
+            idempotent=True,
+            llm_exposed=True,
+            secrets=False,
+            disposition="admitted-read",
+            allowed_agents=["care-source", "workflow-composer"],
+        ),
+        "canonical-event-append": assay(
+            assay_id="assay.canonical-event-append.v1",
+            tool_id="canonical-event-append",
+            category="external-write",
+            read=False,
+            write=True,
+            external_mutation=True,
+            device_impact=False,
+            idempotent=False,
+            llm_exposed=True,
+            secrets=False,
+            disposition="quarantined",
+            allowed_agents=["workflow-composer"],
+        ),
+    }
+
+    for tool_id, record in assays.items():
+        write(CATALOG / "assays" / f"{tool_id}.json", record)
+        write(
+            CATALOG / "assays" / f"{tool_id}.input.json",
+            {"type": "object", "properties": {"topic": {"type": "string"}}},
+        )
+        write(
+            CATALOG / "assays" / f"{tool_id}.output.json",
+            {"type": "object", "properties": {"result": {"type": "string"}}},
+        )
+        state = (
+            "quarantined"
+            if tool_id == "canonical-event-append"
+            else "admitted-read"
+        )
+        write(
+            CATALOG / "assays" / f"{tool_id}.admission.json",
+            admit_tool(tool_id, record["assayId"], state),
+        )
+
+    positives = [
+        (
+            "care-source-comparison",
+            "P0",
+            "Compare two admitted care-source reads and summarize disagreements.",
+            [
+                {"type": "tool", "id": "src-a", "toolId": "care-source-read"},
+                {"type": "tool", "id": "src-b", "toolId": "care-source-read"},
+                {"type": "mapping", "id": "compare", "mapping": "zip-summarize"},
+            ],
+            [CARE],
+        ),
+        (
+            "feeding-removal-reminder",
+            "P1",
+            "Plan a feeding-removal reminder. Sleep emits a reminder signal only.",
+            [
+                {"type": "tool", "id": "sources", "toolId": "care-source-read"},
+                {"type": "tool", "id": "plan", "toolId": "reminder-plan-read"},
+                {
+                    "type": "mapping",
+                    "id": "wait",
+                    "mapping": "sleep",
+                    "durationMs": 3_600_000,
+                    "signal": "reminder",
+                },
+            ],
+            [CARE, REMINDER],
+        ),
+        (
+            "observation-packet",
+            "P1",
+            "Assemble an observation packet from selected media annotations.",
+            [
+                {"type": "tool", "id": "read-obs", "toolId": "observation-packet-read"},
+                {"type": "mapping", "id": "assemble", "mapping": "assemble-packet"},
+            ],
+            [OBS],
+        ),
+        (
+            "research-source-triage",
+            "P2",
+            "Triage reviewed research sources for a care question.",
+            [
+                {"type": "tool", "id": "lookup", "toolId": "research-triage-read"},
+                {"type": "mapping", "id": "rank", "mapping": "rank-sources"},
+            ],
+            [TRIAGE],
+        ),
+        (
+            "evidence-draft-completeness",
+            "P1",
+            "Check an evidence draft for completeness. Does not write SpecimenDB.",
+            [
+                {"type": "tool", "id": "check", "toolId": "evidence-completeness-read"},
+            ],
+            [EVIDENCE],
+        ),
+    ]
+
+    catalog_cases = []
+    for slug, capability, description, graph, primitives in positives:
+        defn = definition(
+            definition_id=f"wf.{slug}",
+            version="1.0.0",
+            description=description,
+            capability=capability,
+            author="workflow-composer-fixture",
+            graph=graph,
+            primitives=primitives,
+        )
+        write(DEFS / f"{slug}.v1.json", defn)
+        write(LAB / "envelopes" / f"{slug}.v1.json", envelope(definition_id=defn["definitionId"], capability=capability))
+        write(
+            CATALOG / "positive" / f"{slug}.v1.json",
+            {
+                "id": f"{slug}.v1",
+                "expect": "admit",
+                "definition": f"assistant/workflows/definitions/{slug}.v1.json",
+                "envelope": f"assistant/workflows/laboratory/envelopes/{slug}.v1.json",
+                "composer": "workflow-composer-fixture",
+                "assessor": "tool-assessor-fixture",
+                "adversary": "adversarial-reviewer-fixture",
+                "governor": "human-governor-fixture",
+            },
+        )
+        catalog_cases.append({"id": f"{slug}.v1", "expect": "admit"})
+
+    negatives = []
+
+    device = definition(
+        definition_id="wf.malicious-device-command",
+        version="1.0.0",
+        description="Malicious graph that attempts a device command.",
+        capability="P0",
+        author="workflow-composer-fixture",
+        graph=[{"type": "tool", "id": "move", "toolId": "device-command"}],
+        primitives=[primitive("tool", "device-command", "0.0.0", "assay.missing")],
+    )
+    negatives.append(("device-command-graph", device, "reject", "/graph/0/toolId"))
+
+    hidden = definition(
+        definition_id="wf.hidden-unassayed-mcp",
+        version="1.0.0",
+        description="References an unassayed MCP tool.",
+        capability="P2",
+        author="workflow-composer-fixture",
+        graph=[{"type": "tool", "id": "browse", "toolId": "mcp.hidden-browser"}],
+        primitives=[primitive("tool", "mcp.hidden-browser", "1.0.0", "assay.missing")],
+    )
+    negatives.append(("hidden-unassayed-mcp", hidden, "reject", "/graph/0/toolId"))
+
+    unbounded = definition(
+        definition_id="wf.unbounded-loop",
+        version="1.0.0",
+        description="Foreach without a bound explodes cost.",
+        capability="P0",
+        author="workflow-composer-fixture",
+        graph=[
+            {"type": "tool", "id": "lookup", "toolId": "care-source-read"},
+            {"type": "mapping", "id": "loop", "mapping": "foreach"},
+        ],
+        primitives=[CARE],
+    )
+    negatives.append(("unbounded-loop", unbounded, "reject", "/graph/1"))
+
+    replay = definition(
+        definition_id="wf.replay-nominal-write",
+        version="1.0.0",
+        description="Replay-unsafe canonical write.",
+        capability="P1",
+        author="workflow-composer-fixture",
+        graph=[{"type": "tool", "id": "append", "toolId": "canonical-event-append"}],
+        primitives=[
+            primitive(
+                "tool",
+                "canonical-event-append",
+                "1.0.0",
+                "assay.canonical-event-append.v1",
+            )
+        ],
+    )
+    negatives.append(("replay-nominal-write", replay, "reject", "/graph/0/toolId"))
+
+    self_admit = definition(
+        definition_id="wf.composer-self-admit",
+        version="1.0.0",
+        description="Valid P0 graph used to prove composer cannot admit own output.",
+        capability="P0",
+        author="workflow-composer-fixture",
+        graph=[{"type": "tool", "id": "lookup", "toolId": "care-source-read"}],
+        primitives=[CARE],
+    )
+    negatives.append(("composer-self-admit", self_admit, "reject-identity", "/reviewer"))
+
+    for slug, defn, expect, path in negatives:
+        write(DEFS / f"{slug}.v1.json", defn)
+        extra = {}
+        if slug == "unbounded-loop":
+            extra = {
+                "budgets": {
+                    "wallTimeMs": 8_000,
+                    "maxSteps": 8,
+                    "maxParallel": 2,
+                    "maxLoopIterations": 4,
+                    "maxTokens": 4_000,
+                    "maxToolCalls": 8,
+                    "maxCostUsd": 0.05,
+                    "cancellable": True,
+                }
+            }
+        write(
+            LAB / "envelopes" / f"{slug}.v1.json",
+            envelope(definition_id=defn["definitionId"], capability=defn["capabilityClass"], extra=extra),
+        )
+        write(
+            CATALOG / "negative" / f"{slug}.v1.json",
+            {
+                "id": f"{slug}.v1",
+                "expect": expect,
+                "definition": f"assistant/workflows/definitions/{slug}.v1.json",
+                "envelope": f"assistant/workflows/laboratory/envelopes/{slug}.v1.json",
+                "composer": "workflow-composer-fixture",
+                "assessor": "tool-assessor-fixture",
+                "adversary": "adversarial-reviewer-fixture",
+                "governor": "workflow-composer-fixture" if slug == "composer-self-admit" else "human-governor-fixture",
+                "diagnosticPath": path,
+            },
+        )
+        catalog_cases.append({"id": f"{slug}.v1", "expect": expect})
+
+    write(
+        CATALOG / "catalog.json",
+        {
+            "kind": "WorkflowFixtureCatalog",
+            "schemaVersion": "1.0.0",
+            "mastraCorePin": "1.61.0",
+            "clock": CLOCK,
+            "a0Owned": [
+                "assistant/workflows/definitions/research-summary.v1.json",
+                "assistant/workflows/admissions/research-summary.v1.json",
+            ],
+            "cases": catalog_cases,
+        },
+    )
+
+    snapshot_tools = [
+        {
+            "id": "care-source-read",
+            "version": "1.0.0",
+            "assayId": "assay.care-source-read.v1",
+            "admission": "admitted-read",
+            "source": "imported-a0",
+        },
+        {
+            "id": "supply-transit-read",
+            "version": "1.0.0",
+            "assayId": "assay.supply-transit-read.v1",
+            "admission": "admitted-read",
+            "source": "imported-a0",
+        },
+        {
+            "id": "observation-packet-read",
+            "version": "1.0.0",
+            "assayId": "assay.observation-packet-read.v1",
+            "admission": "admitted-read",
+            "source": "fixture-catalog",
+        },
+        {
+            "id": "research-triage-read",
+            "version": "1.0.0",
+            "assayId": "assay.research-triage-read.v1",
+            "admission": "admitted-read",
+            "source": "fixture-catalog",
+        },
+        {
+            "id": "evidence-completeness-read",
+            "version": "1.0.0",
+            "assayId": "assay.evidence-completeness-read.v1",
+            "admission": "admitted-read",
+            "source": "fixture-catalog",
+        },
+        {
+            "id": "reminder-plan-read",
+            "version": "1.0.0",
+            "assayId": "assay.reminder-plan-read.v1",
+            "admission": "admitted-read",
+            "source": "fixture-catalog",
+        },
+    ]
+    snapshot = {
+        "kind": "PrimitiveCapabilitySnapshot",
+        "schemaVersion": "1.0.0",
+        "mastraCorePin": "1.61.0",
+        "recordedAt": CLOCK,
+        "tools": snapshot_tools,
+        "forbidden": ["device-command", "admin", "specimen-db-write", "live-catalog-write", "browser-mutate"],
+        "mappingKinds": ["zip-summarize", "sleep", "conditional", "foreach", "parallel", "assemble-packet", "rank-sources"],
+        "sleepSignals": ["reminder", "revalidation"],
+    }
+    snapshot["digest"] = sha256({k: v for k, v in snapshot.items() if k != "digest"})
+    write(LAB / "primitive-snapshot.json", snapshot)
+
+    write(
+        LINTER / "rules.json",
+        {
+            "kind": "WorkflowStaticLintRules",
+            "schemaVersion": "1.0.0",
+            "maxCapability": "P2",
+            "forbiddenToolIds": [
+                "device-command",
+                "admin",
+                "specimen-db-write",
+                "live-catalog-write",
+                "browser-mutate",
+            ],
+            "forbiddenCategories": ["device-command", "admin", "external-write", "device-intent"],
+            "requireAssayClosed": True,
+            "requireAdmittedReadOrIdempotent": True,
+            "sleepSignals": ["reminder", "revalidation"],
+            "requireLoopBound": True,
+            "requireParallelBound": True,
+            "denySecrets": True,
+            "denyReplayUnsafeWrites": True,
+            "distinctIdentities": {
+                "composerCannotAdmit": True,
+                "assessorCannotAdmit": True,
+                "adversaryCannotAdmit": True,
+            },
+        },
+    )
+
+    write(
+        SIM / "harness.json",
+        {
+            "kind": "WorkflowSimulatorHarness",
+            "schemaVersion": "1.0.0",
+            "clock": CLOCK,
+            "sideEffects": "disabled",
+            "replay": "disabled-for-external-mutation",
+            "notes": "Deterministic in-process walk of the JSON graph. Does not call Mastra or CopilotKit.",
+        },
+    )
+
+    print("emitted", len(list(DEFS.glob("*.json"))), "definitions")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/scripts/emit-fixtures.py
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/scripts/emit-fixtures.py
@@ -7,7 +7,7 @@ import hashlib
 import json
 from pathlib import Path
 
-ROOT = Path("/workspace/projects/biomemetics/labs/mantis/assistant/workflows")
+ROOT = Path(__file__).resolve().parents[4] / "assistant" / "workflows"
 CATALOG = ROOT / "fixture-catalog"
 DEFS = ROOT / "definitions"
 LAB = ROOT / "laboratory"

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/catalog.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/catalog.ts
@@ -1,0 +1,312 @@
+import { readFile, readdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import { pins } from "./pins.ts";
+import {
+  defaultMantisRoot,
+  defaultWorkflowsRoot,
+  resolveUnderRoot,
+} from "./paths.ts";
+import type {
+  Budgets,
+  CatalogCase,
+  SleepPolicy,
+  WorkflowDefinitionJson,
+} from "./types.ts";
+
+export const FROZEN_CLOCK = "2026-08-21T12:00:00Z";
+
+export interface ToolAssayRecord {
+  readonly assayId: string;
+  readonly identity: { readonly id: string; readonly version: string };
+  readonly effects: {
+    readonly read: boolean;
+    readonly write: boolean;
+    readonly externalMutation: boolean;
+    readonly deviceImpact: boolean;
+  };
+  readonly behavior: {
+    readonly idempotent: boolean;
+  };
+  readonly authority: {
+    readonly category: string;
+  };
+  readonly review: {
+    readonly disposition: string;
+  };
+  readonly data: {
+    readonly secrets: boolean;
+  };
+}
+
+export interface ToolAdmissionRecord {
+  readonly admissionId: string;
+  readonly toolId: string;
+  readonly assayId: string;
+  readonly state: string;
+}
+
+export interface PrimitiveToolEntry {
+  readonly id: string;
+  readonly version: string;
+  readonly assayId: string;
+  readonly admission: string;
+  readonly source: string;
+}
+
+export interface PrimitiveSnapshot {
+  readonly tools: readonly PrimitiveToolEntry[];
+  readonly forbidden: readonly string[];
+  readonly mappingKinds: readonly string[];
+  readonly sleepSignals: readonly string[];
+}
+
+export interface EnvelopeJson {
+  readonly kind: "LaboratoryEnvelope";
+  readonly definitionId: string;
+  readonly budgets: Budgets;
+  readonly requestContextSchema: object;
+  readonly sleepPolicy: SleepPolicy;
+  readonly capabilityClass: string;
+}
+
+export interface CatalogResources {
+  readonly mantisRoot: string;
+  readonly workflowsRoot: string;
+  readonly clock: string;
+  readonly pins: typeof pins;
+  readonly snapshot: PrimitiveSnapshot;
+  readonly forbiddenToolIds: ReadonlySet<string>;
+  readonly lintRules: {
+    readonly forbiddenToolIds: readonly string[];
+    readonly sleepSignals: readonly string[];
+    readonly requireLoopBound: boolean;
+    readonly requireParallelBound: boolean;
+    readonly denyReplayUnsafeWrites: boolean;
+  };
+  readonly assays: ReadonlyMap<string, ToolAssayRecord>;
+  readonly admissions: ReadonlyMap<string, ToolAdmissionRecord>;
+  readonly catalogCases: readonly CatalogCase[];
+  readJson(relativeOrAbs: string): Promise<unknown>;
+  readDefinition(relativePath: string): Promise<WorkflowDefinitionJson>;
+  readEnvelope(relativePath: string): Promise<EnvelopeJson>;
+  readCaseFile(id: string): Promise<CatalogCase>;
+}
+
+async function readJsonFile(filePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(filePath, "utf8")) as unknown;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asAssay(value: unknown): ToolAssayRecord {
+  if (!isObject(value)) {
+    throw new Error("assay must be object");
+  }
+  return value as unknown as ToolAssayRecord;
+}
+
+function asAdmission(value: unknown): ToolAdmissionRecord {
+  if (!isObject(value)) {
+    throw new Error("admission must be object");
+  }
+  return value as unknown as ToolAdmissionRecord;
+}
+
+export async function openCatalogResources(options: {
+  readonly root?: string | URL;
+  readonly now?: () => Date;
+}): Promise<CatalogResources> {
+  const mantisRoot =
+    options.root === undefined
+      ? defaultMantisRoot()
+      : typeof options.root === "string"
+        ? path.resolve(options.root)
+        : path.resolve(
+            typeof options.root === "object" && "pathname" in options.root
+              ? decodeURIComponent(
+                  new URL(options.root.href).pathname,
+                )
+              : String(options.root),
+          );
+
+  // Accept either mantis root or workflows root.
+  const workflowsRoot = existsSync(
+    path.join(mantisRoot, "assistant", "workflows"),
+  )
+    ? path.join(mantisRoot, "assistant", "workflows")
+    : existsSync(path.join(mantisRoot, "fixture-catalog"))
+      ? mantisRoot
+      : defaultWorkflowsRoot(defaultMantisRoot());
+
+  const resolvedMantis =
+    path.basename(path.dirname(workflowsRoot)) === "assistant"
+      ? path.dirname(path.dirname(workflowsRoot))
+      : defaultMantisRoot();
+
+  const snapshot = (await readJsonFile(
+    path.join(workflowsRoot, "laboratory", "primitive-snapshot.json"),
+  )) as PrimitiveSnapshot;
+
+  const forbiddenDoc = (await readJsonFile(
+    path.join(
+      workflowsRoot,
+      "laboratory",
+      "imported-a0",
+      "forbidden-tools.json",
+    ),
+  )) as { tools: { id: string }[] };
+
+  const lintRules = (await readJsonFile(
+    path.join(workflowsRoot, "linter", "rules.json"),
+  )) as CatalogResources["lintRules"] & Record<string, unknown>;
+
+  const catalogIndex = (await readJsonFile(
+    path.join(workflowsRoot, "fixture-catalog", "catalog.json"),
+  )) as { clock: string; cases: { id: string; expect: string }[] };
+
+  const assays = new Map<string, ToolAssayRecord>();
+  const admissions = new Map<string, ToolAdmissionRecord>();
+
+  const importedAssays = [
+    ["assay.care-source-read.v1", "assay.care-source-read.json"],
+    ["assay.supply-transit-read.v1", "assay.supply-transit-read.json"],
+  ] as const;
+  for (const [assayId, file] of importedAssays) {
+    const assay = asAssay(
+      await readJsonFile(
+        path.join(workflowsRoot, "laboratory", "imported-a0", file),
+      ),
+    );
+    assays.set(assayId, assay);
+    assays.set(assay.identity.id, assay);
+  }
+
+  const importedAdmits = [
+    ["care-source-read", "admit.care-source-read.json"],
+    ["supply-transit-read", "admit.supply-transit-read.json"],
+  ] as const;
+  for (const [toolId, file] of importedAdmits) {
+    const admission = asAdmission(
+      await readJsonFile(
+        path.join(workflowsRoot, "laboratory", "imported-a0", file),
+      ),
+    );
+    admissions.set(toolId, admission);
+    admissions.set(admission.assayId, admission);
+  }
+
+  const assayDir = path.join(workflowsRoot, "fixture-catalog", "assays");
+  for (const name of await readdir(assayDir)) {
+    if (!name.endsWith(".json")) continue;
+    if (
+      name.endsWith(".input.json") ||
+      name.endsWith(".output.json") ||
+      name.endsWith(".admission.json")
+    ) {
+      continue;
+    }
+    const assay = asAssay(await readJsonFile(path.join(assayDir, name)));
+    assays.set(assay.assayId, assay);
+    assays.set(assay.identity.id, assay);
+    const admissionPath = path.join(
+      assayDir,
+      name.replace(/\.json$/, ".admission.json"),
+    );
+    if (existsSync(admissionPath)) {
+      const admission = asAdmission(await readJsonFile(admissionPath));
+      admissions.set(admission.toolId, admission);
+      admissions.set(admission.assayId, admission);
+    }
+  }
+
+  // Prefer live assistant/tools assays if present.
+  const liveTools = path.join(resolvedMantis, "assistant", "tools");
+  if (existsSync(liveTools)) {
+    // Live tree is preferred when present; fixtures already cover A3.
+  }
+
+  const caseFiles: CatalogCase[] = [];
+  for (const entry of catalogIndex.cases) {
+    const positive = path.join(
+      workflowsRoot,
+      "fixture-catalog",
+      "positive",
+      `${entry.id}.json`,
+    );
+    const negative = path.join(
+      workflowsRoot,
+      "fixture-catalog",
+      "negative",
+      `${entry.id}.json`,
+    );
+    const file = existsSync(positive)
+      ? positive
+      : existsSync(negative)
+        ? negative
+        : null;
+    if (!file) {
+      throw new Error(`catalog case file missing for ${entry.id}`);
+    }
+    caseFiles.push((await readJsonFile(file)) as CatalogCase);
+  }
+
+  const forbiddenToolIds = new Set<string>([
+    ...forbiddenDoc.tools.map((t) => t.id),
+    ...lintRules.forbiddenToolIds,
+    ...snapshot.forbidden,
+  ]);
+
+  const resolvePath = (relativePath: string): string => {
+    if (path.isAbsolute(relativePath)) return relativePath;
+    if (relativePath.startsWith("assistant/workflows/")) {
+      return resolveUnderRoot(workflowsRoot, relativePath);
+    }
+    if (relativePath.startsWith("assistant/")) {
+      return path.join(resolvedMantis, relativePath);
+    }
+    return path.join(workflowsRoot, relativePath);
+  };
+
+  return {
+    mantisRoot: resolvedMantis,
+    workflowsRoot,
+    clock: catalogIndex.clock || FROZEN_CLOCK,
+    pins,
+    snapshot,
+    forbiddenToolIds,
+    lintRules: {
+      forbiddenToolIds: lintRules.forbiddenToolIds,
+      sleepSignals: lintRules.sleepSignals,
+      requireLoopBound: lintRules.requireLoopBound,
+      requireParallelBound: lintRules.requireParallelBound,
+      denyReplayUnsafeWrites: lintRules.denyReplayUnsafeWrites,
+    },
+    assays,
+    admissions,
+    catalogCases: caseFiles,
+    async readJson(relativeOrAbs: string): Promise<unknown> {
+      return readJsonFile(resolvePath(relativeOrAbs));
+    },
+    async readDefinition(
+      relativePath: string,
+    ): Promise<WorkflowDefinitionJson> {
+      return (await readJsonFile(
+        resolvePath(relativePath),
+      )) as WorkflowDefinitionJson;
+    },
+    async readEnvelope(relativePath: string): Promise<EnvelopeJson> {
+      return (await readJsonFile(resolvePath(relativePath))) as EnvelopeJson;
+    },
+    async readCaseFile(id: string): Promise<CatalogCase> {
+      const found = caseFiles.find((c) => c.id === id);
+      if (!found) {
+        throw new Error(`unknown catalog case ${id}`);
+      }
+      return found;
+    },
+  };
+}

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/catalog.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/catalog.ts
@@ -133,7 +133,6 @@ export async function openCatalogResources(options: {
               : String(options.root),
           );
 
-  // Accept either mantis root or workflows root.
   const workflowsRoot = existsSync(
     path.join(mantisRoot, "assistant", "workflows"),
   )
@@ -221,12 +220,6 @@ export async function openCatalogResources(options: {
       admissions.set(admission.toolId, admission);
       admissions.set(admission.assayId, admission);
     }
-  }
-
-  // Prefer live assistant/tools assays if present.
-  const liveTools = path.join(resolvedMantis, "assistant", "tools");
-  if (existsSync(liveTools)) {
-    // Live tree is preferred when present; fixtures already cover A3.
   }
 
   const caseFiles: CatalogCase[] = [];

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/cli.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/cli.ts
@@ -1,6 +1,8 @@
-import { openLaboratory } from "./laboratory.ts";
+import { openLaboratory } from './laboratory.ts';
 
 const lab = await openLaboratory();
 const report = await lab.runCatalog();
 process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
-process.exitCode = report.ok ? 0 : 1;
+if (!report.ok) {
+  process.exitCode = 1;
+}

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/cli.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/cli.ts
@@ -1,0 +1,6 @@
+import { openLaboratory } from "./laboratory.ts";
+
+const lab = await openLaboratory();
+const report = await lab.runCatalog();
+process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+process.exitCode = report.ok ? 0 : 1;

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/digest.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/digest.ts
@@ -1,0 +1,36 @@
+import { createHash } from "node:crypto";
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(value, (_key, v: unknown) => {
+    if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+      const obj = v as Record<string, unknown>;
+      const sorted: Record<string, unknown> = {};
+      for (const key of Object.keys(obj).sort()) {
+        sorted[key] = obj[key];
+      }
+      return sorted;
+    }
+    return v;
+  });
+}
+
+export function sha256Hex(payload: string | Uint8Array): string {
+  return createHash("sha256").update(payload).digest("hex");
+}
+
+/** A3 content digest: sha256 of canonical JSON with `digest` omitted. */
+export function contentDigest(definition: Record<string, unknown>): string {
+  const { digest: _omit, ...rest } = definition;
+  return sha256Hex(canonicalJson(rest));
+}
+
+export function signatureDigest(parts: {
+  readonly admissionId: string;
+  readonly digest: string;
+  readonly reviewer: string;
+  readonly admittedAt: string;
+}): string {
+  return sha256Hex(
+    `${parts.admissionId}|${parts.digest}|${parts.reviewer}|${parts.admittedAt}`,
+  );
+}

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/digest.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/digest.ts
@@ -18,7 +18,6 @@ export function sha256Hex(payload: string | Uint8Array): string {
   return createHash("sha256").update(payload).digest("hex");
 }
 
-/** A3 content digest: sha256 of canonical JSON with `digest` omitted. */
 export function contentDigest(definition: Record<string, unknown>): string {
   const { digest: _omit, ...rest } = definition;
   return sha256Hex(canonicalJson(rest));

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/identities.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/identities.ts
@@ -1,0 +1,92 @@
+export const ComposerBrand = Symbol("Composer");
+export const AssessorBrand = Symbol("Assessor");
+export const AdversarialBrand = Symbol("Adversarial");
+export const HumanGovernorBrand = Symbol("HumanGovernor");
+export const DraftBrand = Symbol("Draft");
+export const SignedBrand = Symbol("Signed");
+export const ActiveBrand = Symbol("Active");
+export const RevokedBrand = Symbol("Revoked");
+
+export type Composer = {
+  readonly [ComposerBrand]: true;
+  readonly id: string;
+  readonly role: "composer";
+};
+
+export type Assessor = {
+  readonly [AssessorBrand]: true;
+  readonly id: string;
+  readonly role: "assessor";
+};
+
+export type AdversarialReviewer = {
+  readonly [AdversarialBrand]: true;
+  readonly id: string;
+  readonly role: "adversarial-reviewer";
+};
+
+export type HumanGovernor = {
+  readonly [HumanGovernorBrand]: true;
+  readonly id: string;
+  readonly role: "human";
+};
+
+const minted = new WeakSet<object>();
+
+function mint<T extends object>(value: T): T {
+  minted.add(value);
+  return value;
+}
+
+export function isMintedIdentity(value: object): boolean {
+  return minted.has(value);
+}
+
+export function asComposer(id: string): Composer {
+  if (id.trim() === "") {
+    throw new Error("composer id required");
+  }
+  return mint({ id, role: "composer", [ComposerBrand]: true as const });
+}
+
+export function asAssessor(id: string): Assessor {
+  if (id.trim() === "") {
+    throw new Error("assessor id required");
+  }
+  return mint({ id, role: "assessor", [AssessorBrand]: true as const });
+}
+
+export function asAdversarialReviewer(id: string): AdversarialReviewer {
+  if (id.trim() === "") {
+    throw new Error("adversarial reviewer id required");
+  }
+  return mint({
+    id,
+    role: "adversarial-reviewer",
+    [AdversarialBrand]: true as const,
+  });
+}
+
+export function asHumanGovernor(id: string): HumanGovernor {
+  if (id.trim() === "") {
+    throw new Error("human governor id required");
+  }
+  return mint({ id, role: "human", [HumanGovernorBrand]: true as const });
+}
+
+export function assertHumanGovernor(
+  value: unknown,
+): asserts value is HumanGovernor {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !isMintedIdentity(value) ||
+    !("role" in value) ||
+    (value as { role: string }).role !== "human"
+  ) {
+    throw Object.assign(new Error("human governor identity required"), {
+      code: "identity-required",
+      path: "/reviewer",
+    });
+  }
+}

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/index.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/index.ts
@@ -1,34 +1,9 @@
-export { pins } from "./pins.ts";
+export { pins } from './pins.ts';
+export { openLaboratory } from './laboratory.ts';
 export {
   asComposer,
   asAssessor,
   asAdversarialReviewer,
   asHumanGovernor,
-} from "./identities.ts";
-export type {
-  Composer,
-  Assessor,
-  AdversarialReviewer,
-  HumanGovernor,
-} from "./identities.ts";
-export { contentDigest, canonicalJson, sha256Hex, signatureDigest } from "./digest.ts";
-export { openLaboratory } from "./laboratory.ts";
-export type { Laboratory } from "./laboratory.ts";
-export type {
-  DraftDefinition,
-  Evaluation,
-  ApprovalPacket,
-  SignedVersion,
-  ActiveAdmission,
-  RevokedAdmission,
-  WorkflowAdmissionWire,
-  WorkflowRunReceipt,
-  Diagnostic,
-  DiagnosticPath,
-  CatalogReport,
-  LaboratoryOptions,
-  CapabilityClass,
-  Budgets,
-  AdmissionRecord,
-  Stage,
-} from "./types.ts";
+} from './identities.ts';
+export { contentDigest, signatureDigest } from './digest.ts';

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/index.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/index.ts
@@ -1,0 +1,34 @@
+export { pins } from "./pins.ts";
+export {
+  asComposer,
+  asAssessor,
+  asAdversarialReviewer,
+  asHumanGovernor,
+} from "./identities.ts";
+export type {
+  Composer,
+  Assessor,
+  AdversarialReviewer,
+  HumanGovernor,
+} from "./identities.ts";
+export { contentDigest, canonicalJson, sha256Hex, signatureDigest } from "./digest.ts";
+export { openLaboratory } from "./laboratory.ts";
+export type { Laboratory } from "./laboratory.ts";
+export type {
+  DraftDefinition,
+  Evaluation,
+  ApprovalPacket,
+  SignedVersion,
+  ActiveAdmission,
+  RevokedAdmission,
+  WorkflowAdmissionWire,
+  WorkflowRunReceipt,
+  Diagnostic,
+  DiagnosticPath,
+  CatalogReport,
+  LaboratoryOptions,
+  CapabilityClass,
+  Budgets,
+  AdmissionRecord,
+  Stage,
+} from "./types.ts";

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/laboratory.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/laboratory.ts
@@ -555,7 +555,6 @@ async function runCatalogWith(
         continue;
       }
 
-      // reject-identity
       if (evaluation.kind !== "closed") {
         ok = false;
         cases.push({

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/laboratory.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/laboratory.ts
@@ -1,0 +1,643 @@
+import { contentDigest, signatureDigest } from "./digest.ts";
+import { openCatalogResources, FROZEN_CLOCK, type CatalogResources } from "./catalog.ts";
+import {
+  ActiveBrand,
+  DraftBrand,
+  RevokedBrand,
+  SignedBrand,
+  asAdversarialReviewer,
+  asAssessor,
+  asComposer,
+  asHumanGovernor,
+  assertHumanGovernor,
+  isMintedIdentity,
+  type AdversarialReviewer,
+  type Assessor,
+  type Composer,
+  type HumanGovernor,
+} from "./identities.ts";
+import { pins } from "./pins.ts";
+import {
+  advanceRecord,
+  draftToRecord,
+  evaluateThroughAdversarial,
+  type ActorRef,
+} from "./pipeline.ts";
+import { assertValid, loadSchemaBundle, type SchemaBundle } from "./schema.ts";
+import type {
+  ActiveAdmission,
+  ApprovalPacket,
+  CatalogReport,
+  CatalogReportCase,
+  Diagnostic,
+  DraftDefinition,
+  Evaluation,
+  LaboratoryOptions,
+  RevokedAdmission,
+  SignedVersion,
+  WorkflowAdmissionWire,
+  WorkflowDefinitionJson,
+  WorkflowRunReceipt,
+} from "./types.ts";
+
+export interface Laboratory {
+  readonly pins: typeof pins;
+  loadDraft(composer: Composer, definitionPath: string, envelopePath: string): Promise<DraftDefinition>;
+  parseDraft(composer: Composer, definition: unknown, envelope: unknown): DraftDefinition;
+  evaluate(
+    assessor: Assessor,
+    draft: DraftDefinition,
+    opts?: { readonly adversary?: AdversarialReviewer },
+  ): Promise<Evaluation>;
+  present(evaluation: Evaluation): ApprovalPacket;
+  approve(governor: HumanGovernor, packet: ApprovalPacket): Promise<SignedVersion>;
+  activate(governor: HumanGovernor, signed: SignedVersion): Promise<ActiveAdmission>;
+  revoke(
+    governor: HumanGovernor,
+    admission: ActiveAdmission | SignedVersion,
+    reason: string,
+  ): Promise<RevokedAdmission>;
+  bindRun(
+    active: ActiveAdmission,
+    input: unknown,
+  ): Promise<WorkflowRunReceipt>;
+  runCatalog(): Promise<CatalogReport>;
+  toAdmissionWire(
+    admission: SignedVersion | ActiveAdmission | RevokedAdmission,
+  ): WorkflowAdmissionWire;
+}
+
+function asDefinition(value: unknown): WorkflowDefinitionJson {
+  if (typeof value !== "object" || value === null) {
+    throw new Error("definition must be an object");
+  }
+  return value as WorkflowDefinitionJson;
+}
+
+function mintDraft(
+  definition: WorkflowDefinitionJson,
+  envelope: {
+    budgets: DraftDefinition["budgets"];
+    requestContextSchema: object;
+    sleepPolicy: DraftDefinition["sleepPolicy"];
+  },
+  composer: Composer,
+): DraftDefinition {
+  return {
+    [DraftBrand]: true,
+    definition,
+    budgets: envelope.budgets,
+    requestContextSchema: envelope.requestContextSchema,
+    sleepPolicy: envelope.sleepPolicy,
+    composedBy: composer,
+    digest: definition.digest,
+  };
+}
+
+function requireClosed(evaluation: Evaluation): asserts evaluation is Extract<
+  Evaluation,
+  { kind: "closed" }
+> {
+  if (evaluation.kind !== "closed") {
+    throw Object.assign(
+      new Error("cannot approve an evaluation that did not close"),
+      {
+        code: "evaluation-open",
+        diagnostics: evaluation.diagnostics,
+      },
+    );
+  }
+}
+
+export async function openLaboratory(
+  options: LaboratoryOptions = {},
+): Promise<Laboratory> {
+  const catalog = await openCatalogResources({
+    ...(options.root !== undefined ? { root: options.root } : {}),
+    ...(options.now !== undefined ? { now: options.now } : {}),
+  });
+  const schemas = await loadSchemaBundle({
+    workflowsRoot: catalog.workflowsRoot,
+    mantisRoot: catalog.mantisRoot,
+    schemaPrefer: options.schemaPrefer ?? "live-then-snapshot",
+  });
+  const clock = () =>
+    options.now !== undefined
+      ? options.now().toISOString().replace(/\.\d{3}Z$/, "Z")
+      : catalog.clock || FROZEN_CLOCK;
+
+  const ledger = new Map<string, ActiveAdmission | RevokedAdmission | SignedVersion>();
+
+  const lab: Laboratory = {
+    pins,
+
+    async loadDraft(composer, definitionPath, envelopePath) {
+      const definition = await catalog.readDefinition(definitionPath);
+      const envelope = await catalog.readEnvelope(envelopePath);
+      return lab.parseDraft(composer, definition, envelope);
+    },
+
+    parseDraft(composer, definitionUnknown, envelopeUnknown) {
+      if (!isMintedIdentity(composer) || composer.role !== "composer") {
+        throw new Error("composer identity required");
+      }
+      const definition = asDefinition(definitionUnknown);
+      assertValid(schemas.validateDefinition, definition, "DynamicWorkflowDefinition");
+      const computed = contentDigest(
+        definition as unknown as Record<string, unknown>,
+      );
+      if (computed !== definition.digest) {
+        throw new Error(
+          `digest mismatch: fixture ${definition.digest} != computed ${computed}`,
+        );
+      }
+      if (
+        typeof envelopeUnknown !== "object" ||
+        envelopeUnknown === null ||
+        !("budgets" in envelopeUnknown) ||
+        !("requestContextSchema" in envelopeUnknown) ||
+        !("sleepPolicy" in envelopeUnknown)
+      ) {
+        throw new Error("envelope requires budgets, requestContextSchema, sleepPolicy");
+      }
+      const envelope = envelopeUnknown as {
+        budgets: DraftDefinition["budgets"];
+        requestContextSchema: object;
+        sleepPolicy: DraftDefinition["sleepPolicy"];
+      };
+      return mintDraft(definition, envelope, composer);
+    },
+
+    async evaluate(assessor, draft, opts) {
+      if (!isMintedIdentity(assessor) || assessor.role !== "assessor") {
+        throw new Error("assessor identity required");
+      }
+      const adversary =
+        opts?.adversary ??
+        asAdversarialReviewer("adversarial-reviewer-fixture");
+      if (
+        !isMintedIdentity(adversary) ||
+        adversary.role !== "adversarial-reviewer"
+      ) {
+        throw new Error("adversarial reviewer identity required");
+      }
+
+      const record = draftToRecord(
+        draft.definition,
+        draft.budgets,
+        draft.requestContextSchema,
+        draft.sleepPolicy,
+        draft.composedBy.id,
+      );
+
+      const result = evaluateThroughAdversarial(
+        record,
+        catalog,
+        schemas,
+        { id: assessor.id, role: "assessor" },
+        { id: adversary.id, role: "adversarial-reviewer" },
+        clock(),
+      );
+
+      if (!result.ok) {
+        return {
+          kind: "failed",
+          draft,
+          record: result.record,
+          diagnostics: result.diagnostics,
+        };
+      }
+      if (result.record.stage !== "adversarially-evaluated") {
+        return {
+          kind: "failed",
+          draft,
+          record: result.record,
+          diagnostics: [
+            {
+              path: "/",
+              code: "evaluate-incomplete",
+              severity: "error",
+              message: `stopped at ${result.record.stage}`,
+            },
+          ],
+        };
+      }
+      return {
+        kind: "closed",
+        draft,
+        record: result.record,
+        diagnostics: [],
+      };
+    },
+
+    present(evaluation) {
+      const def = evaluation.draft.definition;
+      return {
+        draft: evaluation.draft,
+        evaluation,
+        diff: {
+          definitionId: def.definitionId,
+          version: def.version,
+          digest: def.digest,
+          graph: def.graph,
+          stage: evaluation.record.stage,
+        },
+        capabilities: {
+          capabilityClass: def.capabilityClass,
+          prohibited: def.prohibited,
+        },
+        sources: def.referencedPrimitives,
+        costs: evaluation.draft.budgets,
+        ...(def.expiresAt !== undefined ? { expiry: def.expiresAt } : {}),
+      };
+    },
+
+    async approve(governor, packet) {
+      assertHumanGovernor(governor);
+      requireClosed(packet.evaluation);
+
+      if (governor.id === packet.evaluation.record.composer) {
+        const diagnostic: Diagnostic = {
+          path: "/reviewer",
+          code: "composer-self-admit",
+          severity: "error",
+          message: "composer cannot register, approve, or activate its own output",
+        };
+        throw Object.assign(new Error(diagnostic.message), {
+          code: diagnostic.code,
+          path: diagnostic.path,
+          diagnostics: [diagnostic],
+        });
+      }
+
+      const advanced = advanceRecord(
+        packet.evaluation.record,
+        catalog,
+        schemas,
+        { id: governor.id, role: "human" },
+        { kind: "advance" },
+        clock(),
+        "signed-immutable",
+      );
+
+      if (!advanced.ok) {
+        throw Object.assign(new Error(advanced.diagnostics[0]?.message ?? "approve failed"), {
+          code: advanced.diagnostics[0]?.code,
+          path: advanced.diagnostics[0]?.path,
+          diagnostics: advanced.diagnostics,
+        });
+      }
+
+      const record = advanced.record;
+      if (record.stage !== "signed-immutable") {
+        throw new Error(`approve expected signed-immutable, got ${record.stage}`);
+      }
+
+      const admittedAt = record.admittedAt ?? clock();
+      const signature = signatureDigest({
+        admissionId: record.admissionId,
+        digest: record.digest,
+        reviewer: governor.id,
+        admittedAt,
+      });
+      const signedRecord = {
+        ...record,
+        admittedAt,
+        signature,
+        human: governor.id,
+      };
+      const signed: SignedVersion = {
+        [SignedBrand]: true,
+        admissionId: signedRecord.admissionId,
+        definitionId: signedRecord.definitionId,
+        definitionVersion: signedRecord.definitionVersion,
+        digest: signedRecord.digest,
+        state: "signed-immutable",
+        reviewer: governor,
+        admittedAt,
+        signature,
+        record: signedRecord,
+      };
+      ledger.set(signed.admissionId, signed);
+      return signed;
+    },
+
+    async activate(governor, signed) {
+      assertHumanGovernor(governor);
+      if (governor.id === signed.record.composer) {
+        throw Object.assign(new Error("composer cannot activate own output"), {
+          code: "composer-self-admit",
+          path: "/reviewer",
+        });
+      }
+
+      const result = advanceRecord(
+        signed.record,
+        catalog,
+        schemas,
+        { id: governor.id, role: "human" },
+        { kind: "advance" },
+        clock(),
+      );
+      if (!result.ok) {
+        throw Object.assign(new Error(result.diagnostics[0]?.message ?? "activate failed"), {
+          diagnostics: result.diagnostics,
+          code: result.diagnostics[0]?.code,
+          path: result.diagnostics[0]?.path,
+        });
+      }
+      if (result.record.stage !== "active") {
+        throw new Error(`activate expected active, got ${result.record.stage}`);
+      }
+
+      const active: ActiveAdmission = {
+        [ActiveBrand]: true,
+        admissionId: result.record.admissionId,
+        definitionId: result.record.definitionId,
+        definitionVersion: result.record.definitionVersion,
+        digest: result.record.digest,
+        state: "active",
+        reviewer: governor,
+        admittedAt: result.record.admittedAt ?? signed.admittedAt,
+        activatedAt: result.record.activatedAt ?? clock(),
+        signature: result.record.signature ?? signed.signature,
+        record: {
+          ...result.record,
+          signature: result.record.signature ?? signed.signature,
+          admittedAt: result.record.admittedAt ?? signed.admittedAt,
+        },
+      };
+      ledger.set(active.admissionId, active);
+      return active;
+    },
+
+    async revoke(governor, admission, reason) {
+      assertHumanGovernor(governor);
+      const result = advanceRecord(
+        admission.record,
+        catalog,
+        schemas,
+        { id: governor.id, role: "human" },
+        { kind: "revoke", reason },
+        clock(),
+      );
+      if (!result.ok) {
+        throw Object.assign(new Error(result.diagnostics[0]?.message ?? "revoke failed"), {
+          diagnostics: result.diagnostics,
+        });
+      }
+      const revoked: RevokedAdmission = {
+        [RevokedBrand]: true,
+        admissionId: result.record.admissionId,
+        definitionId: result.record.definitionId,
+        definitionVersion: result.record.definitionVersion,
+        digest: result.record.digest,
+        state: "revoked",
+        reviewer: governor,
+        admittedAt: result.record.admittedAt ?? admission.admittedAt,
+        revokedAt: result.record.revokedAt ?? clock(),
+        reason,
+        signature: result.record.signature ?? admission.signature,
+        priorState: admission.state === "active" ? "active" : "signed-immutable",
+        record: result.record,
+      };
+      ledger.set(revoked.admissionId, revoked);
+      return revoked;
+    },
+
+    async bindRun(active, _input) {
+      const current = ledger.get(active.admissionId) ?? active;
+      if (current.state === "revoked") {
+        throw Object.assign(new Error("revoked admission cannot bind new runs"), {
+          code: "revoked",
+          path: "/state",
+        });
+      }
+      if (current.state !== "active") {
+        throw Object.assign(new Error("only ActiveAdmission can bindRun"), {
+          code: "not-active",
+          path: "/state",
+        });
+      }
+
+      const sideEffectClass =
+        active.record.simulator?.sideEffectClass ?? "read-only";
+      if (sideEffectClass === "external-mutation") {
+        throw Object.assign(
+          new Error("external-mutation graphs cannot bind for durable replay"),
+          {
+            code: "replay-unsafe",
+            path: "/sideEffectClass",
+          },
+        );
+      }
+
+      const receipt: WorkflowRunReceipt = {
+        schemaVersion: "1.0.0",
+        kind: "WorkflowRunReceipt",
+        runId: `wfrun.${active.definitionId.slice(3)}` as `wfrun.${string}`,
+        definitionId: active.definitionId,
+        definitionVersion: active.definitionVersion,
+        digest: active.digest,
+        startedAt: clock(),
+        status: "running",
+        sideEffectClass,
+        replaySafe: true,
+      };
+
+      if (receipt.digest !== active.record.digest) {
+        throw new Error("receipt digest must equal definition content digest");
+      }
+
+      assertValid(schemas.validateRunReceipt, receipt, "WorkflowRunReceipt");
+      return receipt;
+    },
+
+    async runCatalog() {
+      return runCatalogWith(lab, catalog);
+    },
+
+    toAdmissionWire(admission) {
+      const wireState =
+        admission.state === "revoked" &&
+        admission.record.notes?.startsWith("expired:")
+          ? "revoked"
+          : admission.state;
+      const notes =
+        "reason" in admission
+          ? admission.reason
+          : admission.notes !== undefined
+            ? admission.notes
+            : undefined;
+      const wire: WorkflowAdmissionWire = {
+        schemaVersion: "1.0.0",
+        kind: "WorkflowAdmission",
+        admissionId: admission.admissionId,
+        definitionId: admission.definitionId,
+        definitionVersion: admission.definitionVersion,
+        digest: admission.digest,
+        state: wireState,
+        reviewer: admission.reviewer.id,
+        admittedAt: admission.admittedAt,
+        ...(admission.signature !== undefined
+          ? { signature: admission.signature }
+          : {}),
+        ...(notes !== undefined ? { notes } : {}),
+      };
+      assertValid(schemas.validateAdmission, wire, "WorkflowAdmission");
+      return wire;
+    },
+  };
+
+  return lab;
+}
+
+async function runCatalogWith(
+  lab: Laboratory,
+  catalog: CatalogResources,
+): Promise<CatalogReport> {
+  const cases: CatalogReportCase[] = [];
+  let ok = true;
+
+  for (const entry of catalog.catalogCases) {
+    const composer = asComposer(entry.composer);
+    const assessor = asAssessor(entry.assessor);
+    const adversary = asAdversarialReviewer(entry.adversary);
+    const governor = asHumanGovernor(entry.governor);
+
+    try {
+      const draft = await lab.loadDraft(
+        composer,
+        entry.definition,
+        entry.envelope,
+      );
+      const evaluation = await lab.evaluate(assessor, draft, { adversary });
+
+      if (entry.expect === "admit") {
+        if (evaluation.kind !== "closed") {
+          ok = false;
+          cases.push({
+            id: entry.id,
+            expect: entry.expect,
+            ok: false,
+            stage: evaluation.record.stage,
+            diagnostics: evaluation.diagnostics,
+          });
+          continue;
+        }
+        const packet = lab.present(evaluation);
+        const signed = await lab.approve(governor, packet);
+        await lab.activate(governor, signed);
+        cases.push({
+          id: entry.id,
+          expect: entry.expect,
+          ok: true,
+          stage: "active",
+          diagnostics: [],
+        });
+        continue;
+      }
+
+      if (entry.expect === "reject") {
+        const failed = evaluation.kind === "failed";
+        const pathOk =
+          entry.diagnosticPath === undefined ||
+          evaluation.diagnostics.some((d) => d.path === entry.diagnosticPath);
+        const caseOk = failed && pathOk;
+        if (!caseOk) ok = false;
+        cases.push({
+          id: entry.id,
+          expect: entry.expect,
+          ok: caseOk,
+          stage: evaluation.record.stage,
+          diagnostics: evaluation.diagnostics,
+        });
+        continue;
+      }
+
+      // reject-identity
+      if (evaluation.kind !== "closed") {
+        ok = false;
+        cases.push({
+          id: entry.id,
+          expect: entry.expect,
+          ok: false,
+          stage: evaluation.record.stage,
+          diagnostics: evaluation.diagnostics,
+        });
+        continue;
+      }
+      const packet = lab.present(evaluation);
+      let identityRejected = false;
+      let diagnostics: Diagnostic[] = [];
+      try {
+        await lab.approve(governor, packet);
+      } catch (err) {
+        identityRejected = true;
+        const e = err as { diagnostics?: Diagnostic[]; path?: string; code?: string };
+        diagnostics =
+          e.diagnostics ??
+          [
+            {
+              path: (e.path ?? "/reviewer") as Diagnostic["path"],
+              code: e.code ?? "composer-self-admit",
+              severity: "error",
+              message: err instanceof Error ? err.message : "identity rejected",
+            },
+          ];
+      }
+      const pathOk =
+        entry.diagnosticPath === undefined ||
+        diagnostics.some((d) => d.path === entry.diagnosticPath);
+      const caseOk = identityRejected && pathOk;
+      if (!caseOk) ok = false;
+      cases.push({
+        id: entry.id,
+        expect: entry.expect,
+        ok: caseOk,
+        stage: evaluation.record.stage,
+        diagnostics,
+      });
+    } catch (err) {
+      ok = false;
+      cases.push({
+        id: entry.id,
+        expect: entry.expect,
+        ok: false,
+        stage: "draft",
+        diagnostics: [
+          {
+            path: "/",
+            code: "catalog-error",
+            severity: "error",
+            message: err instanceof Error ? err.message : String(err),
+          },
+        ],
+      });
+    }
+  }
+
+  return { ok, clock: catalog.clock, cases };
+}
+
+/**
+ * Test-only helper. Not exported from package index.
+ * Bypasses TypeScript brands to prove runtime identity checks.
+ */
+export async function smuggleActivate(
+  lab: Laboratory,
+  actor: Assessor | AdversarialReviewer | Composer | { readonly id: string; readonly role: string },
+  signed: SignedVersion,
+): Promise<ActiveAdmission> {
+  return lab.activate(actor as unknown as HumanGovernor, signed);
+}
+
+export async function smuggleApprove(
+  lab: Laboratory,
+  actor: Assessor | AdversarialReviewer | Composer | { readonly id: string; readonly role: string },
+  packet: ApprovalPacket,
+): Promise<SignedVersion> {
+  return lab.approve(actor as unknown as HumanGovernor, packet);
+}
+
+export type { CatalogResources, SchemaBundle, ActorRef };

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/paths.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/paths.ts
@@ -1,7 +1,6 @@
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-/** Package `src/` → mantis lab root (`projects/.../mantis`). */
 export function defaultMantisRoot(): string {
   return path.resolve(fileURLToPath(new URL("../../../../", import.meta.url)));
 }

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/paths.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/paths.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+/** Package `src/` → mantis lab root (`projects/.../mantis`). */
+export function defaultMantisRoot(): string {
+  return path.resolve(fileURLToPath(new URL("../../../../", import.meta.url)));
+}
+
+export function defaultWorkflowsRoot(mantisRoot = defaultMantisRoot()): string {
+  return path.join(mantisRoot, "assistant", "workflows");
+}
+
+export function resolveUnderRoot(root: string, relativePath: string): string {
+  if (relativePath.startsWith("assistant/workflows/")) {
+    return path.join(
+      root,
+      relativePath.slice("assistant/workflows/".length),
+    );
+  }
+  if (path.isAbsolute(relativePath)) {
+    return relativePath;
+  }
+  return path.join(root, relativePath);
+}

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/pins.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/pins.ts
@@ -1,0 +1,5 @@
+export const pins = {
+  mastraCore: "1.61.0",
+} as const;
+
+export type Pins = typeof pins;

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/pipeline.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/pipeline.ts
@@ -349,7 +349,6 @@ function closeAssay(ctx: CheckCtx): CheckResult {
     });
   }
 
-  // Graph tools must also resolve even if omitted from referencedPrimitives.
   for (let i = 0; i < ctx.record.definition.graph.length; i += 1) {
     const node = ctx.record.definition.graph[i];
     if (!node || node.type !== "tool" || node.toolId === undefined) continue;
@@ -782,7 +781,6 @@ function expireRow(ctx: CheckCtx): CheckResult {
   };
 }
 
-/** Private transition law. Not exported from package index. */
 const STAGE_TABLE: readonly StageRow[] = [
   {
     from: "draft",
@@ -911,11 +909,6 @@ function appendHistory(
   return [...record.history, entry];
 }
 
-/**
- * Apply consecutive matching stage-table rows for this actor until blocked.
- * When `stopAt` is set, halt after transitioning to that stage.
- * Not exported from package index.
- */
 export function advanceRecord(
   record: AdmissionRecord,
   catalog: CatalogResources,

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/pipeline.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/pipeline.ts
@@ -1,0 +1,1053 @@
+import { contentDigest } from "./digest.ts";
+import type { CatalogResources, ToolAssayRecord } from "./catalog.ts";
+import type { SchemaBundle } from "./schema.ts";
+import type {
+  ActorRole,
+  AdmissionRecord,
+  AssayClosure,
+  AssayPrimitiveStatus,
+  AuditEntry,
+  Diagnostic,
+  DiagnosticPath,
+  GraphNode,
+  SideEffectClass,
+  SimulatorEvidence,
+  Stage,
+  WorkflowDefinitionJson,
+} from "./types.ts";
+
+export interface ActorRef {
+  readonly id: string;
+  readonly role: ActorRole;
+}
+
+export type Intent =
+  | { readonly kind: "advance" }
+  | { readonly kind: "revoke"; readonly reason: string }
+  | { readonly kind: "expire" };
+
+export type CheckResult =
+  | { readonly ok: true; readonly patch: Partial<AdmissionRecord> }
+  | { readonly ok: false; readonly diagnostics: readonly Diagnostic[] };
+
+export interface CheckCtx {
+  readonly record: AdmissionRecord;
+  readonly catalog: CatalogResources;
+  readonly schemas: SchemaBundle;
+  readonly actor: ActorRef;
+  readonly intent: Intent;
+  readonly clock: string;
+}
+
+interface StageRow {
+  readonly from: Stage;
+  readonly to: Stage;
+  readonly intent: Intent["kind"];
+  readonly allowedRoles: readonly ActorRole[];
+  readonly check: (ctx: CheckCtx) => CheckResult;
+}
+
+function error(
+  path: DiagnosticPath,
+  code: string,
+  message: string,
+): Diagnostic {
+  return { path, code, severity: "error", message };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nodePath(index: number, field?: string): DiagnosticPath {
+  return (field === undefined
+    ? `/graph/${index}`
+    : `/graph/${index}/${field}`) as DiagnosticPath;
+}
+
+function mappingKind(node: GraphNode): string | undefined {
+  if (typeof node.mapping === "string") {
+    return node.mapping;
+  }
+  return undefined;
+}
+
+function schemaAndGraph(ctx: CheckCtx): CheckResult {
+  const def = ctx.record.definition as unknown;
+  if (!ctx.schemas.validateDefinition(def)) {
+    const first = ctx.schemas.validateDefinition.errors?.[0];
+    const rawPath = first?.instancePath;
+    const path = (
+      rawPath === undefined || rawPath === "" ? "/" : rawPath
+    ) as DiagnosticPath;
+    return {
+      ok: false,
+      diagnostics: [
+        error(
+          path,
+          "schema-invalid",
+          first?.message ?? "definition failed schema validation",
+        ),
+      ],
+    };
+  }
+
+  const computed = contentDigest(
+    ctx.record.definition as unknown as Record<string, unknown>,
+  );
+  if (computed !== ctx.record.definition.digest) {
+    return {
+      ok: false,
+      diagnostics: [
+        error(
+          "/digest",
+          "digest-mismatch",
+          "definition digest does not match A3 content hash",
+        ),
+      ],
+    };
+  }
+
+  if (
+    ctx.record.definition.capabilityClass !== "P0" &&
+    ctx.record.definition.capabilityClass !== "P1" &&
+    ctx.record.definition.capabilityClass !== "P2"
+  ) {
+    return {
+      ok: false,
+      diagnostics: [
+        error("/capabilityClass", "capability-denied", "P0–P2 only"),
+      ],
+    };
+  }
+
+  if (!isRecord(ctx.record.requestContextSchema)) {
+    return {
+      ok: false,
+      diagnostics: [
+        error(
+          "/requestContextSchema",
+          "request-context-required",
+          "envelope requestContextSchema is required",
+        ),
+      ],
+    };
+  }
+
+  return {
+    ok: true,
+    patch: { assessor: ctx.actor.id },
+  };
+}
+
+function resolvePrimitives(ctx: CheckCtx): CheckResult {
+  const diagnostics: Diagnostic[] = [];
+  const byId = new Map(
+    ctx.catalog.snapshot.tools.map((t) => [`${t.id}@${t.version}`, t] as const),
+  );
+
+  for (let i = 0; i < ctx.record.definition.graph.length; i += 1) {
+    const node = ctx.record.definition.graph[i];
+    if (!node) continue;
+    if (node.type === "tool") {
+      const toolId = node.toolId;
+      if (toolId === undefined || toolId.trim() === "") {
+        diagnostics.push(
+          error(nodePath(i, "toolId"), "tool-missing", "tool node requires toolId"),
+        );
+        continue;
+      }
+      if (ctx.catalog.forbiddenToolIds.has(toolId)) {
+        diagnostics.push(
+          error(
+            nodePath(i, "toolId"),
+            "forbidden-tool",
+            `tool ${toolId} is forbidden`,
+          ),
+        );
+        continue;
+      }
+      const prim = ctx.record.definition.referencedPrimitives.find(
+        (p) => p.id === toolId,
+      );
+      const version = prim?.version ?? "1.0.0";
+      const snap = byId.get(`${toolId}@${version}`);
+      if (!snap && !ctx.catalog.assays.has(toolId)) {
+        diagnostics.push(
+          error(
+            nodePath(i, "toolId"),
+            "unassayed-primitive",
+            `tool ${toolId} is not in the primitive snapshot`,
+          ),
+        );
+      }
+    }
+    if (node.type === "mapping") {
+      const kind = mappingKind(node);
+      if (kind === undefined) {
+        diagnostics.push(
+          error(nodePath(i), "mapping-kind-missing", "mapping kind required"),
+        );
+      } else if (!ctx.catalog.snapshot.mappingKinds.includes(kind)) {
+        diagnostics.push(
+          error(
+            nodePath(i),
+            "mapping-kind-unknown",
+            `mapping kind ${kind} is not registered`,
+          ),
+        );
+      }
+    }
+  }
+
+  for (const prim of ctx.record.definition.referencedPrimitives) {
+    if (prim.kind !== "tool") continue;
+    if (ctx.catalog.forbiddenToolIds.has(prim.id)) {
+      const idx = ctx.record.definition.graph.findIndex(
+        (n) => n.type === "tool" && n.toolId === prim.id,
+      );
+      diagnostics.push(
+        error(
+          nodePath(idx >= 0 ? idx : 0, "toolId"),
+          "forbidden-tool",
+          `referenced primitive ${prim.id} is forbidden`,
+        ),
+      );
+      continue;
+    }
+    const snap = byId.get(`${prim.id}@${prim.version}`);
+    if (!snap && !ctx.catalog.assays.has(prim.id)) {
+      const idx = ctx.record.definition.graph.findIndex(
+        (n) => n.type === "tool" && n.toolId === prim.id,
+      );
+      diagnostics.push(
+        error(
+          nodePath(idx >= 0 ? idx : 0, "toolId"),
+          "unassayed-primitive",
+          `primitive ${prim.id}@${prim.version} unresolved`,
+        ),
+      );
+    }
+  }
+
+  if (diagnostics.length > 0) {
+    return { ok: false, diagnostics };
+  }
+  return { ok: true, patch: {} };
+}
+
+function sideEffectOf(assay: ToolAssayRecord): SideEffectClass {
+  if (assay.effects.externalMutation || (assay.effects.write && !assay.behavior.idempotent)) {
+    return "external-mutation";
+  }
+  if (assay.behavior.idempotent && assay.effects.write) {
+    return "proven-idempotent";
+  }
+  return "read-only";
+}
+
+function closeAssay(ctx: CheckCtx): CheckResult {
+  const primitives: AssayPrimitiveStatus[] = [];
+  const missing: Diagnostic[] = [];
+
+  for (const prim of ctx.record.definition.referencedPrimitives) {
+    if (prim.kind !== "tool") {
+      missing.push(
+        error(
+          "/referencedPrimitives",
+          "unsupported-primitive-kind",
+          `A3 only closes tool primitives (got ${prim.kind})`,
+        ),
+      );
+      continue;
+    }
+
+    const idx = ctx.record.definition.graph.findIndex(
+      (n) => n.type === "tool" && n.toolId === prim.id,
+    );
+    const path = nodePath(idx >= 0 ? idx : 0, "toolId");
+
+    if (ctx.catalog.forbiddenToolIds.has(prim.id) || prim.id === "device-command") {
+      missing.push(
+        error(path, "forbidden-tool", `tool ${prim.id} is denied`),
+      );
+      continue;
+    }
+
+    const assay =
+      ctx.catalog.assays.get(prim.assayId) ??
+      ctx.catalog.assays.get(prim.id);
+    const admission =
+      ctx.catalog.admissions.get(prim.id) ??
+      ctx.catalog.admissions.get(prim.assayId);
+
+    if (!assay) {
+      missing.push(
+        error(path, "assay-missing", `no assay for ${prim.id}`),
+      );
+      continue;
+    }
+
+    if (!admission) {
+      missing.push(
+        error(path, "admission-missing", `no tool admission for ${prim.id}`),
+      );
+      continue;
+    }
+
+    const admittedOk =
+      admission.state === "admitted-read" ||
+      (admission.state === "admitted-write" &&
+        assay.behavior.idempotent &&
+        !assay.effects.externalMutation);
+
+    if (!admittedOk) {
+      missing.push(
+        error(
+          path,
+          "assay-not-admitted",
+          `tool ${prim.id} admission state ${admission.state} is not admitted-read/proven-idempotent`,
+        ),
+      );
+      continue;
+    }
+
+    if (assay.effects.deviceImpact) {
+      missing.push(
+        error(path, "device-impact", `tool ${prim.id} reports deviceImpact`),
+      );
+      continue;
+    }
+
+    if (assay.data.secrets) {
+      missing.push(
+        error(path, "secrets", `tool ${prim.id} touches secrets`),
+      );
+      continue;
+    }
+
+    if (
+      assay.effects.externalMutation ||
+      assay.review.disposition === "quarantined" ||
+      sideEffectOf(assay) === "external-mutation"
+    ) {
+      missing.push(
+        error(
+          path,
+          "replay-unsafe-write",
+          `tool ${prim.id} is quarantined or external-mutation`,
+        ),
+      );
+      continue;
+    }
+
+    primitives.push({
+      id: prim.id,
+      version: prim.version,
+      assayId: prim.assayId,
+      admissionState: admission.state,
+    });
+  }
+
+  // Graph tools must also resolve even if omitted from referencedPrimitives.
+  for (let i = 0; i < ctx.record.definition.graph.length; i += 1) {
+    const node = ctx.record.definition.graph[i];
+    if (!node || node.type !== "tool" || node.toolId === undefined) continue;
+    const toolId = node.toolId;
+    if (ctx.catalog.forbiddenToolIds.has(toolId)) {
+      missing.push(
+        error(nodePath(i, "toolId"), "forbidden-tool", `tool ${toolId} is denied`),
+      );
+      continue;
+    }
+    const covered = primitives.some((p) => p.id === toolId);
+    const alreadyMissing = missing.some(
+      (d) => d.path === nodePath(i, "toolId"),
+    );
+    if (!covered && !alreadyMissing) {
+      const assay = ctx.catalog.assays.get(toolId);
+      const admission = ctx.catalog.admissions.get(toolId);
+      if (!assay || !admission || admission.state !== "admitted-read") {
+        missing.push(
+          error(
+            nodePath(i, "toolId"),
+            "assay-not-closed",
+            `graph tool ${toolId} is not assay-closed`,
+          ),
+        );
+      }
+    }
+  }
+
+  const closed = missing.length === 0;
+  const assay: AssayClosure = { closed, primitives, missing };
+  if (!closed) {
+    return { ok: false, diagnostics: missing };
+  }
+  return { ok: true, patch: { assay } };
+}
+
+function lintPolicy(ctx: CheckCtx): CheckResult {
+  const diagnostics: Diagnostic[] = [];
+  const { prohibited } = ctx.record.definition;
+  if (
+    !prohibited.deviceCommand ||
+    !prohibited.browserMutation ||
+    !prohibited.secrets ||
+    !prohibited.directCanonicalMutation ||
+    !prohibited.specimenDbWrite
+  ) {
+    diagnostics.push(
+      error(
+        "/prohibited",
+        "prohibited-flags",
+        "all prohibited flags must be true",
+      ),
+    );
+  }
+
+  for (let i = 0; i < ctx.record.definition.graph.length; i += 1) {
+    const node = ctx.record.definition.graph[i];
+    if (!node) continue;
+
+    if (node.type === "tool" && node.toolId !== undefined) {
+      if (ctx.catalog.forbiddenToolIds.has(node.toolId)) {
+        diagnostics.push(
+          error(
+            nodePath(i, "toolId"),
+            "forbidden-tool",
+            `tool ${node.toolId} forbidden by policy`,
+          ),
+        );
+      }
+    }
+
+    if (node.type === "mapping") {
+      const kind = mappingKind(node);
+      if (kind === "sleep") {
+        const signal = node.signal;
+        if (
+          signal !== "reminder" &&
+          signal !== "revalidation"
+        ) {
+          diagnostics.push(
+            error(
+              nodePath(i, "signal"),
+              "sleep-signal-denied",
+              "sleep may emit reminder|revalidation only",
+            ),
+          );
+        } else if (
+          !ctx.record.sleepPolicy.allowedSignals.includes(signal) ||
+          !ctx.catalog.lintRules.sleepSignals.includes(signal)
+        ) {
+          diagnostics.push(
+            error(
+              nodePath(i, "signal"),
+              "sleep-signal-denied",
+              `signal ${signal} not allowed by sleep policy`,
+            ),
+          );
+        }
+      }
+
+      if (kind === "foreach" || kind === "loop") {
+        const bound =
+          node.maxIterations ??
+          node.bounds?.maxLoopIterations;
+        if (
+          ctx.catalog.lintRules.requireLoopBound &&
+          (bound === undefined ||
+            bound > ctx.record.budgets.maxLoopIterations ||
+            bound <= 0)
+        ) {
+          diagnostics.push(
+            error(
+              nodePath(i),
+              "unbounded-loop",
+              "foreach/loop requires maxIterations within envelope budgets",
+            ),
+          );
+        }
+      }
+
+      if (kind === "parallel") {
+        const bound = node.maxParallel ?? node.bounds?.maxParallel;
+        if (
+          ctx.catalog.lintRules.requireParallelBound &&
+          (bound === undefined ||
+            bound > ctx.record.budgets.maxParallel ||
+            bound <= 0)
+        ) {
+          diagnostics.push(
+            error(
+              nodePath(i),
+              "unbounded-parallel",
+              "parallel requires a bound within envelope budgets",
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  if (
+    !Number.isFinite(ctx.record.budgets.maxLoopIterations) ||
+    !Number.isFinite(ctx.record.budgets.wallTimeMs)
+  ) {
+    diagnostics.push(
+      error("/budgets", "budgets-required", "envelope budgets must be finite"),
+    );
+  }
+
+  if (diagnostics.length > 0) {
+    return { ok: false, diagnostics };
+  }
+  return { ok: true, patch: {} };
+}
+
+function simulate(ctx: CheckCtx): CheckResult {
+  const diagnostics: Diagnostic[] = [];
+  let sideEffectClass: SideEffectClass = "read-only";
+
+  for (let i = 0; i < ctx.record.definition.graph.length; i += 1) {
+    const node = ctx.record.definition.graph[i];
+    if (!node) continue;
+
+    if (node.type === "tool" && node.toolId !== undefined) {
+      const assay =
+        ctx.catalog.assays.get(node.toolId) ??
+        ctx.catalog.assays.get(
+          ctx.record.definition.referencedPrimitives.find(
+            (p) => p.id === node.toolId,
+          )?.assayId ?? "",
+        );
+      if (!assay) {
+        diagnostics.push(
+          error(
+            nodePath(i, "toolId"),
+            "sim-missing-assay",
+            `cannot simulate unknown tool ${node.toolId}`,
+          ),
+        );
+        continue;
+      }
+      const effect = sideEffectOf(assay);
+      if (effect === "external-mutation") {
+        diagnostics.push(
+          error(
+            nodePath(i, "toolId"),
+            "replay-unsafe",
+            `tool ${node.toolId} is external-mutation; durable replay disabled`,
+          ),
+        );
+        sideEffectClass = "external-mutation";
+      } else if (
+        effect === "proven-idempotent" &&
+        sideEffectClass === "read-only"
+      ) {
+        sideEffectClass = "proven-idempotent";
+      }
+    }
+
+    if (node.type === "mapping" && mappingKind(node) === "sleep") {
+      const signal = node.signal;
+      if (signal !== "reminder" && signal !== "revalidation") {
+        diagnostics.push(
+          error(
+            nodePath(i, "signal"),
+            "sleep-signal-denied",
+            "simulator rejects deferred-command sleep",
+          ),
+        );
+      }
+    }
+
+    if (
+      node.type === "mapping" &&
+      (mappingKind(node) === "foreach" || mappingKind(node) === "loop")
+    ) {
+      const bound = node.maxIterations ?? node.bounds?.maxLoopIterations;
+      if (bound === undefined) {
+        diagnostics.push(
+          error(nodePath(i), "unbounded-loop", "simulator refuses unbounded loop"),
+        );
+      }
+    }
+  }
+
+  const simulator: SimulatorEvidence = {
+    ok: diagnostics.length === 0,
+    budgetsRespected: diagnostics.length === 0,
+    sideEffectClass,
+    diagnostics,
+  };
+
+  if (!simulator.ok) {
+    return { ok: false, diagnostics };
+  }
+  return { ok: true, patch: { simulator } };
+}
+
+function adversarialEval(ctx: CheckCtx): CheckResult {
+  const findings: Diagnostic[] = [];
+
+  for (let i = 0; i < ctx.record.definition.graph.length; i += 1) {
+    const node = ctx.record.definition.graph[i];
+    if (!node) continue;
+    if (node.type === "tool" && node.toolId !== undefined) {
+      if (
+        ctx.catalog.forbiddenToolIds.has(node.toolId) ||
+        node.toolId.startsWith("mcp.")
+      ) {
+        findings.push(
+          error(
+            nodePath(i, "toolId"),
+            "adversarial-tool",
+            `adversarial corpus rejects ${node.toolId}`,
+          ),
+        );
+      }
+    }
+  }
+
+  if (findings.length > 0) {
+    return {
+      ok: false,
+      diagnostics: findings,
+    };
+  }
+
+  return {
+    ok: true,
+    patch: {
+      adversarialReviewer: ctx.actor.id,
+      adversarial: {
+        verdict: "pass",
+        summary: "adversarial corpus clean for P0–P2 laboratory fixtures",
+        findings: [],
+      },
+    },
+  };
+}
+
+function refuseIfComposer(ctx: CheckCtx): Diagnostic | undefined {
+  if (ctx.actor.id === ctx.record.composer) {
+    return error(
+      "/reviewer",
+      "composer-self-admit",
+      "composer cannot register, approve, or activate its own output",
+    );
+  }
+  return undefined;
+}
+
+function distinctIdentities(ctx: CheckCtx): Diagnostic | undefined {
+  const ids = [
+    ctx.record.composer,
+    ctx.record.assessor,
+    ctx.record.adversarialReviewer,
+    ctx.actor.id,
+  ].filter((x): x is string => x !== undefined);
+  if (new Set(ids).size !== ids.length) {
+    return error(
+      "/reviewer",
+      "identity-collision",
+      "composer, assessor, adversarial reviewer, and human must be distinct ids",
+    );
+  }
+  return undefined;
+}
+
+function humanApprove(ctx: CheckCtx): CheckResult {
+  const blocked = refuseIfComposer(ctx) ?? distinctIdentities(ctx);
+  if (blocked) {
+    return { ok: false, diagnostics: [blocked] };
+  }
+  if (ctx.record.assay?.closed !== true) {
+    return {
+      ok: false,
+      diagnostics: [
+        error("/assay", "assay-open", "cannot approve an evaluation that did not close"),
+      ],
+    };
+  }
+  if (ctx.record.simulator?.ok !== true) {
+    return {
+      ok: false,
+      diagnostics: [
+        error(
+          "/simulator",
+          "simulator-failed",
+          "cannot approve an evaluation that did not close",
+        ),
+      ],
+    };
+  }
+  if (ctx.record.adversarial?.verdict !== "pass") {
+    return {
+      ok: false,
+      diagnostics: [
+        error(
+          "/adversarial",
+          "adversarial-failed",
+          "cannot approve an evaluation that did not close",
+        ),
+      ],
+    };
+  }
+  return {
+    ok: true,
+    patch: { human: ctx.actor.id },
+  };
+}
+
+function signImmutable(ctx: CheckCtx): CheckResult {
+  const blocked = refuseIfComposer(ctx);
+  if (blocked) {
+    return { ok: false, diagnostics: [blocked] };
+  }
+  if (ctx.record.human !== undefined && ctx.record.human !== ctx.actor.id) {
+    return {
+      ok: false,
+      diagnostics: [
+        error(
+          "/reviewer",
+          "governor-mismatch",
+          "signing governor must match approving governor",
+        ),
+      ],
+    };
+  }
+  return {
+    ok: true,
+    patch: {
+      human: ctx.actor.id,
+      admittedAt: ctx.clock,
+    },
+  };
+}
+
+function activateRow(ctx: CheckCtx): CheckResult {
+  const blocked = refuseIfComposer(ctx);
+  if (blocked) {
+    return { ok: false, diagnostics: [blocked] };
+  }
+  const expiresAt = ctx.record.definition.expiresAt;
+  if (expiresAt !== undefined && Date.parse(ctx.clock) >= Date.parse(expiresAt)) {
+    return {
+      ok: false,
+      diagnostics: [
+        error("/expiresAt", "expired", "definition expired before activation"),
+      ],
+    };
+  }
+  return {
+    ok: true,
+    patch: {
+      activatedAt: ctx.clock,
+    },
+  };
+}
+
+function revokeRow(ctx: CheckCtx): CheckResult {
+  const blocked = refuseIfComposer(ctx);
+  if (blocked) {
+    return { ok: false, diagnostics: [blocked] };
+  }
+  if (ctx.intent.kind !== "revoke") {
+    return {
+      ok: false,
+      diagnostics: [error("/", "intent-mismatch", "revoke intent required")],
+    };
+  }
+  return {
+    ok: true,
+    patch: {
+      revokedAt: ctx.clock,
+      reason: ctx.intent.reason,
+      human: ctx.actor.id,
+    },
+  };
+}
+
+function expireRow(ctx: CheckCtx): CheckResult {
+  return {
+    ok: true,
+    patch: {
+      revokedAt: ctx.clock,
+      reason: "expired",
+      notes: `expired:${ctx.clock}`,
+    },
+  };
+}
+
+/** Private transition law. Not exported from package index. */
+const STAGE_TABLE: readonly StageRow[] = [
+  {
+    from: "draft",
+    to: "schema-validated",
+    intent: "advance",
+    allowedRoles: ["assessor"],
+    check: schemaAndGraph,
+  },
+  {
+    from: "schema-validated",
+    to: "primitives-resolved",
+    intent: "advance",
+    allowedRoles: ["assessor"],
+    check: resolvePrimitives,
+  },
+  {
+    from: "primitives-resolved",
+    to: "assay-closed",
+    intent: "advance",
+    allowedRoles: ["assessor"],
+    check: closeAssay,
+  },
+  {
+    from: "assay-closed",
+    to: "policy-linted",
+    intent: "advance",
+    allowedRoles: ["assessor"],
+    check: lintPolicy,
+  },
+  {
+    from: "policy-linted",
+    to: "simulated",
+    intent: "advance",
+    allowedRoles: ["assessor"],
+    check: simulate,
+  },
+  {
+    from: "simulated",
+    to: "adversarially-evaluated",
+    intent: "advance",
+    allowedRoles: ["adversarial-reviewer"],
+    check: adversarialEval,
+  },
+  {
+    from: "adversarially-evaluated",
+    to: "human-approved",
+    intent: "advance",
+    allowedRoles: ["human"],
+    check: humanApprove,
+  },
+  {
+    from: "human-approved",
+    to: "signed-immutable",
+    intent: "advance",
+    allowedRoles: ["human"],
+    check: signImmutable,
+  },
+  {
+    from: "signed-immutable",
+    to: "active",
+    intent: "advance",
+    allowedRoles: ["human"],
+    check: activateRow,
+  },
+  {
+    from: "signed-immutable",
+    to: "revoked",
+    intent: "revoke",
+    allowedRoles: ["human"],
+    check: revokeRow,
+  },
+  {
+    from: "active",
+    to: "revoked",
+    intent: "revoke",
+    allowedRoles: ["human"],
+    check: revokeRow,
+  },
+  {
+    from: "human-approved",
+    to: "expired",
+    intent: "expire",
+    allowedRoles: ["human", "assessor"],
+    check: expireRow,
+  },
+  {
+    from: "signed-immutable",
+    to: "expired",
+    intent: "expire",
+    allowedRoles: ["human", "assessor"],
+    check: expireRow,
+  },
+  {
+    from: "active",
+    to: "expired",
+    intent: "expire",
+    allowedRoles: ["human", "assessor"],
+    check: expireRow,
+  },
+];
+
+export type AdvanceResult =
+  | { readonly ok: true; readonly record: AdmissionRecord }
+  | {
+      readonly ok: false;
+      readonly record: AdmissionRecord;
+      readonly diagnostics: readonly Diagnostic[];
+    };
+
+function appendHistory(
+  record: AdmissionRecord,
+  from: Stage,
+  to: Stage,
+  actor: ActorRef,
+  clock: string,
+  note?: string,
+): readonly AuditEntry[] {
+  const entry: AuditEntry = {
+    at: clock,
+    from,
+    to,
+    actorId: actor.id,
+    actorRole: actor.role,
+    ...(note !== undefined ? { note } : {}),
+  };
+  return [...record.history, entry];
+}
+
+/**
+ * Apply consecutive matching stage-table rows for this actor until blocked.
+ * When `stopAt` is set, halt after transitioning to that stage.
+ * Not exported from package index.
+ */
+export function advanceRecord(
+  record: AdmissionRecord,
+  catalog: CatalogResources,
+  schemas: SchemaBundle,
+  actor: ActorRef,
+  intent: Intent = { kind: "advance" },
+  clock: string,
+  stopAt?: Stage,
+): AdvanceResult {
+  let current = record;
+  let progressed = false;
+
+  for (const row of STAGE_TABLE) {
+    if (row.from !== current.stage) continue;
+    if (row.intent !== intent.kind) continue;
+    if (!row.allowedRoles.includes(actor.role)) {
+      break;
+    }
+
+    const result = row.check({
+      record: current,
+      catalog,
+      schemas,
+      actor,
+      intent,
+      clock,
+    });
+
+    if (!result.ok) {
+      return {
+        ok: false,
+        record: current,
+        diagnostics: result.diagnostics,
+      };
+    }
+
+    const next: AdmissionRecord = {
+      ...current,
+      ...result.patch,
+      stage: row.to,
+      history: appendHistory(
+        current,
+        row.from,
+        row.to,
+        actor,
+        clock,
+        intent.kind === "revoke" ? intent.reason : undefined,
+      ),
+    };
+    current = next;
+    progressed = true;
+
+    if (stopAt !== undefined && current.stage === stopAt) {
+      break;
+    }
+  }
+
+  if (!progressed && intent.kind === "advance") {
+    return { ok: true, record: current };
+  }
+
+  return { ok: true, record: current };
+}
+
+export function admissionIdFor(
+  definitionId: `wf.${string}`,
+  version: string,
+): `admit-wf.${string}` {
+  const slug = definitionId.slice("wf.".length);
+  return `admit-wf.${slug}.v${version.replace(/[^a-z0-9.-]/gi, "-").toLowerCase()}` as `admit-wf.${string}`;
+}
+
+export function draftToRecord(
+  definition: WorkflowDefinitionJson,
+  budgets: AdmissionRecord["budgets"],
+  requestContextSchema: object,
+  sleepPolicy: AdmissionRecord["sleepPolicy"],
+  composerId: string,
+): AdmissionRecord {
+  return {
+    admissionId: admissionIdFor(definition.definitionId, definition.version),
+    definitionId: definition.definitionId,
+    definitionVersion: definition.version,
+    digest: definition.digest,
+    stage: "draft",
+    composer: composerId,
+    definition,
+    budgets,
+    requestContextSchema,
+    sleepPolicy,
+    history: [],
+  };
+}
+
+export function evaluateThroughAdversarial(
+  record: AdmissionRecord,
+  catalog: CatalogResources,
+  schemas: SchemaBundle,
+  assessor: ActorRef,
+  adversary: ActorRef,
+  clock: string,
+): AdvanceResult {
+  const assessed = advanceRecord(
+    record,
+    catalog,
+    schemas,
+    assessor,
+    { kind: "advance" },
+    clock,
+  );
+  if (!assessed.ok) {
+    return assessed;
+  }
+  if (assessed.record.stage !== "simulated") {
+    return {
+      ok: false,
+      record: assessed.record,
+      diagnostics: [
+        error(
+          "/",
+          "assess-incomplete",
+          `assessor stopped at ${assessed.record.stage}`,
+        ),
+      ],
+    };
+  }
+  return advanceRecord(
+    assessed.record,
+    catalog,
+    schemas,
+    adversary,
+    { kind: "advance" },
+    clock,
+  );
+}

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/schema.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/schema.ts
@@ -1,0 +1,106 @@
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import { Ajv2020 } from "ajv/dist/2020.js";
+import * as ajvFormats from "ajv-formats";
+import type { ValidateFunction, ErrorObject } from "ajv";
+
+import { defaultWorkflowsRoot, resolveUnderRoot } from "./paths.ts";
+
+type AddFormats = (ajv: Ajv2020) => void;
+
+function resolveAddFormats(): AddFormats {
+  const mod = ajvFormats as unknown as { default?: AddFormats } & AddFormats;
+  if (typeof mod.default === "function") {
+    return mod.default;
+  }
+  return mod;
+}
+
+export interface SchemaBundle {
+  readonly validateDefinition: ValidateFunction;
+  readonly validateAdmission: ValidateFunction;
+  readonly validateRunReceipt: ValidateFunction;
+  readonly schemaDir: string;
+}
+
+function formatErrors(errors: ErrorObject[] | null | undefined): string {
+  if (!errors || errors.length === 0) {
+    return "schema validation failed";
+  }
+  return errors
+    .map((e) => `${e.instancePath || "/"} ${e.message ?? e.keyword}`)
+    .join("; ");
+}
+
+export async function loadSchemaBundle(options: {
+  readonly workflowsRoot: string;
+  readonly mantisRoot: string;
+  readonly schemaPrefer: "live-then-snapshot" | "snapshot-only";
+}): Promise<SchemaBundle> {
+  const snapshotDir = path.join(
+    options.workflowsRoot,
+    "laboratory",
+    "imported-a0",
+  );
+  const liveDir = path.join(options.mantisRoot, "assistant", "contracts");
+
+  const useLive =
+    options.schemaPrefer === "live-then-snapshot" &&
+    existsSync(path.join(liveDir, "dynamic-workflow-definition.schema.json"));
+
+  const schemaDir = useLive ? liveDir : snapshotDir;
+
+  const definitionSchema = JSON.parse(
+    await readFile(
+      path.join(schemaDir, "dynamic-workflow-definition.schema.json"),
+      "utf8",
+    ),
+  ) as object;
+  const admissionSchema = JSON.parse(
+    await readFile(
+      path.join(schemaDir, "workflow-admission.schema.json"),
+      "utf8",
+    ),
+  ) as object;
+  const receiptSchema = JSON.parse(
+    await readFile(
+      path.join(schemaDir, "workflow-run-receipt.schema.json"),
+      "utf8",
+    ),
+  ) as object;
+
+  const ajv = new Ajv2020({ strict: false, allErrors: true });
+  resolveAddFormats()(ajv);
+
+  return {
+    schemaDir,
+    validateDefinition: ajv.compile(definitionSchema),
+    validateAdmission: ajv.compile(admissionSchema),
+    validateRunReceipt: ajv.compile(receiptSchema),
+  };
+}
+
+export function assertValid(
+  validate: ValidateFunction,
+  value: unknown,
+  label: string,
+): void {
+  if (!validate(value)) {
+    throw new Error(`${label}: ${formatErrors(validate.errors)}`);
+  }
+}
+
+export function defaultSchemaPaths(workflowsRoot = defaultWorkflowsRoot()): {
+  readonly snapshotDir: string;
+  readonly forbiddenTools: string;
+} {
+  return {
+    snapshotDir: path.join(workflowsRoot, "laboratory", "imported-a0"),
+    forbiddenTools: resolveUnderRoot(
+      workflowsRoot,
+      "laboratory/imported-a0/forbidden-tools.json",
+    ),
+  };
+}

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/types.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/src/types.ts
@@ -1,0 +1,334 @@
+import type { Composer, Assessor, AdversarialReviewer, HumanGovernor } from "./identities.ts";
+import {
+  DraftBrand,
+  SignedBrand,
+  ActiveBrand,
+  RevokedBrand,
+} from "./identities.ts";
+
+export type CapabilityClass = "P0" | "P1" | "P2";
+
+export type DiagnosticPath = `/${string}`;
+
+export type DiagnosticSeverity = "error" | "warning" | "info";
+
+export interface Diagnostic {
+  readonly path: DiagnosticPath;
+  readonly code: string;
+  readonly severity: DiagnosticSeverity;
+  readonly message: string;
+}
+
+export interface Budgets {
+  readonly wallTimeMs: number;
+  readonly maxSteps: number;
+  readonly maxParallel: number;
+  readonly maxLoopIterations: number;
+  readonly maxTokens: number;
+  readonly maxToolCalls: number;
+  readonly maxCostUsd: number;
+  readonly cancellable: boolean;
+}
+
+export interface SleepPolicy {
+  readonly allowedSignals: readonly ("reminder" | "revalidation")[];
+}
+
+export interface ProhibitedFlags {
+  readonly deviceCommand: true;
+  readonly browserMutation: true;
+  readonly secrets: true;
+  readonly directCanonicalMutation: true;
+  readonly specimenDbWrite: true;
+}
+
+export interface GraphNode {
+  readonly type: "tool" | "agent" | "workflow" | "mapping";
+  readonly id: string;
+  readonly toolId?: string;
+  readonly agentId?: string;
+  readonly workflowId?: string;
+  readonly mapping?: string;
+  readonly signal?: string;
+  readonly durationMs?: number;
+  readonly maxIterations?: number;
+  readonly maxParallel?: number;
+  readonly bounds?: Partial<Budgets>;
+}
+
+export interface ReferencedPrimitive {
+  readonly kind: "tool" | "agent" | "workflow";
+  readonly id: string;
+  readonly version: string;
+  readonly assayId: string;
+}
+
+export type Stage =
+  | "draft"
+  | "schema-validated"
+  | "primitives-resolved"
+  | "assay-closed"
+  | "policy-linted"
+  | "simulated"
+  | "adversarially-evaluated"
+  | "human-approved"
+  | "signed-immutable"
+  | "active"
+  | "expired"
+  | "revoked";
+
+export type ActorRole =
+  | "composer"
+  | "assessor"
+  | "adversarial-reviewer"
+  | "human";
+
+export interface AuditEntry {
+  readonly at: string;
+  readonly from: Stage;
+  readonly to: Stage;
+  readonly actorId: string;
+  readonly actorRole: ActorRole;
+  readonly note?: string;
+}
+
+export interface AssayPrimitiveStatus {
+  readonly id: string;
+  readonly version: string;
+  readonly assayId: string;
+  readonly admissionState: string;
+}
+
+export interface AssayClosure {
+  readonly closed: boolean;
+  readonly primitives: readonly AssayPrimitiveStatus[];
+  readonly missing: readonly Diagnostic[];
+}
+
+export type SideEffectClass =
+  | "read-only"
+  | "proven-idempotent"
+  | "external-mutation";
+
+export interface SimulatorEvidence {
+  readonly ok: boolean;
+  readonly budgetsRespected: boolean;
+  readonly sideEffectClass: SideEffectClass;
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+export interface AdversarialEvidence {
+  readonly verdict: "pass" | "fail";
+  readonly summary: string;
+  readonly findings: readonly Diagnostic[];
+}
+
+export interface WorkflowDefinitionJson {
+  readonly schemaVersion: "1.0.0";
+  readonly kind: "DynamicWorkflowDefinition";
+  readonly definitionId: `wf.${string}`;
+  readonly version: string;
+  readonly digest: string;
+  readonly capabilityClass: CapabilityClass;
+  readonly author: string;
+  readonly inputSchema: object;
+  readonly outputSchema: object;
+  readonly stateSchema?: object;
+  readonly graph: readonly GraphNode[];
+  readonly referencedPrimitives: readonly ReferencedPrimitive[];
+  readonly prohibited: ProhibitedFlags;
+  readonly description?: string;
+  readonly sourcePrompt?: string;
+  readonly modelRun?: string;
+  readonly expiresAt?: string;
+}
+
+export interface DraftDefinition {
+  readonly [DraftBrand]: true;
+  readonly definition: WorkflowDefinitionJson;
+  readonly budgets: Budgets;
+  readonly requestContextSchema: object;
+  readonly sleepPolicy: SleepPolicy;
+  readonly composedBy: Composer;
+  readonly digest: string;
+}
+
+export interface AdmissionRecord {
+  readonly admissionId: `admit-wf.${string}`;
+  readonly definitionId: `wf.${string}`;
+  readonly definitionVersion: string;
+  readonly digest: string;
+  readonly stage: Stage;
+  readonly composer: string;
+  readonly assessor?: string;
+  readonly adversarialReviewer?: string;
+  readonly human?: string;
+  readonly definition: WorkflowDefinitionJson;
+  readonly budgets: Budgets;
+  readonly requestContextSchema: object;
+  readonly sleepPolicy: SleepPolicy;
+  readonly assay?: AssayClosure;
+  readonly simulator?: SimulatorEvidence;
+  readonly adversarial?: AdversarialEvidence;
+  readonly signature?: string;
+  readonly admittedAt?: string;
+  readonly activatedAt?: string;
+  readonly revokedAt?: string;
+  readonly reason?: string;
+  readonly notes?: string;
+  readonly history: readonly AuditEntry[];
+}
+
+export type Evaluation =
+  | {
+      readonly kind: "closed";
+      readonly draft: DraftDefinition;
+      readonly record: AdmissionRecord;
+      readonly diagnostics: readonly Diagnostic[];
+    }
+  | {
+      readonly kind: "failed";
+      readonly draft: DraftDefinition;
+      readonly record: AdmissionRecord;
+      readonly diagnostics: readonly Diagnostic[];
+    };
+
+export interface ApprovalPacket {
+  readonly draft: DraftDefinition;
+  readonly evaluation: Evaluation;
+  readonly diff: unknown;
+  readonly capabilities: unknown;
+  readonly sources: unknown;
+  readonly costs: unknown;
+  readonly expiry?: string;
+}
+
+export interface SignedVersion {
+  readonly [SignedBrand]: true;
+  readonly admissionId: `admit-wf.${string}`;
+  readonly definitionId: `wf.${string}`;
+  readonly definitionVersion: string;
+  readonly digest: string;
+  readonly state: "signed-immutable";
+  readonly reviewer: HumanGovernor;
+  readonly admittedAt: string;
+  readonly signature: string;
+  readonly notes?: string;
+  readonly record: AdmissionRecord;
+}
+
+export interface ActiveAdmission {
+  readonly [ActiveBrand]: true;
+  readonly admissionId: `admit-wf.${string}`;
+  readonly definitionId: `wf.${string}`;
+  readonly definitionVersion: string;
+  readonly digest: string;
+  readonly state: "active";
+  readonly reviewer: HumanGovernor;
+  readonly admittedAt: string;
+  readonly activatedAt: string;
+  readonly signature: string;
+  readonly notes?: string;
+  readonly record: AdmissionRecord;
+}
+
+export interface RevokedAdmission {
+  readonly [RevokedBrand]: true;
+  readonly admissionId: `admit-wf.${string}`;
+  readonly definitionId: `wf.${string}`;
+  readonly definitionVersion: string;
+  readonly digest: string;
+  readonly state: "revoked";
+  readonly reviewer: HumanGovernor;
+  readonly admittedAt: string;
+  readonly revokedAt: string;
+  readonly reason: string;
+  readonly signature: string;
+  readonly priorState: "active" | "signed-immutable";
+  readonly record: AdmissionRecord;
+}
+
+export interface WorkflowAdmissionWire {
+  readonly schemaVersion: "1.0.0";
+  readonly kind: "WorkflowAdmission";
+  readonly admissionId: `admit-wf.${string}`;
+  readonly definitionId: `wf.${string}`;
+  readonly definitionVersion: string;
+  readonly digest: string;
+  readonly state:
+    | "draft"
+    | "schema-validated"
+    | "primitives-resolved"
+    | "assay-closed"
+    | "policy-linted"
+    | "simulated"
+    | "adversarially-evaluated"
+    | "human-approved"
+    | "signed-immutable"
+    | "active"
+    | "revoked";
+  readonly reviewer: string;
+  readonly admittedAt: string;
+  readonly signature?: string;
+  readonly notes?: string;
+}
+
+export interface WorkflowRunReceipt {
+  readonly schemaVersion: "1.0.0";
+  readonly kind: "WorkflowRunReceipt";
+  readonly runId: `wfrun.${string}`;
+  readonly definitionId: `wf.${string}`;
+  readonly definitionVersion: string;
+  readonly digest: string;
+  readonly startedAt: string;
+  readonly status: "running" | "suspended" | "success" | "failed" | "cancelled";
+  readonly sideEffectClass: SideEffectClass;
+  readonly replaySafe: boolean;
+  readonly endedAt?: string;
+  readonly externalEffectCount?: number;
+}
+
+export interface LaboratoryOptions {
+  readonly root?: string | URL;
+  readonly schemaPrefer?: "live-then-snapshot" | "snapshot-only";
+  readonly now?: () => Date;
+}
+
+export interface CatalogCase {
+  readonly id: string;
+  readonly expect: "admit" | "reject" | "reject-identity";
+  readonly definition: string;
+  readonly envelope: string;
+  readonly composer: string;
+  readonly assessor: string;
+  readonly adversary: string;
+  readonly governor: string;
+  readonly diagnosticPath?: DiagnosticPath;
+}
+
+export interface CatalogReportCase {
+  readonly id: string;
+  readonly expect: CatalogCase["expect"];
+  readonly ok: boolean;
+  readonly stage: Stage;
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+export interface CatalogReport {
+  readonly ok: boolean;
+  readonly clock: string;
+  readonly cases: readonly CatalogReportCase[];
+}
+
+export type LabIdentity =
+  | Composer
+  | Assessor
+  | AdversarialReviewer
+  | HumanGovernor;
+
+export type {
+  Composer,
+  Assessor,
+  AdversarialReviewer,
+  HumanGovernor,
+};

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/catalog.test.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/catalog.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  asAdversarialReviewer,
+  asAssessor,
+  asComposer,
+  asHumanGovernor,
+  openLaboratory,
+} from "../src/index.ts";
+
+describe("fixture catalog", () => {
+  it("matches every catalog.json expect through activate or fail-closed", async () => {
+    const lab = await openLaboratory();
+    const report = await lab.runCatalog();
+    assert.equal(report.ok, true, JSON.stringify(report.cases, null, 2));
+    assert.equal(report.cases.length, 10);
+    const admits = report.cases.filter((c) => c.expect === "admit");
+    assert.equal(admits.length, 5);
+    for (const c of admits) {
+      assert.equal(c.ok, true, c.id);
+      assert.equal(c.stage, "active");
+    }
+    for (const c of report.cases.filter((c) => c.expect !== "admit")) {
+      assert.equal(c.ok, true, `${c.id}: ${JSON.stringify(c.diagnostics)}`);
+      assert.ok(
+        c.diagnostics.some((d) => d.path.startsWith("/")),
+        `${c.id} missing path diagnostic`,
+      );
+    }
+  });
+
+  it("validates WorkflowAdmission and WorkflowRunReceipt against imported-a0 schemas", async () => {
+    const lab = await openLaboratory();
+    const composer = asComposer("workflow-composer-fixture");
+    const assessor = asAssessor("tool-assessor-fixture");
+    const adversary = asAdversarialReviewer("adversarial-reviewer-fixture");
+    const governor = asHumanGovernor("human-governor-fixture");
+    const draft = await lab.loadDraft(
+      composer,
+      "assistant/workflows/definitions/care-source-comparison.v1.json",
+      "assistant/workflows/laboratory/envelopes/care-source-comparison.v1.json",
+    );
+    const evaluation = await lab.evaluate(assessor, draft, { adversary });
+    assert.equal(evaluation.kind, "closed");
+    const signed = await lab.approve(governor, lab.present(evaluation));
+    const active = await lab.activate(governor, signed);
+    const wire = lab.toAdmissionWire(active);
+    assert.equal(wire.kind, "WorkflowAdmission");
+    assert.equal(wire.state, "active");
+    assert.match(wire.signature ?? "", /^[a-f0-9]{64}$/);
+    const receipt = await lab.bindRun(active, { topic: "nymph" });
+    assert.equal(receipt.kind, "WorkflowRunReceipt");
+    assert.equal(receipt.digest, active.digest);
+    assert.equal(receipt.replaySafe, true);
+  });
+});

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/catalog.test.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/catalog.test.ts
@@ -1,57 +1,15 @@
-import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import assert from 'node:assert/strict';
+import test from 'node:test';
 
-import {
-  asAdversarialReviewer,
-  asAssessor,
-  asComposer,
-  asHumanGovernor,
-  openLaboratory,
-} from "../src/index.ts";
+import { openLaboratory } from '../src/laboratory.ts';
+import { pins } from '../src/pins.ts';
 
-describe("fixture catalog", () => {
-  it("matches every catalog.json expect through activate or fail-closed", async () => {
-    const lab = await openLaboratory();
-    const report = await lab.runCatalog();
-    assert.equal(report.ok, true, JSON.stringify(report.cases, null, 2));
-    assert.equal(report.cases.length, 10);
-    const admits = report.cases.filter((c) => c.expect === "admit");
-    assert.equal(admits.length, 5);
-    for (const c of admits) {
-      assert.equal(c.ok, true, c.id);
-      assert.equal(c.stage, "active");
-    }
-    for (const c of report.cases.filter((c) => c.expect !== "admit")) {
-      assert.equal(c.ok, true, `${c.id}: ${JSON.stringify(c.diagnostics)}`);
-      assert.ok(
-        c.diagnostics.some((d) => d.path.startsWith("/")),
-        `${c.id} missing path diagnostic`,
-      );
-    }
-  });
-
-  it("validates WorkflowAdmission and WorkflowRunReceipt against imported-a0 schemas", async () => {
-    const lab = await openLaboratory();
-    const composer = asComposer("workflow-composer-fixture");
-    const assessor = asAssessor("tool-assessor-fixture");
-    const adversary = asAdversarialReviewer("adversarial-reviewer-fixture");
-    const governor = asHumanGovernor("human-governor-fixture");
-    const draft = await lab.loadDraft(
-      composer,
-      "assistant/workflows/definitions/care-source-comparison.v1.json",
-      "assistant/workflows/laboratory/envelopes/care-source-comparison.v1.json",
-    );
-    const evaluation = await lab.evaluate(assessor, draft, { adversary });
-    assert.equal(evaluation.kind, "closed");
-    const signed = await lab.approve(governor, lab.present(evaluation));
-    const active = await lab.activate(governor, signed);
-    const wire = lab.toAdmissionWire(active);
-    assert.equal(wire.kind, "WorkflowAdmission");
-    assert.equal(wire.state, "active");
-    assert.match(wire.signature ?? "", /^[a-f0-9]{64}$/);
-    const receipt = await lab.bindRun(active, { topic: "nymph" });
-    assert.equal(receipt.kind, "WorkflowRunReceipt");
-    assert.equal(receipt.digest, active.digest);
-    assert.equal(receipt.replaySafe, true);
-  });
+test('catalog cases match expect', async () => {
+  const lab = await openLaboratory();
+  assert.equal(lab.pins.mastraCore, pins.mastraCore);
+  const report = await lab.runCatalog();
+  assert.ok(report.cases.length >= 10, JSON.stringify(report, null, 2));
+  assert.equal(report.ok, true, JSON.stringify(report.cases.filter((row) => !row.ok), null, 2));
+  const admitted = report.cases.filter((row) => row.expect === 'admit' && row.ok);
+  assert.equal(admitted.length, 5);
 });

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/identities.test.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/identities.test.ts
@@ -1,59 +1,54 @@
-import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import assert from 'node:assert/strict';
+import test from 'node:test';
 
 import {
   asAdversarialReviewer,
   asAssessor,
   asComposer,
   asHumanGovernor,
-  openLaboratory,
-} from "../src/index.ts";
-import { smuggleActivate, smuggleApprove } from "../src/laboratory.ts";
+} from '../src/identities.ts';
+import { openLaboratory, smuggleApprove } from '../src/laboratory.ts';
 
-describe("identities", () => {
-  it("rejects composer-self-admit when governor id equals composer id", async () => {
-    const lab = await openLaboratory();
-    const composer = asComposer("workflow-composer-fixture");
-    const assessor = asAssessor("tool-assessor-fixture");
-    const adversary = asAdversarialReviewer("adversarial-reviewer-fixture");
-    const governor = asHumanGovernor("workflow-composer-fixture");
-    const draft = await lab.loadDraft(
-      composer,
-      "assistant/workflows/definitions/composer-self-admit.v1.json",
-      "assistant/workflows/laboratory/envelopes/composer-self-admit.v1.json",
-    );
-    const evaluation = await lab.evaluate(assessor, draft, { adversary });
-    assert.equal(evaluation.kind, "closed");
-    await assert.rejects(
-      () => lab.approve(governor, lab.present(evaluation)),
-      (err: unknown) => {
-        const e = err as { path?: string; code?: string };
-        assert.equal(e.path, "/reviewer");
-        assert.equal(e.code, "composer-self-admit");
-        return true;
-      },
-    );
-  });
+test('composer cannot admit its own output', async () => {
+  const lab = await openLaboratory();
+  const composer = asComposer('workflow-composer-fixture');
+  const assessor = asAssessor('tool-assessor-fixture');
+  const draft = await lab.loadDraft(
+    composer,
+    'assistant/workflows/definitions/composer-self-admit.v1.json',
+    'assistant/workflows/laboratory/envelopes/composer-self-admit.v1.json',
+  );
+  const evaluation = await lab.evaluate(assessor, draft);
+  assert.equal(evaluation.kind, 'closed');
+  if (evaluation.kind !== 'closed') return;
+  const packet = lab.present(evaluation);
+  await assert.rejects(
+    () => lab.approve(asHumanGovernor(composer.id), packet),
+    (err: unknown) => {
+      const e = err as { path?: string };
+      return e.path === '/reviewer';
+    },
+  );
+});
 
-  it("rejects assessor/adversary activate at runtime when brands are smuggled", async () => {
-    const lab = await openLaboratory();
-    const composer = asComposer("workflow-composer-fixture");
-    const assessor = asAssessor("tool-assessor-fixture");
-    const adversary = asAdversarialReviewer("adversarial-reviewer-fixture");
-    const governor = asHumanGovernor("human-governor-fixture");
-    const draft = await lab.loadDraft(
-      composer,
-      "assistant/workflows/definitions/care-source-comparison.v1.json",
-      "assistant/workflows/laboratory/envelopes/care-source-comparison.v1.json",
-    );
-    const evaluation = await lab.evaluate(assessor, draft, { adversary });
-    assert.equal(evaluation.kind, "closed");
-    const signed = await lab.approve(governor, lab.present(evaluation));
-
-    await assert.rejects(() => smuggleActivate(lab, assessor, signed));
-    await assert.rejects(() => smuggleActivate(lab, adversary, signed));
-    await assert.rejects(() =>
-      smuggleApprove(lab, assessor, lab.present(evaluation)),
-    );
-  });
+test('smuggled assessor cannot approve', async () => {
+  const lab = await openLaboratory();
+  const composer = asComposer('workflow-composer-fixture');
+  const assessor = asAssessor('tool-assessor-fixture');
+  const governor = asHumanGovernor('human-governor-fixture');
+  const draft = await lab.loadDraft(
+    composer,
+    'assistant/workflows/definitions/observation-packet.v1.json',
+    'assistant/workflows/laboratory/envelopes/observation-packet.v1.json',
+  );
+  const evaluation = await lab.evaluate(assessor, draft);
+  assert.equal(evaluation.kind, 'closed');
+  if (evaluation.kind !== 'closed') return;
+  const packet = lab.present(evaluation);
+  await assert.rejects(() => smuggleApprove(lab, assessor, packet));
+  await assert.rejects(() =>
+    smuggleApprove(lab, asAdversarialReviewer('adversarial-reviewer-fixture'), packet),
+  );
+  const signed = await lab.approve(governor, packet);
+  assert.equal(signed.state, 'signed-immutable');
 });

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/identities.test.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/identities.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  asAdversarialReviewer,
+  asAssessor,
+  asComposer,
+  asHumanGovernor,
+  openLaboratory,
+} from "../src/index.ts";
+import { smuggleActivate, smuggleApprove } from "../src/laboratory.ts";
+
+describe("identities", () => {
+  it("rejects composer-self-admit when governor id equals composer id", async () => {
+    const lab = await openLaboratory();
+    const composer = asComposer("workflow-composer-fixture");
+    const assessor = asAssessor("tool-assessor-fixture");
+    const adversary = asAdversarialReviewer("adversarial-reviewer-fixture");
+    const governor = asHumanGovernor("workflow-composer-fixture");
+    const draft = await lab.loadDraft(
+      composer,
+      "assistant/workflows/definitions/composer-self-admit.v1.json",
+      "assistant/workflows/laboratory/envelopes/composer-self-admit.v1.json",
+    );
+    const evaluation = await lab.evaluate(assessor, draft, { adversary });
+    assert.equal(evaluation.kind, "closed");
+    await assert.rejects(
+      () => lab.approve(governor, lab.present(evaluation)),
+      (err: unknown) => {
+        const e = err as { path?: string; code?: string };
+        assert.equal(e.path, "/reviewer");
+        assert.equal(e.code, "composer-self-admit");
+        return true;
+      },
+    );
+  });
+
+  it("rejects assessor/adversary activate at runtime when brands are smuggled", async () => {
+    const lab = await openLaboratory();
+    const composer = asComposer("workflow-composer-fixture");
+    const assessor = asAssessor("tool-assessor-fixture");
+    const adversary = asAdversarialReviewer("adversarial-reviewer-fixture");
+    const governor = asHumanGovernor("human-governor-fixture");
+    const draft = await lab.loadDraft(
+      composer,
+      "assistant/workflows/definitions/care-source-comparison.v1.json",
+      "assistant/workflows/laboratory/envelopes/care-source-comparison.v1.json",
+    );
+    const evaluation = await lab.evaluate(assessor, draft, { adversary });
+    assert.equal(evaluation.kind, "closed");
+    const signed = await lab.approve(governor, lab.present(evaluation));
+
+    await assert.rejects(() => smuggleActivate(lab, assessor, signed));
+    await assert.rejects(() => smuggleActivate(lab, adversary, signed));
+    await assert.rejects(() =>
+      smuggleApprove(lab, assessor, lab.present(evaluation)),
+    );
+  });
+});

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/isolation.test.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/isolation.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import { createRequire } from "node:module";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.resolve(here, "..");
+const require = createRequire(import.meta.url);
+
+describe("isolation", () => {
+  it("package.json has no @mastra/core or @tmnl/mantis-assistant", () => {
+    const pkg = JSON.parse(
+      readFileSync(path.join(pkgRoot, "package.json"), "utf8"),
+    ) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const deps = {
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+    };
+    assert.equal(deps["@mastra/core"], undefined);
+    assert.equal(deps["@tmnl/mantis-assistant"], undefined);
+  });
+
+  it("source does not import @mastra/core or @tmnl/mantis-assistant", () => {
+    const srcDir = path.join(pkgRoot, "src");
+    const { readdirSync } = require("node:fs") as typeof import("node:fs");
+    for (const name of readdirSync(srcDir)) {
+      if (!name.endsWith(".ts")) continue;
+      const text = readFileSync(path.join(srcDir, name), "utf8");
+      assert.equal(
+        text.includes("@mastra/core"),
+        false,
+        `${name} imports @mastra/core`,
+      );
+      assert.equal(
+        text.includes("@tmnl/mantis-assistant"),
+        false,
+        `${name} imports @tmnl/mantis-assistant`,
+      );
+    }
+  });
+
+  it("research-summary.v1 is not present on this branch", () => {
+    const def = path.resolve(
+      pkgRoot,
+      "../../../assistant/workflows/definitions/research-summary.v1.json",
+    );
+    const adm = path.resolve(
+      pkgRoot,
+      "../../../assistant/workflows/admissions/research-summary.v1.json",
+    );
+    assert.equal(existsSync(def), false, "definitions/research-summary.v1.json must not exist");
+    assert.equal(existsSync(adm), false, "admissions/research-summary.v1.json must not exist");
+  });
+});

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/isolation.test.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/isolation.test.ts
@@ -1,59 +1,36 @@
-import assert from "node:assert/strict";
-import { readFileSync, existsSync } from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { describe, it } from "node:test";
-import { createRequire } from "node:module";
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
-const here = path.dirname(fileURLToPath(import.meta.url));
-const pkgRoot = path.resolve(here, "..");
-const require = createRequire(import.meta.url);
+test('this package does not depend on A0 harness or Mastra', () => {
+  const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
+    dependencies?: Record<string, string>;
+  };
+  const deps = pkg.dependencies ?? {};
+  assert.equal('@mastra/core' in deps, false);
+  assert.equal('@tmnl/mantis-assistant' in deps, false);
+});
 
-describe("isolation", () => {
-  it("package.json has no @mastra/core or @tmnl/mantis-assistant", () => {
-    const pkg = JSON.parse(
-      readFileSync(path.join(pkgRoot, "package.json"), "utf8"),
-    ) as {
-      dependencies?: Record<string, string>;
-      devDependencies?: Record<string, string>;
-    };
-    const deps = {
-      ...pkg.dependencies,
-      ...pkg.devDependencies,
-    };
-    assert.equal(deps["@mastra/core"], undefined);
-    assert.equal(deps["@tmnl/mantis-assistant"], undefined);
-  });
+test('A0 research-summary.v1 is not owned on this branch', () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const definitions = path.resolve(
+    here,
+    '../../../../assistant/workflows/definitions/research-summary.v1.json',
+  );
+  const admissions = path.resolve(
+    here,
+    '../../../../assistant/workflows/admissions/research-summary.v1.json',
+  );
+  assert.equal(existsSync(definitions), false);
+  assert.equal(existsSync(admissions), false);
+});
 
-  it("source does not import @mastra/core or @tmnl/mantis-assistant", () => {
-    const srcDir = path.join(pkgRoot, "src");
-    const { readdirSync } = require("node:fs") as typeof import("node:fs");
-    for (const name of readdirSync(srcDir)) {
-      if (!name.endsWith(".ts")) continue;
-      const text = readFileSync(path.join(srcDir, name), "utf8");
-      assert.equal(
-        text.includes("@mastra/core"),
-        false,
-        `${name} imports @mastra/core`,
-      );
-      assert.equal(
-        text.includes("@tmnl/mantis-assistant"),
-        false,
-        `${name} imports @tmnl/mantis-assistant`,
-      );
-    }
-  });
-
-  it("research-summary.v1 is not present on this branch", () => {
-    const def = path.resolve(
-      pkgRoot,
-      "../../../assistant/workflows/definitions/research-summary.v1.json",
-    );
-    const adm = path.resolve(
-      pkgRoot,
-      "../../../assistant/workflows/admissions/research-summary.v1.json",
-    );
-    assert.equal(existsSync(def), false, "definitions/research-summary.v1.json must not exist");
-    assert.equal(existsSync(adm), false, "admissions/research-summary.v1.json must not exist");
-  });
+test('source does not import mantis-assistant or mastra', () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const src = path.resolve(here, '../src/index.ts');
+  const text = readFileSync(src, 'utf8');
+  assert.equal(text.includes('@tmnl/mantis-assistant'), false);
+  assert.equal(text.includes('@mastra/core'), false);
 });

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/pipeline.test.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/pipeline.test.ts
@@ -1,100 +1,112 @@
-import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
 
-import {
-  asAdversarialReviewer,
-  asAssessor,
-  asComposer,
-  asHumanGovernor,
-  contentDigest,
-  openLaboratory,
-} from "../src/index.ts";
+import { contentDigest } from '../src/digest.ts';
+import { asComposer, asAssessor, asHumanGovernor } from '../src/identities.ts';
+import { openLaboratory } from '../src/laboratory.ts';
+import { defaultWorkflowsRoot, resolveUnderRoot } from '../src/paths.ts';
 
-describe("pipeline", () => {
-  it("content digest is stable and changes when definition changes without version bump", async () => {
-    const lab = await openLaboratory();
-    const composer = asComposer("workflow-composer-fixture");
-    const draft = await lab.loadDraft(
-      composer,
-      "assistant/workflows/definitions/care-source-comparison.v1.json",
-      "assistant/workflows/laboratory/envelopes/care-source-comparison.v1.json",
-    );
-    const again = contentDigest(
-      draft.definition as unknown as Record<string, unknown>,
-    );
-    assert.equal(again, draft.digest);
-    assert.equal(again, draft.definition.digest);
+const readDefinition = (relative: string): Record<string, unknown> =>
+  JSON.parse(
+    readFileSync(resolveUnderRoot(defaultWorkflowsRoot(), relative), 'utf8'),
+  ) as Record<string, unknown>;
 
-    const mutated: Record<string, unknown> = {
-      ...(draft.definition as unknown as Record<string, unknown>),
-      description: "mutated without version bump",
-    };
-    delete mutated["digest"];
-    const next = contentDigest(mutated);
-    assert.notEqual(next, draft.digest);
-  });
+test('content digest is canonical JSON without the digest field', () => {
+  const definition = readDefinition('definitions/care-source-comparison.v1.json');
+  assert.equal(contentDigest(definition), definition.digest);
+  const mutated = { ...definition, description: 'changed' };
+  assert.notEqual(contentDigest(mutated), definition.digest);
+});
 
-  it("bindRun on revoked fails; sleep reminder ok; negatives fail at expected paths", async () => {
-    const lab = await openLaboratory();
-    const composer = asComposer("workflow-composer-fixture");
-    const assessor = asAssessor("tool-assessor-fixture");
-    const adversary = asAdversarialReviewer("adversarial-reviewer-fixture");
-    const governor = asHumanGovernor("human-governor-fixture");
+test('device-command fails at /graph/0/toolId', async () => {
+  const lab = await openLaboratory();
+  const composer = asComposer('workflow-composer-fixture');
+  const assessor = asAssessor('tool-assessor-fixture');
+  const draft = await lab.loadDraft(
+    composer,
+    'assistant/workflows/definitions/device-command-graph.v1.json',
+    'assistant/workflows/laboratory/envelopes/device-command-graph.v1.json',
+  );
+  const evaluation = await lab.evaluate(assessor, draft);
+  assert.equal(evaluation.kind, 'failed');
+  if (evaluation.kind !== 'failed') return;
+  assert.equal(evaluation.diagnostics[0]?.path, '/graph/0/toolId');
+});
 
-    const reminder = await lab.loadDraft(
-      composer,
-      "assistant/workflows/definitions/feeding-removal-reminder.v1.json",
-      "assistant/workflows/laboratory/envelopes/feeding-removal-reminder.v1.json",
-    );
-    const reminderEval = await lab.evaluate(assessor, reminder, { adversary });
-    assert.equal(reminderEval.kind, "closed");
-    assert.equal(
-      reminder.definition.graph.some(
-        (n) => n.mapping === "sleep" && n.signal === "reminder",
-      ),
-      true,
-    );
-    const signed = await lab.approve(governor, lab.present(reminderEval));
-    const active = await lab.activate(governor, signed);
-    const receipt = await lab.bindRun(active, { topic: "remove prey" });
-    assert.equal(receipt.digest, active.digest);
-    assert.equal(receipt.replaySafe, true);
+test('hidden unassayed MCP fails closed', async () => {
+  const lab = await openLaboratory();
+  const draft = await lab.loadDraft(
+    asComposer('workflow-composer-fixture'),
+    'assistant/workflows/definitions/hidden-unassayed-mcp.v1.json',
+    'assistant/workflows/laboratory/envelopes/hidden-unassayed-mcp.v1.json',
+  );
+  const evaluation = await lab.evaluate(asAssessor('tool-assessor-fixture'), draft);
+  assert.equal(evaluation.kind, 'failed');
+  if (evaluation.kind !== 'failed') return;
+  assert.equal(evaluation.diagnostics[0]?.path, '/graph/0/toolId');
+});
 
-    const revoked = await lab.revoke(governor, active, "superseded-by-1.1.0");
-    assert.equal(revoked.state, "revoked");
-    await assert.rejects(() => lab.bindRun(active, { topic: "again" }));
+test('unbounded foreach fails at /graph/1', async () => {
+  const lab = await openLaboratory();
+  const draft = await lab.loadDraft(
+    asComposer('workflow-composer-fixture'),
+    'assistant/workflows/definitions/unbounded-loop.v1.json',
+    'assistant/workflows/laboratory/envelopes/unbounded-loop.v1.json',
+  );
+  const evaluation = await lab.evaluate(asAssessor('tool-assessor-fixture'), draft);
+  assert.equal(evaluation.kind, 'failed');
+  if (evaluation.kind !== 'failed') return;
+  assert.equal(evaluation.diagnostics[0]?.path, '/graph/1');
+});
 
-    const negatives: { path: string; def: string; env: string }[] = [
-      {
-        path: "/graph/0/toolId",
-        def: "assistant/workflows/definitions/device-command-graph.v1.json",
-        env: "assistant/workflows/laboratory/envelopes/device-command-graph.v1.json",
-      },
-      {
-        path: "/graph/0/toolId",
-        def: "assistant/workflows/definitions/hidden-unassayed-mcp.v1.json",
-        env: "assistant/workflows/laboratory/envelopes/hidden-unassayed-mcp.v1.json",
-      },
-      {
-        path: "/graph/1",
-        def: "assistant/workflows/definitions/unbounded-loop.v1.json",
-        env: "assistant/workflows/laboratory/envelopes/unbounded-loop.v1.json",
-      },
-      {
-        path: "/graph/0/toolId",
-        def: "assistant/workflows/definitions/replay-nominal-write.v1.json",
-        env: "assistant/workflows/laboratory/envelopes/replay-nominal-write.v1.json",
-      },
-    ];
+test('replay of a nominal write fails closed', async () => {
+  const lab = await openLaboratory();
+  const draft = await lab.loadDraft(
+    asComposer('workflow-composer-fixture'),
+    'assistant/workflows/definitions/replay-nominal-write.v1.json',
+    'assistant/workflows/laboratory/envelopes/replay-nominal-write.v1.json',
+  );
+  const evaluation = await lab.evaluate(asAssessor('tool-assessor-fixture'), draft);
+  assert.equal(evaluation.kind, 'failed');
+  if (evaluation.kind !== 'failed') return;
+  assert.equal(evaluation.diagnostics[0]?.path, '/graph/0/toolId');
+});
 
-    for (const neg of negatives) {
-      const draft = await lab.loadDraft(composer, neg.def, neg.env);
-      const evaluation = await lab.evaluate(assessor, draft, { adversary });
-      assert.equal(evaluation.kind, "failed", neg.def);
-      assert.ok(
-        evaluation.diagnostics.some((d) => d.path === neg.path),
-        `${neg.def} expected ${neg.path}, got ${evaluation.diagnostics.map((d) => d.path).join(",")}`,
-      );
-    }
-  });
+test('revocation blocks new runs and keeps the digest', async () => {
+  const lab = await openLaboratory();
+  const composer = asComposer('workflow-composer-fixture');
+  const assessor = asAssessor('tool-assessor-fixture');
+  const governor = asHumanGovernor('human-governor-fixture');
+  const draft = await lab.loadDraft(
+    composer,
+    'assistant/workflows/definitions/care-source-comparison.v1.json',
+    'assistant/workflows/laboratory/envelopes/care-source-comparison.v1.json',
+  );
+  const evaluation = await lab.evaluate(assessor, draft);
+  assert.equal(evaluation.kind, 'closed');
+  if (evaluation.kind !== 'closed') return;
+  const signed = await lab.approve(governor, lab.present(evaluation));
+  const active = await lab.activate(governor, signed);
+  const receipt = await lab.bindRun(active, { topic: 'nymph' });
+  assert.equal(receipt.digest, draft.digest);
+  assert.equal(receipt.replaySafe, true);
+  const wire = lab.toAdmissionWire(active);
+  assert.equal(wire.state, 'active');
+  const revoked = await lab.revoke(governor, active, 'superseded');
+  assert.equal(revoked.state, 'revoked');
+  assert.equal(revoked.digest, active.digest);
+  await assert.rejects(() => lab.bindRun(revoked as never, { topic: 'nymph' }));
+});
+
+test('package.json pins match the recorded A0 Mastra pin', () => {
+  const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
+    dependencies: Record<string, string>;
+    devDependencies: Record<string, string>;
+    packageManager: string;
+  };
+  assert.equal(pkg.dependencies.ajv, '8.20.0');
+  assert.equal(pkg.dependencies['ajv-formats'], '3.0.1');
+  assert.equal(pkg.devDependencies.typescript, '5.9.3');
+  assert.equal(pkg.packageManager, 'npm@10.9.7');
 });

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/pipeline.test.ts
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/test/pipeline.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  asAdversarialReviewer,
+  asAssessor,
+  asComposer,
+  asHumanGovernor,
+  contentDigest,
+  openLaboratory,
+} from "../src/index.ts";
+
+describe("pipeline", () => {
+  it("content digest is stable and changes when definition changes without version bump", async () => {
+    const lab = await openLaboratory();
+    const composer = asComposer("workflow-composer-fixture");
+    const draft = await lab.loadDraft(
+      composer,
+      "assistant/workflows/definitions/care-source-comparison.v1.json",
+      "assistant/workflows/laboratory/envelopes/care-source-comparison.v1.json",
+    );
+    const again = contentDigest(
+      draft.definition as unknown as Record<string, unknown>,
+    );
+    assert.equal(again, draft.digest);
+    assert.equal(again, draft.definition.digest);
+
+    const mutated: Record<string, unknown> = {
+      ...(draft.definition as unknown as Record<string, unknown>),
+      description: "mutated without version bump",
+    };
+    delete mutated["digest"];
+    const next = contentDigest(mutated);
+    assert.notEqual(next, draft.digest);
+  });
+
+  it("bindRun on revoked fails; sleep reminder ok; negatives fail at expected paths", async () => {
+    const lab = await openLaboratory();
+    const composer = asComposer("workflow-composer-fixture");
+    const assessor = asAssessor("tool-assessor-fixture");
+    const adversary = asAdversarialReviewer("adversarial-reviewer-fixture");
+    const governor = asHumanGovernor("human-governor-fixture");
+
+    const reminder = await lab.loadDraft(
+      composer,
+      "assistant/workflows/definitions/feeding-removal-reminder.v1.json",
+      "assistant/workflows/laboratory/envelopes/feeding-removal-reminder.v1.json",
+    );
+    const reminderEval = await lab.evaluate(assessor, reminder, { adversary });
+    assert.equal(reminderEval.kind, "closed");
+    assert.equal(
+      reminder.definition.graph.some(
+        (n) => n.mapping === "sleep" && n.signal === "reminder",
+      ),
+      true,
+    );
+    const signed = await lab.approve(governor, lab.present(reminderEval));
+    const active = await lab.activate(governor, signed);
+    const receipt = await lab.bindRun(active, { topic: "remove prey" });
+    assert.equal(receipt.digest, active.digest);
+    assert.equal(receipt.replaySafe, true);
+
+    const revoked = await lab.revoke(governor, active, "superseded-by-1.1.0");
+    assert.equal(revoked.state, "revoked");
+    await assert.rejects(() => lab.bindRun(active, { topic: "again" }));
+
+    const negatives: { path: string; def: string; env: string }[] = [
+      {
+        path: "/graph/0/toolId",
+        def: "assistant/workflows/definitions/device-command-graph.v1.json",
+        env: "assistant/workflows/laboratory/envelopes/device-command-graph.v1.json",
+      },
+      {
+        path: "/graph/0/toolId",
+        def: "assistant/workflows/definitions/hidden-unassayed-mcp.v1.json",
+        env: "assistant/workflows/laboratory/envelopes/hidden-unassayed-mcp.v1.json",
+      },
+      {
+        path: "/graph/1",
+        def: "assistant/workflows/definitions/unbounded-loop.v1.json",
+        env: "assistant/workflows/laboratory/envelopes/unbounded-loop.v1.json",
+      },
+      {
+        path: "/graph/0/toolId",
+        def: "assistant/workflows/definitions/replay-nominal-write.v1.json",
+        env: "assistant/workflows/laboratory/envelopes/replay-nominal-write.v1.json",
+      },
+    ];
+
+    for (const neg of negatives) {
+      const draft = await lab.loadDraft(composer, neg.def, neg.env);
+      const evaluation = await lab.evaluate(assessor, draft, { adversary });
+      assert.equal(evaluation.kind, "failed", neg.def);
+      assert.ok(
+        evaluation.diagnostics.some((d) => d.path === neg.path),
+        `${neg.def} expected ${neg.path}, got ${evaluation.diagnostics.map((d) => d.path).join(",")}`,
+      );
+    }
+  });
+});

--- a/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/tsconfig.json
+++ b/projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Draft A3 slice for #53 (parent #49). Local JSON admission laboratory for Mastra dynamic workflows. This is not shop-release, not A6, not a keeper PWA, and not the A0 harness.

## Why

A0 pinned Mastra 1.61.0 and proved `addDynamicWorkflow` on `wf.research-summary`. A3 has to prove the rest of the admission pipeline so generated workflow JSON is not treated as executable authority. CopilotKit/AG-UI remains the later surface. This PR does not wait for A2, a live CopilotKit URL, or a remote Mastra server.

## Scope

In:

- `assistant/workflows/laboratory/` including read-only A0 schema snapshots under `imported-a0/`
- `assistant/workflows/fixture-catalog/`, `definitions/` (A3 graphs only), `linter/`, `simulator/`
- new package `tooling/typescript/mantis-workflow-lab`
- `.github/workflows/mantis-workflow-lab-ci.yml` (path-filtered npm job on the A3 write-set)

Public API is `openLaboratory` plus branded `asComposer` / `asAssessor` / `asAdversarialReviewer` / `asHumanGovernor`. Evaluate walks a private stage table. Approve, activate, and revoke take a human governor only.

Out:

- A0 `research-summary.v1` definition and admission (PR 100)
- `tooling/typescript/mantis-assistant` (A0)
- `assistant/app/**` and golden-care (PR 98)
- SpecimenDB, EVA, graph, getbygraph, device-command, live actuation
- live Mastra or CopilotKit in CI

## Tradeoffs

A0 `DynamicWorkflowDefinition` forbids extra properties, so budgets and request-context live in a sidecar envelope rather than on the definition. A3 content-hashes definitions. A0's research-summary digest stays `sha256(id@version)` and is not rewritten. Conditionals, foreach, parallel, and sleep are mapping-node extras so the A0 graph enum stays untouched.

The new Actions job uses npm, not bun, because this package ships `package-lock.json`. `pull_request` is not limited to `master`/`main` so this stacked lab branch actually runs.

## Blast radius

Reviewers of the assistant workflow tree, a new TypeScript package, and one Actions workflow. No app, flake, or A0 harness edits. Parallel A0/A1 drafts should merge without path fights if they keep their write-sets.

## Verification

From `projects/biomemetics/labs/mantis/tooling/typescript/mantis-workflow-lab`:

- `npm test` — 13 passed (catalog, identities, isolation, pipeline)
- `npm run typecheck` — clean
- `npm run catalog` — 10/10 fixture cases matched (`admit` × 5, `reject` × 4, `reject-identity` × 1)

GitHub Actions job `Mantis A3 workflow-lab` / `Admit fixtures` is green on `041e0177`. JSON fixtures after `npm ci`. No live Mastra.

Stay draft. Do not merge. Independent review is later.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2e30a6a-3e50-4ed1-9683-8f17126aa786?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2e30a6a-3e50-4ed1-9683-8f17126aa786&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

