### PR TITLE
feat(mantis-assistant): add A5 evidence queue and projection preview

### DIFF
--- a/.github/workflows/mantis-assistant-a5.yml
+++ b/.github/workflows/mantis-assistant-a5.yml
@@ -1,0 +1,50 @@
+name: Mantis Assistant A5
+
+on:
+  push:
+    paths:
+      - "projects/biomemetics/labs/mantis/assistant/evidence/**"
+      - "projects/biomemetics/labs/mantis/assistant/projection/**"
+      - "projects/biomemetics/labs/mantis/contracts/evidence.schema.json"
+      - "projects/biomemetics/labs/mantis/assistant/docs/A5*.md"
+      - ".github/workflows/mantis-assistant-a5.yml"
+  pull_request:
+    paths:
+      - "projects/biomemetics/labs/mantis/assistant/evidence/**"
+      - "projects/biomemetics/labs/mantis/assistant/projection/**"
+      - "projects/biomemetics/labs/mantis/contracts/evidence.schema.json"
+      - "projects/biomemetics/labs/mantis/assistant/docs/A5*.md"
+      - ".github/workflows/mantis-assistant-a5.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  evidence-projection:
+    name: evidence and projection
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: projects/biomemetics/labs/mantis/assistant/evidence
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: projects/biomemetics/labs/mantis/assistant/evidence/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test

--- a/projects/biomemetics/labs/mantis/assistant/docs/A5-evidence-queue.md
+++ b/projects/biomemetics/labs/mantis/assistant/docs/A5-evidence-queue.md
@@ -1,0 +1,29 @@
+# About the A5 evidence queue
+
+The review queue is the consistency boundary. A lab `EvidenceRecord` can be schema-valid and still be the wrong kind of thing for the assistant to admit. The queue is the missing state machine. Packets move `draft → validated → pending-review → accepted | rejected | retained-inconclusive`.
+
+Call `createEvidenceQueue`, then `enqueueDraft`, `validate`, `submit`, and `accept`. Do not treat a single JSON object as a self-sufficient envelope that can preview, bind a target, or carry its own admission.
+
+## Origins
+
+`parseIntake` takes a closed `origin` string. It does not infer origin from producer, text, or `kind`.
+
+Admissible origins are `canonical-record` and `lab-artifact`. Inadmissible origins never construct a `DraftPacket`. Those origins are `observational-memory`, `chat`, `recommendation`, `raw-telemetry`, `taxon-hypothesis`, `photo-only-taxon`, and `photo-only-location`. Mastra observational memory is `observational-memory`. It is not care truth and not a catalog write.
+
+A canonical record that still carries taxon or locality keys is refused as `taxon-or-locality-keys-present`.
+
+## Roles
+
+`curator` drafts and submits. `adversarialReviewer` calls `flagDefect` and leaves the packet in `pending-review`. `governedReviewer` is the only role `accept` will take. A curator object that is cast through still fails at runtime when `role` is not `governed-reviewer`, or when `actorId` equals the author.
+
+Incoming `review.status` is discarded to `pending`. Incoming `projectionBinding` is stripped. A fixture that already says `accepted` cannot self-admit.
+
+## Schema gate
+
+`schema-gate.ts` reads `labs/mantis/contracts/evidence.schema.json` and pins digest `bf38331eb8f66d1152e0ef16ab003ebc6fb4c5d9ec9b06cf395860e2f3485cf1`. It does not import `@tmnl/mantis-lab` or `@tmnl/specimendb`. A lookalike gate that is not in the WeakSet throws.
+
+`claim-unbound` and `digest-missing` are named transition reasons at `validate`. They are not silent schema noise.
+
+## Empty wells that are not this aggregate
+
+CopilotKit `runtimeUrl` is not required. A2 is not required. The queue does not mint a Specimen, select a target, or infer locality.

--- a/projects/biomemetics/labs/mantis/assistant/docs/A5-projection-preview.md
+++ b/projects/biomemetics/labs/mantis/assistant/docs/A5-projection-preview.md
@@ -1,0 +1,19 @@
+# About A5 projection preview
+
+Preview is a pure function of an `AcceptedPacket` plus a caller-supplied existing catalog target. `previewAccepted` goes through `requireAccepted`. Draft, validated-only, pending-review, rejected, and retained-inconclusive packets cannot preview.
+
+## Payload
+
+Component text is `admission.text`. Analog links use `admission.target`. `result.summary` is not a field the payload builder copies. Observed and measured records with `result.disposition === 'supports'` are the only preview-eligible source classes. Taxon and Locality are not `ProjectionComponent` tags.
+
+`parseExistingTarget` wraps a caller string as `gbg:specimen:<id>`. It refuses a blank id, `biomemetics.mantis`, `mantis-lab`, and `projects/biomemetics/labs/mantis`. It does not call Intake. It does not invent an id.
+
+## Cheap entity, gated component
+
+A preview ref and a receipt ref are cheap entities. They are local branded strings `gbg:preview:<evidenceId>:<targetId>@<payloadDigest>` and `gbg:receipt:<evidenceId>:<targetId>@<payloadDigest>`. They are not `SpecimenId`. Honesty is the literal `projected` because the receipt is a receipt of a plan that did not run.
+
+The same evidence id, target id, and payload digest mint the same refs. Retry and restart do not create a second attachment identity.
+
+Catalog attach stays gated. `packages/specimendb/src/rpc/SpecimenRpcs.ts` on this branch exports Intake, Get, List, and Promote. There is no Attach RPC. `probeAttachWell` looks at a caller-supplied port. If `attach` or `Attach` is not a function, the well is `empty-well` with reason `specimendb-attach-unavailable`. If it is a function, the well is `gated-well` and this cut still does not call it. `executable` and `storeWrite` stay the literal `false`. `planAttach` does not mutate the accepted packet when the well is empty.
+
+This cut is not shop-release and not A6.

--- a/projects/biomemetics/labs/mantis/assistant/docs/A5.md
+++ b/projects/biomemetics/labs/mantis/assistant/docs/A5.md
@@ -1,0 +1,11 @@
+# About A5 evidence and projection preview
+
+A5 is a draft TypeScript library under `assistant/evidence` and `assistant/projection`. It is not a Lab screen, not a live catalog write, and not A6 control.
+
+The pipeline named in gbg#55 is:
+
+canonical records and artifacts, then an evidence draft, then schema and provenance validation, then independent review, then accepted evidence, then a projection preview against an explicit existing target, then a governed #16 attach API, then a receipt.
+
+This cut stops at preview. Catalog attach is gated. CopilotKit and Mastra agents are out of this cut.
+
+Read `A5-evidence-queue.md` for the queue, roles, and state machine. Read `A5-projection-preview.md` for payload text, cheap entity refs, and the empty attach well.

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/assistant-memory.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/assistant-memory.json
@@ -1,0 +1,6 @@
+{
+  "kind": "assistant-memory",
+  "threadId": "care:local-subject:conversation",
+  "observation": "User asked what to feed a juvenile in a cup.",
+  "reflectedAt": "2026-08-21T00:00:00Z"
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/chat.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/chat.json
@@ -1,0 +1,7 @@
+{
+  "kind": "chat",
+  "messages": [
+    { "role": "user", "text": "What do I feed it?" },
+    { "role": "assistant", "text": "I can draft care advice. That is not evidence." }
+  ]
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/claim-unbound.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/claim-unbound.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "EvidenceRecord",
+  "evidenceId": "fixture-claim-unbound",
+  "workspaceRef": "biomemetics.mantis",
+  "claimRefs": ["claim:rail:contact-count"],
+  "sourceClass": "measured",
+  "recordedAt": "2026-08-20T12:00:00Z",
+  "producer": { "kind": "instrument", "name": "caliper", "version": "n/a" },
+  "environment": { "description": "theoretical fixture bench", "gitCommit": "1e6683272e4e15d50dd90b60fd3f7c0f3dd5bbb3" },
+  "method": {
+    "protocol": "count exposed pads",
+    "acceptance": "two agreeing counts"
+  },
+  "measurements": [
+    {
+      "parameterRef": "rail.contact_count",
+      "value": 12,
+      "unit": "count",
+      "uncertainty": 0,
+      "sampleCount": 1
+    }
+  ],
+  "artifacts": [
+    {
+      "path": "evidence/fixtures/corpus/positive/contact-count.json",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "mediaType": "application/json"
+    }
+  ],
+  "admissions": [
+    {
+      "claimRef": "claim:borrowed-prose",
+      "kind": "structure",
+      "text": "Admission claimRef is not in claimRefs."
+    }
+  ],
+  "result": {
+    "disposition": "supports",
+    "summary": "Admission is not bound to a claimed ref.",
+    "limitations": ["Must refuse as claim-unbound."]
+  },
+  "review": {
+    "status": "accepted",
+    "reviewer": "fixture-reviewer",
+    "reviewedAt": "2026-08-20T12:05:00Z"
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/digest-missing.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/digest-missing.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "EvidenceRecord",
+  "evidenceId": "fixture-digest-missing",
+  "workspaceRef": "biomemetics.mantis",
+  "claimRefs": ["claim:rail:contact-count"],
+  "sourceClass": "measured",
+  "recordedAt": "2026-08-20T12:00:00Z",
+  "producer": { "kind": "instrument", "name": "caliper", "version": "n/a" },
+  "environment": { "description": "theoretical fixture bench", "gitCommit": "1e6683272e4e15d50dd90b60fd3f7c0f3dd5bbb3" },
+  "method": {
+    "protocol": "count exposed pads",
+    "acceptance": "two agreeing counts"
+  },
+  "measurements": [
+    {
+      "parameterRef": "rail.contact_count",
+      "value": 12,
+      "unit": "count",
+      "uncertainty": 0,
+      "sampleCount": 1
+    }
+  ],
+  "artifacts": [
+    {
+      "uri": "https://example.invalid/mantis/missing-digest.bin",
+      "mediaType": "application/octet-stream"
+    }
+  ],
+  "admissions": [
+    {
+      "claimRef": "claim:rail:contact-count",
+      "kind": "structure",
+      "text": "Coupon exposes twelve contacts."
+    }
+  ],
+  "result": {
+    "disposition": "supports",
+    "summary": "URI artifact without a digest.",
+    "limitations": ["Must refuse as digest-missing."]
+  },
+  "review": {
+    "status": "accepted",
+    "reviewer": "fixture-reviewer",
+    "reviewedAt": "2026-08-20T12:05:00Z"
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/inconclusive.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/inconclusive.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "EvidenceRecord",
+  "evidenceId": "fixture-inconclusive",
+  "workspaceRef": "biomemetics.mantis",
+  "claimRefs": ["claim:rail:contact-count"],
+  "sourceClass": "measured",
+  "recordedAt": "2026-08-20T12:00:00Z",
+  "producer": { "kind": "instrument", "name": "caliper", "version": "n/a" },
+  "environment": { "description": "theoretical fixture bench", "gitCommit": "1e6683272e4e15d50dd90b60fd3f7c0f3dd5bbb3" },
+  "method": {
+    "protocol": "count exposed pads",
+    "acceptance": "two agreeing counts"
+  },
+  "measurements": [
+    {
+      "parameterRef": "rail.contact_count",
+      "value": 12,
+      "unit": "count",
+      "uncertainty": 0,
+      "sampleCount": 1
+    }
+  ],
+  "artifacts": [
+    {
+      "path": "evidence/fixtures/corpus/positive/contact-count.json",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "mediaType": "application/json"
+    }
+  ],
+  "admissions": [
+    {
+      "claimRef": "claim:rail:contact-count",
+      "kind": "structure",
+      "text": "Coupon exposes twelve contacts."
+    }
+  ],
+  "result": {
+    "disposition": "inconclusive",
+    "summary": "Counts disagreed; disposition is inconclusive.",
+    "limitations": ["Inconclusive evidence stays in the queue and cannot attach."]
+  },
+  "review": {
+    "status": "accepted",
+    "reviewer": "fixture-reviewer",
+    "reviewedAt": "2026-08-20T12:05:00Z"
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/invented-locality.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/invented-locality.json
@@ -1,0 +1,8 @@
+{
+  "origin": "canonical-record",
+  "record": {
+    "evidenceId": "smuggled-gps",
+    "latitude": 51.5,
+    "longitude": -0.1
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/om.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/om.json
@@ -1,0 +1,7 @@
+{
+  "origin": "observational-memory",
+  "record": {
+    "class": "assistant-memory",
+    "sentence": "the keeper said it looked like a Chinese mantis"
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/pending-review.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/pending-review.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "EvidenceRecord",
+  "evidenceId": "fixture-pending-review",
+  "workspaceRef": "biomemetics.mantis",
+  "claimRefs": ["claim:rail:contact-count"],
+  "sourceClass": "measured",
+  "recordedAt": "2026-08-20T12:00:00Z",
+  "producer": { "kind": "instrument", "name": "caliper", "version": "n/a" },
+  "environment": { "description": "theoretical fixture bench", "gitCommit": "1e6683272e4e15d50dd90b60fd3f7c0f3dd5bbb3" },
+  "method": {
+    "protocol": "count exposed pads",
+    "acceptance": "two agreeing counts"
+  },
+  "measurements": [
+    {
+      "parameterRef": "rail.contact_count",
+      "value": 12,
+      "unit": "count",
+      "uncertainty": 0,
+      "sampleCount": 1
+    }
+  ],
+  "artifacts": [
+    {
+      "path": "evidence/fixtures/corpus/positive/contact-count.json",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "mediaType": "application/json"
+    }
+  ],
+  "admissions": [
+    {
+      "claimRef": "claim:rail:contact-count",
+      "kind": "structure",
+      "text": "Coupon exposes twelve contacts."
+    }
+  ],
+  "result": {
+    "disposition": "supports",
+    "summary": "Pending review; cannot preview-attach.",
+    "limitations": ["Review has not accepted this record."]
+  },
+  "review": {
+    "status": "pending"
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/photo-only-location.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/photo-only-location.json
@@ -1,0 +1,5 @@
+{
+  "kind": "photo-only-location",
+  "gps": { "latitude": 51.5, "longitude": -0.1 },
+  "exif": { "GPSLatitude": 51.5, "GPSLongitude": -0.1 }
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/photo-only-taxon.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/photo-only-taxon.json
@@ -1,0 +1,5 @@
+{
+  "kind": "photo-only-taxon",
+  "scientificName": "Mantis religiosa",
+  "from": "photo"
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/raw-telemetry.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/raw-telemetry.json
@@ -1,0 +1,6 @@
+{
+  "kind": "raw-telemetry",
+  "samples": [
+    { "parameter": "enclosure.temperature", "value": 24.1, "unit": "C" }
+  ]
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/recommendation.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/recommendation.json
@@ -1,0 +1,5 @@
+{
+  "kind": "recommendation",
+  "advice": "Offer a small cricket and watch whether it is taken.",
+  "confidence": "unverified"
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/rejected.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/rejected.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "EvidenceRecord",
+  "evidenceId": "fixture-rejected-review",
+  "workspaceRef": "biomemetics.mantis",
+  "claimRefs": ["claim:rail:contact-count"],
+  "sourceClass": "measured",
+  "recordedAt": "2026-08-20T12:00:00Z",
+  "producer": { "kind": "instrument", "name": "caliper", "version": "n/a" },
+  "environment": { "description": "theoretical fixture bench", "gitCommit": "1e6683272e4e15d50dd90b60fd3f7c0f3dd5bbb3" },
+  "method": {
+    "protocol": "count exposed pads",
+    "acceptance": "two agreeing counts"
+  },
+  "measurements": [
+    {
+      "parameterRef": "rail.contact_count",
+      "value": 12,
+      "unit": "count",
+      "uncertainty": 0,
+      "sampleCount": 1
+    }
+  ],
+  "artifacts": [
+    {
+      "path": "evidence/fixtures/corpus/positive/contact-count.json",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "mediaType": "application/json"
+    }
+  ],
+  "admissions": [
+    {
+      "claimRef": "claim:rail:contact-count",
+      "kind": "structure",
+      "text": "Coupon exposes twelve contacts."
+    }
+  ],
+  "result": {
+    "disposition": "supports",
+    "summary": "Rejected by independent review.",
+    "limitations": ["Rejected records stay in the queue and cannot attach."]
+  },
+  "review": {
+    "status": "rejected",
+    "reviewer": "fixture-reviewer",
+    "reviewedAt": "2026-08-20T12:05:00Z",
+    "notes": "Negative rejected case."
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/taxon-hypothesis.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/negative/taxon-hypothesis.json
@@ -1,0 +1,6 @@
+{
+  "kind": "taxon-hypothesis",
+  "scientificName": "Mantis religiosa",
+  "confidence": 0.4,
+  "from": "photo-only"
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/positive/accepted-measured.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/fixtures/positive/accepted-measured.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": "1.0.0",
+  "kind": "EvidenceRecord",
+  "evidenceId": "fixture-positive-measured",
+  "workspaceRef": "biomemetics.mantis",
+  "claimRefs": ["claim:rail:contact-count"],
+  "sourceClass": "measured",
+  "recordedAt": "2026-08-20T12:00:00Z",
+  "producer": { "kind": "instrument", "name": "caliper", "version": "n/a" },
+  "environment": { "description": "theoretical fixture bench", "gitCommit": "1e6683272e4e15d50dd90b60fd3f7c0f3dd5bbb3" },
+  "method": {
+    "protocol": "count exposed pads",
+    "acceptance": "two agreeing counts"
+  },
+  "measurements": [
+    {
+      "parameterRef": "rail.contact_count",
+      "value": 12,
+      "unit": "count",
+      "uncertainty": 0,
+      "sampleCount": 1
+    }
+  ],
+  "artifacts": [
+    {
+      "path": "evidence/fixtures/corpus/positive/contact-count.json",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "mediaType": "application/json"
+    },
+    {
+      "uri": "https://example.invalid/mantis/fixture-positive.bin",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "mediaType": "application/octet-stream"
+    }
+  ],
+  "admissions": [
+    {
+      "claimRef": "claim:rail:contact-count",
+      "kind": "structure",
+      "text": "Coupon exposes twelve contacts.",
+      "projectionBinding": {
+        "evidenceId": "fixture-positive-measured",
+        "claimRef": "claim:rail:contact-count",
+        "admissionText": "Coupon exposes twelve contacts.",
+        "reviewStatus": "accepted"
+      }
+    }
+  ],
+  "result": {
+    "disposition": "supports",
+    "summary": "Positive Draft 2020-12 fixture with digested path and URI artifacts.",
+    "limitations": ["Theoretical fixture only; not measured hardware."]
+  },
+  "review": {
+    "status": "accepted",
+    "reviewer": "fixture-reviewer",
+    "reviewedAt": "2026-08-20T12:05:00Z",
+    "notes": "Corpus positive case."
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/package-lock.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "@tmnl/mantis-assistant-evidence",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@tmnl/mantis-assistant-evidence",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^25.0.8",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/package.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tmnl/mantis-assistant-evidence",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Reviewed evidence queue for mantis assistant A5. Draft library, not live catalog attach.",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node --test --experimental-strip-types test/*.test.ts ../projection/test/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.8",
+    "typescript": "^5.9.3"
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/src/actors.ts
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/src/actors.ts
@@ -1,0 +1,37 @@
+export type ActorId = string & { readonly __brand: 'ActorId' };
+
+export type Curator = {
+  readonly actorId: ActorId;
+  readonly role: 'evidence-curator';
+};
+
+export type AdversarialReviewer = {
+  readonly actorId: ActorId;
+  readonly role: 'adversarial-reviewer';
+};
+
+export type GovernedReviewer = {
+  readonly actorId: ActorId;
+  readonly role: 'governed-reviewer';
+};
+
+export type Actor = Curator | AdversarialReviewer | GovernedReviewer;
+
+const brandActorId = (id: string): ActorId => {
+  if (id.trim() === '') {
+    throw new TypeError('actor id is blank');
+  }
+  return id as ActorId;
+};
+
+export function curator(id: string): Curator {
+  return { actorId: brandActorId(id), role: 'evidence-curator' };
+}
+
+export function adversarialReviewer(id: string): AdversarialReviewer {
+  return { actorId: brandActorId(id), role: 'adversarial-reviewer' };
+}
+
+export function governedReviewer(id: string): GovernedReviewer {
+  return { actorId: brandActorId(id), role: 'governed-reviewer' };
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/src/index.ts
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/src/index.ts
@@ -1,0 +1,48 @@
+export {
+  adversarialReviewer,
+  curator,
+  governedReviewer,
+  type Actor,
+  type ActorId,
+  type AdversarialReviewer,
+  type Curator,
+  type GovernedReviewer,
+} from './actors.ts';
+export {
+  parseIntake,
+  type AdmissibleOrigin,
+  type InadmissibleOrigin,
+  type IntakeOrigin,
+  type IntakeRefusal,
+  type IntakeRefusalReason,
+  type IntakeRequest,
+} from './intake.ts';
+export {
+  isTransitionRefusal,
+  type AcceptedPacket,
+  type Clock,
+  type DraftPacket,
+  type EvidencePacket,
+  type PacketId,
+  type PendingReviewPacket,
+  type QueueId,
+  type RejectedPacket,
+  type RetainedInconclusivePacket,
+  type TransitionRefusal,
+  type TransitionRefusalReason,
+  type ValidatedPacket,
+} from './packet.ts';
+export {
+  createEvidenceQueue,
+  type EvidenceQueue,
+  type PreviewRefusal,
+  type PreviewRefusalReason,
+} from './queue.ts';
+export {
+  EVIDENCE_SCHEMA_PATH,
+  EVIDENCE_SCHEMA_SHA256,
+  isTrustedEvidenceSchemaGate,
+  loadEvidenceSchemaGate,
+  type EvidenceSchemaGate,
+  type ValidatedEvidenceRecord,
+} from './schema-gate.ts';

--- a/projects/biomemetics/labs/mantis/assistant/evidence/src/intake.ts
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/src/intake.ts
@@ -1,0 +1,112 @@
+export type AdmissibleOrigin = 'canonical-record' | 'lab-artifact';
+
+export type InadmissibleOrigin =
+  | 'observational-memory'
+  | 'chat'
+  | 'recommendation'
+  | 'raw-telemetry'
+  | 'taxon-hypothesis'
+  | 'photo-only-taxon'
+  | 'photo-only-location';
+
+export type IntakeOrigin = AdmissibleOrigin | InadmissibleOrigin;
+
+export type IntakeRequest = {
+  readonly ok: true;
+  readonly origin: AdmissibleOrigin;
+  readonly record: unknown;
+};
+
+export type IntakeRefusalReason =
+  | `origin-inadmissible:${InadmissibleOrigin}`
+  | 'origin-missing'
+  | 'origin-unknown'
+  | 'taxon-or-locality-keys-present'
+  | 'evidence-id-missing';
+
+export type IntakeRefusal = {
+  readonly ok: false;
+  readonly reasons: readonly IntakeRefusalReason[];
+};
+
+const ADMISSIBLE = new Set<AdmissibleOrigin>(['canonical-record', 'lab-artifact']);
+
+const INADMISSIBLE = new Set<InadmissibleOrigin>([
+  'observational-memory',
+  'chat',
+  'recommendation',
+  'raw-telemetry',
+  'taxon-hypothesis',
+  'photo-only-taxon',
+  'photo-only-location',
+]);
+
+const TAXON_OR_LOCALITY_KEYS = new Set([
+  'taxon',
+  'photoTaxon',
+  'locality',
+  'gps',
+  'geo',
+  'latitude',
+  'longitude',
+  'altitudeMeters',
+  'GPSLatitude',
+  'GPSLongitude',
+  'gpsLatitude',
+  'gpsLongitude',
+  'exifGps',
+]);
+
+type JsonObject = Record<string, unknown>;
+
+const isObject = (value: unknown): value is JsonObject =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const collectKeys = (value: unknown, depth: number, acc: Set<string>): void => {
+  if (depth < 0) return;
+  if (Array.isArray(value)) {
+    for (const item of value) collectKeys(item, depth - 1, acc);
+    return;
+  }
+  if (!isObject(value)) return;
+  for (const [key, nested] of Object.entries(value)) {
+    acc.add(key);
+    collectKeys(nested, depth - 1, acc);
+  }
+};
+
+const hasTaxonOrLocalityKeys = (value: unknown): boolean => {
+  const keys = new Set<string>();
+  collectKeys(value, 4, keys);
+  for (const key of keys) {
+    if (TAXON_OR_LOCALITY_KEYS.has(key)) return true;
+  }
+  if (keys.has('exif') && isObject(value) && isObject(value.exif)) {
+    return true;
+  }
+  return false;
+};
+
+export function parseIntake(input: unknown): IntakeRequest | IntakeRefusal {
+  if (!isObject(input)) {
+    return { ok: false, reasons: ['origin-missing'] };
+  }
+  if (!('origin' in input)) {
+    return { ok: false, reasons: ['origin-missing'] };
+  }
+  const origin = input.origin;
+  if (typeof origin !== 'string') {
+    return { ok: false, reasons: ['origin-missing'] };
+  }
+  if (INADMISSIBLE.has(origin as InadmissibleOrigin)) {
+    return { ok: false, reasons: [`origin-inadmissible:${origin as InadmissibleOrigin}`] };
+  }
+  if (!ADMISSIBLE.has(origin as AdmissibleOrigin)) {
+    return { ok: false, reasons: ['origin-unknown'] };
+  }
+  const record = 'record' in input ? input.record : undefined;
+  if (hasTaxonOrLocalityKeys(input) || hasTaxonOrLocalityKeys(record)) {
+    return { ok: false, reasons: ['taxon-or-locality-keys-present'] };
+  }
+  return { ok: true, origin: origin as AdmissibleOrigin, record };
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/src/packet.ts
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/src/packet.ts
@@ -1,0 +1,347 @@
+import type { AdversarialReviewer, Curator, GovernedReviewer } from './actors.ts';
+import type { AdmissibleOrigin } from './intake.ts';
+import {
+  isTrustedEvidenceSchemaGate,
+  type EvidenceAdmission,
+  type EvidenceSchemaGate,
+  type ValidatedEvidenceRecord,
+} from './schema-gate.ts';
+
+export type QueueId = string & { readonly __brand: 'QueueId' };
+export type PacketId = string & { readonly __brand: 'PacketId' };
+
+type PacketBase = {
+  readonly packetId: PacketId;
+  readonly evidenceId: string;
+  readonly origin: AdmissibleOrigin;
+  readonly author: Curator;
+};
+
+export type DefectFlag = {
+  readonly flaggedBy: AdversarialReviewer;
+  readonly notes: string;
+};
+
+export type DraftPacket = PacketBase & {
+  readonly state: 'draft';
+  readonly record: unknown;
+};
+
+export type ValidatedPacket = PacketBase & {
+  readonly state: 'validated';
+  readonly record: ValidatedEvidenceRecord;
+};
+
+export type PendingReviewPacket = PacketBase & {
+  readonly state: 'pending-review';
+  readonly record: ValidatedEvidenceRecord;
+  readonly defects: readonly DefectFlag[];
+};
+
+export type AcceptedPacket = PacketBase & {
+  readonly state: 'accepted';
+  readonly record: ValidatedEvidenceRecord & {
+    readonly review: {
+      readonly status: 'accepted';
+      readonly reviewer: string;
+      readonly reviewedAt: string;
+    };
+  };
+  readonly reviewer: GovernedReviewer;
+};
+
+export type RejectedPacket = PacketBase & {
+  readonly state: 'rejected';
+  readonly record: ValidatedEvidenceRecord & {
+    readonly review: {
+      readonly status: 'rejected';
+      readonly reviewer: string;
+      readonly reviewedAt: string;
+    };
+  };
+  readonly reviewer: GovernedReviewer;
+};
+
+export type RetainedInconclusivePacket = PacketBase & {
+  readonly state: 'retained-inconclusive';
+  readonly record: ValidatedEvidenceRecord;
+  readonly reviewer: GovernedReviewer;
+};
+
+export type EvidencePacket =
+  | DraftPacket
+  | ValidatedPacket
+  | PendingReviewPacket
+  | AcceptedPacket
+  | RejectedPacket
+  | RetainedInconclusivePacket;
+
+export type TransitionRefusalReason =
+  | 'wrong-state'
+  | 'schema-invalid'
+  | 'claim-unbound'
+  | 'digest-missing'
+  | 'self-admission'
+  | 'author-cannot-accept'
+  | 'adversarial-cannot-accept'
+  | 'adversarial-cannot-edit'
+  | 'reviewer-is-author'
+  | 'curator-cannot-accept'
+  | 'disposition-not-supportable'
+  | 'source-class-not-projectable'
+  | 'admission-missing'
+  | 'admission-ambiguous'
+  | 'incoming-review-not-pending'
+  | 'record-digest-conflict'
+  | 'evidence-id-missing';
+
+export type TransitionRefusal = {
+  readonly ok: false;
+  readonly packetId: PacketId;
+  readonly reasons: readonly TransitionRefusalReason[];
+};
+
+export type Clock = { readonly now: () => string };
+
+type JsonObject = Record<string, unknown>;
+
+const isObject = (value: unknown): value is JsonObject =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const isTransitionRefusal = (value: unknown): value is TransitionRefusal =>
+  isObject(value) &&
+  value.ok === false &&
+  typeof value.packetId === 'string' &&
+  Array.isArray(value.reasons);
+
+const refuse = (
+  packetId: PacketId,
+  reasons: readonly TransitionRefusalReason[],
+): TransitionRefusal => ({ ok: false, packetId, reasons });
+
+const digestMissing = (record: unknown): boolean => {
+  if (!isObject(record) || !Array.isArray(record.artifacts)) return false;
+  return record.artifacts.some((artifact) => {
+    if (!isObject(artifact)) return false;
+    const hasLocator =
+      typeof artifact.path === 'string' || typeof artifact.uri === 'string';
+    return hasLocator && typeof artifact.sha256 !== 'string';
+  });
+};
+
+const unboundClaims = (record: unknown): boolean => {
+  if (!isObject(record)) return false;
+  const claimRefs = Array.isArray(record.claimRefs) ? record.claimRefs : [];
+  const admissions = Array.isArray(record.admissions) ? record.admissions : [];
+  return admissions.some(
+    (admission) => isObject(admission) && !claimRefs.includes(admission.claimRef),
+  );
+};
+
+const incomingReviewBlocks = (record: unknown): TransitionRefusalReason | undefined => {
+  if (!isObject(record) || !isObject(record.review)) return undefined;
+  if (record.review.status !== 'pending') return 'incoming-review-not-pending';
+  const admissions = Array.isArray(record.admissions) ? record.admissions : [];
+  const bound = admissions.some(
+    (admission) => isObject(admission) && admission.projectionBinding !== undefined,
+  );
+  if (bound) return 'self-admission';
+  return undefined;
+};
+
+const projectableSource = (sourceClass: string): boolean =>
+  sourceClass === 'observed' || sourceClass === 'measured';
+
+const stampBindings = (
+  record: ValidatedEvidenceRecord,
+): readonly EvidenceAdmission[] =>
+  (record.admissions ?? []).map((admission) => {
+    const binding = {
+      evidenceId: record.evidenceId,
+      claimRef: admission.claimRef,
+      admissionText: admission.text,
+      reviewStatus: 'accepted' as const,
+    };
+    return admission.target === undefined
+      ? {
+          claimRef: admission.claimRef,
+          kind: admission.kind,
+          text: admission.text,
+          projectionBinding: binding,
+        }
+      : {
+          claimRef: admission.claimRef,
+          kind: admission.kind,
+          text: admission.text,
+          target: admission.target,
+          projectionBinding: binding,
+        };
+  });
+
+export function validateDraft(
+  packet: DraftPacket,
+  gate: EvidenceSchemaGate,
+): ValidatedPacket | TransitionRefusal {
+  if (!isTrustedEvidenceSchemaGate(gate)) {
+    throw new TypeError('evidence schema gate is not trusted');
+  }
+  const reasons: TransitionRefusalReason[] = [];
+  const reviewBlock = incomingReviewBlocks(packet.record);
+  if (reviewBlock !== undefined) reasons.push(reviewBlock);
+  if (digestMissing(packet.record)) reasons.push('digest-missing');
+  if (unboundClaims(packet.record)) reasons.push('claim-unbound');
+  const schema = gate.validate(packet.record);
+  if (!schema.valid) {
+    reasons.push('schema-invalid');
+    return refuse(packet.packetId, reasons);
+  }
+  if (reasons.length > 0) return refuse(packet.packetId, reasons);
+  return {
+    packetId: packet.packetId,
+    evidenceId: packet.evidenceId,
+    origin: packet.origin,
+    author: packet.author,
+    state: 'validated',
+    record: schema.value,
+  };
+}
+
+const actorRole = (actor: { readonly role: string }): string => actor.role;
+
+export function submitValidated(
+  packet: ValidatedPacket,
+  actor: Curator,
+): PendingReviewPacket | TransitionRefusal {
+  if (actor.actorId !== packet.author.actorId) {
+    return refuse(packet.packetId, ['wrong-state']);
+  }
+  return {
+    packetId: packet.packetId,
+    evidenceId: packet.evidenceId,
+    origin: packet.origin,
+    author: packet.author,
+    state: 'pending-review',
+    record: packet.record,
+    defects: [],
+  };
+}
+
+export function flagPending(
+  packet: PendingReviewPacket,
+  actor: AdversarialReviewer,
+  notes: string,
+): PendingReviewPacket | TransitionRefusal {
+  if (actorRole(actor) !== 'adversarial-reviewer') {
+    return refuse(packet.packetId, ['adversarial-cannot-edit']);
+  }
+  return {
+    ...packet,
+    defects: [...packet.defects, { flaggedBy: actor, notes }],
+  };
+}
+
+const independence = (
+  packet: PendingReviewPacket,
+  reviewer: GovernedReviewer,
+): TransitionRefusal | undefined => {
+  const role = actorRole(reviewer);
+  if (role === 'adversarial-reviewer') {
+    return refuse(packet.packetId, ['adversarial-cannot-accept']);
+  }
+  if (role !== 'governed-reviewer') {
+    return refuse(packet.packetId, ['curator-cannot-accept']);
+  }
+  if (reviewer.actorId === packet.author.actorId) {
+    return refuse(packet.packetId, ['reviewer-is-author']);
+  }
+  return undefined;
+};
+
+export function acceptPending(
+  packet: PendingReviewPacket,
+  reviewer: GovernedReviewer,
+  clock: Clock,
+): AcceptedPacket | TransitionRefusal {
+  const blocked = independence(packet, reviewer);
+  if (blocked !== undefined) return blocked;
+  if (!projectableSource(packet.record.sourceClass)) {
+    return refuse(packet.packetId, ['source-class-not-projectable']);
+  }
+  if (packet.record.result.disposition !== 'supports') {
+    return refuse(packet.packetId, ['disposition-not-supportable']);
+  }
+  const admissions = packet.record.admissions ?? [];
+  if (admissions.length === 0) {
+    return refuse(packet.packetId, ['admission-missing']);
+  }
+  const byClaim = new Map<string, number>();
+  for (const admission of admissions) {
+    byClaim.set(admission.claimRef, (byClaim.get(admission.claimRef) ?? 0) + 1);
+  }
+  for (const count of byClaim.values()) {
+    if (count !== 1) return refuse(packet.packetId, ['admission-ambiguous']);
+  }
+  const reviewedAt = clock.now();
+  return {
+    packetId: packet.packetId,
+    evidenceId: packet.evidenceId,
+    origin: packet.origin,
+    author: packet.author,
+    state: 'accepted',
+    reviewer,
+    record: {
+      ...packet.record,
+      admissions: stampBindings(packet.record),
+      review: {
+        status: 'accepted',
+        reviewer: reviewer.actorId,
+        reviewedAt,
+      },
+    },
+  };
+}
+
+export function rejectPending(
+  packet: PendingReviewPacket,
+  reviewer: GovernedReviewer,
+  clock: Clock,
+): RejectedPacket | TransitionRefusal {
+  const blocked = independence(packet, reviewer);
+  if (blocked !== undefined) return blocked;
+  return {
+    packetId: packet.packetId,
+    evidenceId: packet.evidenceId,
+    origin: packet.origin,
+    author: packet.author,
+    state: 'rejected',
+    reviewer,
+    record: {
+      ...packet.record,
+      review: {
+        status: 'rejected',
+        reviewer: reviewer.actorId,
+        reviewedAt: clock.now(),
+      },
+    },
+  };
+}
+
+export function retainPendingInconclusive(
+  packet: PendingReviewPacket,
+  reviewer: GovernedReviewer,
+): RetainedInconclusivePacket | TransitionRefusal {
+  const blocked = independence(packet, reviewer);
+  if (blocked !== undefined) return blocked;
+  if (packet.record.result.disposition !== 'inconclusive') {
+    return refuse(packet.packetId, ['disposition-not-supportable']);
+  }
+  return {
+    packetId: packet.packetId,
+    evidenceId: packet.evidenceId,
+    origin: packet.origin,
+    author: packet.author,
+    state: 'retained-inconclusive',
+    reviewer,
+    record: packet.record,
+  };
+}

--- a/projects/biomemetics/labs/mantis/assistant/evidence/src/queue.ts
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/src/queue.ts
@@ -1,0 +1,308 @@
+import { createHash } from 'node:crypto';
+
+import type { AdversarialReviewer, Curator, GovernedReviewer } from './actors.ts';
+import { parseIntake, type IntakeRefusal } from './intake.ts';
+import {
+  acceptPending,
+  flagPending,
+  isTransitionRefusal,
+  rejectPending,
+  retainPendingInconclusive,
+  submitValidated,
+  validateDraft,
+  type AcceptedPacket,
+  type Clock,
+  type DraftPacket,
+  type EvidencePacket,
+  type PacketId,
+  type PendingReviewPacket,
+  type QueueId,
+  type RejectedPacket,
+  type RetainedInconclusivePacket,
+  type TransitionRefusal,
+  type ValidatedPacket,
+} from './packet.ts';
+import {
+  isTrustedEvidenceSchemaGate,
+  loadEvidenceSchemaGate,
+  type EvidenceSchemaGate,
+} from './schema-gate.ts';
+
+export type PreviewRefusalReason =
+  | 'packet-not-found'
+  | 'packet-not-accepted'
+  | 'packet-rejected'
+  | 'packet-retained-inconclusive'
+  | 'packet-pending-review'
+  | 'packet-draft'
+  | 'packet-validated-only'
+  | 'claim-unbound'
+  | 'digest-missing'
+  | 'admission-text-missing'
+  | 'source-class-not-projectable'
+  | 'result-does-not-support'
+  | 'invented-target'
+  | 'lab-as-specimen'
+  | 'invented-locality'
+  | 'invented-taxon'
+  | 'caller-component-prose';
+
+export type PreviewRefusal = {
+  readonly ok: false;
+  readonly reasons: readonly PreviewRefusalReason[];
+};
+
+export type EvidenceQueue = {
+  readonly queueId: QueueId;
+  readonly enqueueDraft: (
+    actor: Curator,
+    input: unknown,
+  ) => { readonly ok: true; readonly packet: DraftPacket } | IntakeRefusal | TransitionRefusal;
+  readonly validate: (
+    packetId: PacketId,
+  ) => { readonly ok: true; readonly packet: ValidatedPacket } | TransitionRefusal;
+  readonly submit: (
+    packetId: PacketId,
+    actor: Curator,
+  ) => { readonly ok: true; readonly packet: PendingReviewPacket } | TransitionRefusal;
+  readonly flagDefect: (
+    packetId: PacketId,
+    actor: AdversarialReviewer,
+    notes: string,
+  ) => { readonly ok: true; readonly packet: PendingReviewPacket } | TransitionRefusal;
+  readonly accept: (
+    packetId: PacketId,
+    actor: GovernedReviewer,
+  ) => { readonly ok: true; readonly packet: AcceptedPacket } | TransitionRefusal;
+  readonly reject: (
+    packetId: PacketId,
+    actor: GovernedReviewer,
+  ) => { readonly ok: true; readonly packet: RejectedPacket } | TransitionRefusal;
+  readonly retainInconclusive: (
+    packetId: PacketId,
+    actor: GovernedReviewer,
+  ) =>
+    | { readonly ok: true; readonly packet: RetainedInconclusivePacket }
+    | TransitionRefusal;
+  readonly get: (packetId: PacketId) => EvidencePacket | undefined;
+  readonly requireAccepted: (
+    packetId: PacketId,
+  ) => { readonly ok: true; readonly packet: AcceptedPacket } | PreviewRefusal;
+  readonly list: (state?: EvidencePacket['state']) => readonly EvidencePacket[];
+};
+
+type JsonObject = Record<string, unknown>;
+
+const isObject = (value: unknown): value is JsonObject =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const EVIDENCE_ID = /^[a-z][a-z0-9.-]*$/;
+
+const asPacketId = (evidenceId: string): PacketId => evidenceId as PacketId;
+
+const asQueueId = (queueId: string): QueueId => {
+  if (queueId.trim() === '') {
+    throw new TypeError('queue id is blank');
+  }
+  return queueId as QueueId;
+};
+
+const digestOf = (record: unknown): string =>
+  createHash('sha256').update(JSON.stringify(record)).digest('hex');
+
+const stripSelfAdmission = (record: unknown): unknown => {
+  if (!isObject(record)) return record;
+  const clone: JsonObject = { ...record, review: { status: 'pending' } };
+  if (!Array.isArray(record.admissions)) return clone;
+  clone.admissions = record.admissions.map((admission) => {
+    if (!isObject(admission)) return admission;
+    const { projectionBinding: _binding, ...rest } = admission;
+    return rest;
+  });
+  return clone;
+};
+
+const evidenceIdOf = (record: unknown): string | undefined => {
+  if (!isObject(record) || typeof record.evidenceId !== 'string') return undefined;
+  if (!EVIDENCE_ID.test(record.evidenceId)) return undefined;
+  return record.evidenceId;
+};
+
+const missing = (packetId: PacketId): TransitionRefusal => ({
+  ok: false,
+  packetId,
+  reasons: ['wrong-state'],
+});
+
+const isoClock: Clock = { now: () => new Date().toISOString() };
+
+export function createEvidenceQueue(options: {
+  readonly queueId: string;
+  readonly gate?: EvidenceSchemaGate;
+  readonly clock?: Clock;
+}): EvidenceQueue {
+  const queueId = asQueueId(options.queueId);
+  const gate = options.gate ?? loadEvidenceSchemaGate();
+  if (!isTrustedEvidenceSchemaGate(gate)) {
+    throw new TypeError('evidence schema gate is not trusted');
+  }
+  const clock = options.clock ?? isoClock;
+  const packets = new Map<string, EvidencePacket>();
+  const intakeDigests = new Map<string, string>();
+
+  const put = (packet: EvidencePacket): void => {
+    packets.set(packet.packetId, packet);
+  };
+
+  return {
+    queueId,
+    enqueueDraft: (actor, input) => {
+      const parsed = parseIntake(input);
+      if (parsed.ok === false) return parsed;
+      const record = stripSelfAdmission(parsed.record);
+      const evidenceId = evidenceIdOf(record);
+      if (evidenceId === undefined) {
+        return { ok: false, reasons: ['evidence-id-missing'] };
+      }
+      const packetId = asPacketId(evidenceId);
+      const digest = digestOf(record);
+      const existing = packets.get(packetId);
+      if (existing !== undefined) {
+        if (intakeDigests.get(packetId) === digest) {
+          return existing.state === 'draft'
+            ? { ok: true, packet: existing }
+            : { ok: false, packetId, reasons: ['wrong-state'] };
+        }
+        return { ok: false, packetId, reasons: ['record-digest-conflict'] };
+      }
+      const packet: DraftPacket = {
+        packetId,
+        evidenceId,
+        origin: parsed.origin,
+        author: actor,
+        state: 'draft',
+        record,
+      };
+      intakeDigests.set(packetId, digest);
+      put(packet);
+      return { ok: true, packet };
+    },
+    validate: (packetId) => {
+      const packet = packets.get(packetId);
+      if (packet === undefined) return missing(packetId);
+      if (packet.state === 'validated') return { ok: true, packet };
+      if (packet.state !== 'draft') {
+        return { ok: false, packetId, reasons: ['wrong-state'] };
+      }
+      const next = validateDraft(packet, gate);
+      if (isTransitionRefusal(next)) return next;
+      put(next);
+      return { ok: true, packet: next };
+    },
+    submit: (packetId, actor) => {
+      const packet = packets.get(packetId);
+      if (packet === undefined) return missing(packetId);
+      if (packet.state === 'pending-review') return { ok: true, packet };
+      if (packet.state !== 'validated') {
+        return { ok: false, packetId, reasons: ['wrong-state'] };
+      }
+      const next = submitValidated(packet, actor);
+      if (isTransitionRefusal(next)) return next;
+      put(next);
+      return { ok: true, packet: next };
+    },
+    flagDefect: (packetId, actor, notes) => {
+      const packet = packets.get(packetId);
+      if (packet === undefined) return missing(packetId);
+      if (packet.state !== 'pending-review') {
+        return { ok: false, packetId, reasons: ['wrong-state'] };
+      }
+      const next = flagPending(packet, actor, notes);
+      if (isTransitionRefusal(next)) return next;
+      put(next);
+      return { ok: true, packet: next };
+    },
+    accept: (packetId, actor) => {
+      const packet = packets.get(packetId);
+      if (packet === undefined) return missing(packetId);
+      if (packet.state === 'accepted') {
+        if (packet.reviewer.actorId === actor.actorId) {
+          return { ok: true, packet };
+        }
+        return { ok: false, packetId, reasons: ['wrong-state'] };
+      }
+      if (packet.state !== 'pending-review') {
+        return { ok: false, packetId, reasons: ['wrong-state'] };
+      }
+      const next = acceptPending(packet, actor, clock);
+      if (isTransitionRefusal(next)) return next;
+      put(next);
+      return { ok: true, packet: next };
+    },
+    reject: (packetId, actor) => {
+      const packet = packets.get(packetId);
+      if (packet === undefined) return missing(packetId);
+      if (packet.state === 'rejected') {
+        if (packet.reviewer.actorId === actor.actorId) {
+          return { ok: true, packet };
+        }
+        return { ok: false, packetId, reasons: ['wrong-state'] };
+      }
+      if (packet.state !== 'pending-review') {
+        return { ok: false, packetId, reasons: ['wrong-state'] };
+      }
+      const next = rejectPending(packet, actor, clock);
+      if (isTransitionRefusal(next)) return next;
+      put(next);
+      return { ok: true, packet: next };
+    },
+    retainInconclusive: (packetId, actor) => {
+      const packet = packets.get(packetId);
+      if (packet === undefined) return missing(packetId);
+      if (packet.state === 'retained-inconclusive') {
+        if (packet.reviewer.actorId === actor.actorId) {
+          return { ok: true, packet };
+        }
+        return { ok: false, packetId, reasons: ['wrong-state'] };
+      }
+      if (packet.state !== 'pending-review') {
+        return { ok: false, packetId, reasons: ['wrong-state'] };
+      }
+      const next = retainPendingInconclusive(packet, actor);
+      if (isTransitionRefusal(next)) return next;
+      put(next);
+      return { ok: true, packet: next };
+    },
+    get: (packetId) => packets.get(packetId),
+    requireAccepted: (packetId) => {
+      const packet = packets.get(packetId);
+      if (packet === undefined) {
+        return { ok: false, reasons: ['packet-not-found'] };
+      }
+      switch (packet.state) {
+        case 'accepted':
+          return { ok: true, packet };
+        case 'draft':
+          return { ok: false, reasons: ['packet-draft'] };
+        case 'validated':
+          return { ok: false, reasons: ['packet-validated-only'] };
+        case 'pending-review':
+          return { ok: false, reasons: ['packet-pending-review'] };
+        case 'rejected':
+          return { ok: false, reasons: ['packet-rejected'] };
+        case 'retained-inconclusive':
+          return { ok: false, reasons: ['packet-retained-inconclusive'] };
+        default: {
+          const _exhaustive: never = packet;
+          return _exhaustive;
+        }
+      }
+    },
+    list: (state) => {
+      const all = [...packets.values()];
+      return state === undefined ? all : all.filter((packet) => packet.state === state);
+    },
+  };
+}
+
+export type { EvidencePacket, PacketId, QueueId } from './packet.ts';

--- a/projects/biomemetics/labs/mantis/assistant/evidence/src/schema-gate.ts
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/src/schema-gate.ts
@@ -1,0 +1,663 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+export const EVIDENCE_SCHEMA_PATH = 'contracts/evidence.schema.json' as const;
+export const EVIDENCE_SCHEMA_SHA256 =
+  'bf38331eb8f66d1152e0ef16ab003ebc6fb4c5d9ec9b06cf395860e2f3485cf1' as const;
+
+export type SchemaDigest = string & { readonly __brand: 'SchemaDigest' };
+
+export type EvidenceAdmission = {
+  readonly claimRef: string;
+  readonly kind: 'observation' | 'structure' | 'mechanism' | 'function' | 'analog';
+  readonly text: string;
+  readonly target?: string;
+  readonly projectionBinding?: {
+    readonly evidenceId: string;
+    readonly claimRef: string;
+    readonly admissionText: string;
+    readonly reviewStatus: 'accepted';
+  };
+};
+
+export type EvidenceReview =
+  | { readonly status: 'pending'; readonly notes?: string }
+  | {
+      readonly status: 'accepted' | 'rejected';
+      readonly reviewer: string;
+      readonly reviewedAt: string;
+      readonly notes?: string;
+    }
+  | { readonly status: 'superseded'; readonly notes?: string };
+
+export type ValidatedEvidenceRecord = {
+  readonly schemaVersion: '1.0.0';
+  readonly kind: 'EvidenceRecord';
+  readonly evidenceId: string;
+  readonly workspaceRef: 'biomemetics.mantis';
+  readonly claimRefs: readonly string[];
+  readonly sourceClass:
+    | 'measured'
+    | 'simulated'
+    | 'calculated'
+    | 'observed'
+    | 'external-source';
+  readonly recordedAt: string;
+  readonly producer: {
+    readonly kind: 'human' | 'agent' | 'tool' | 'instrument';
+    readonly name: string;
+    readonly version?: string;
+    readonly model?: string;
+  };
+  readonly environment: { readonly description: string; readonly gitCommit?: string };
+  readonly method: { readonly protocol: string; readonly acceptance: string };
+  readonly inputs?: readonly { readonly ref: string; readonly role: string; readonly sha256?: string }[];
+  readonly observations?: readonly {
+    readonly statement: string;
+    readonly status: 'observed' | 'interpreted' | 'unverified';
+    readonly sourceRef?: string;
+  }[];
+  readonly measurements?: readonly {
+    readonly parameterRef: string;
+    readonly value: number;
+    readonly unit: string;
+    readonly uncertainty: number;
+  }[];
+  readonly artifacts?: readonly {
+    readonly path?: string;
+    readonly uri?: string;
+    readonly sha256: string;
+    readonly mediaType: string;
+  }[];
+  readonly admissions?: readonly EvidenceAdmission[];
+  readonly result: {
+    readonly disposition: 'supports' | 'contradicts' | 'inconclusive' | 'not-run';
+    readonly summary: string;
+    readonly limitations: readonly string[];
+  };
+  readonly review: EvidenceReview;
+};
+
+export type SchemaValidation =
+  | { readonly valid: true; readonly value: ValidatedEvidenceRecord }
+  | { readonly valid: false; readonly errors: readonly string[] };
+
+export type EvidenceSchemaGate = {
+  readonly schemaPath: typeof EVIDENCE_SCHEMA_PATH;
+  readonly schemaSha256: SchemaDigest;
+  readonly validate: (input: unknown) => SchemaValidation;
+};
+
+const validators = new WeakSet<object>();
+const schemaUrl = new URL(
+  '../../../contracts/evidence.schema.json',
+  import.meta.url,
+);
+
+type JsonObject = Record<string, unknown>;
+
+const isObject = (value: unknown): value is JsonObject =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isNonBlank = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim() !== '';
+
+const hasOnlyKeys = (value: JsonObject, allowed: ReadonlySet<string>): boolean =>
+  Object.keys(value).every((key) => allowed.has(key));
+
+const isSha256 = (value: unknown): value is string =>
+  typeof value === 'string' && /^[a-fA-F0-9]{64}$/.test(value);
+
+const isDateTime = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(
+    value,
+  ) &&
+  Number.isFinite(Date.parse(value));
+
+const uniqueNonBlankStrings = (value: unknown, minItems = 0): value is string[] =>
+  Array.isArray(value) &&
+  value.length >= minItems &&
+  value.every(isNonBlank) &&
+  new Set(value).size === value.length;
+
+const push = (errors: string[], condition: boolean, path: string): void => {
+  if (!condition) errors.push(path);
+};
+
+const validateProducer = (value: unknown, errors: string[]): void => {
+  if (!isObject(value)) {
+    errors.push('/producer must be an object');
+    return;
+  }
+  push(
+    errors,
+    hasOnlyKeys(value, new Set(['kind', 'name', 'version', 'model'])),
+    '/producer contains an unknown property',
+  );
+  push(
+    errors,
+    ['human', 'agent', 'tool', 'instrument'].includes(String(value.kind)),
+    '/producer/kind is invalid',
+  );
+  push(errors, isNonBlank(value.name), '/producer/name is required');
+  if (value.version !== undefined) {
+    push(errors, isNonBlank(value.version), '/producer/version is invalid');
+  }
+  if (value.model !== undefined) {
+    push(errors, isNonBlank(value.model), '/producer/model is invalid');
+  }
+};
+
+const validateEnvironment = (value: unknown, errors: string[]): void => {
+  if (!isObject(value)) {
+    errors.push('/environment must be an object');
+    return;
+  }
+  push(
+    errors,
+    hasOnlyKeys(
+      value,
+      new Set(['description', 'nixDerivation', 'gitCommit', 'hardware']),
+    ),
+    '/environment contains an unknown property',
+  );
+  push(errors, isNonBlank(value.description), '/environment/description is required');
+  if (value.nixDerivation !== undefined) {
+    push(
+      errors,
+      isNonBlank(value.nixDerivation),
+      '/environment/nixDerivation is invalid',
+    );
+  }
+  if (value.gitCommit !== undefined) {
+    push(
+      errors,
+      typeof value.gitCommit === 'string' && /^[a-fA-F0-9]{7,64}$/.test(value.gitCommit),
+      '/environment/gitCommit is invalid',
+    );
+  }
+  if (value.hardware !== undefined) {
+    push(
+      errors,
+      uniqueNonBlankStrings(value.hardware),
+      '/environment/hardware is invalid',
+    );
+  }
+};
+
+const validateMethod = (value: unknown, errors: string[]): void => {
+  if (!isObject(value)) {
+    errors.push('/method must be an object');
+    return;
+  }
+  push(
+    errors,
+    hasOnlyKeys(value, new Set(['protocol', 'acceptance', 'deviations'])),
+    '/method contains an unknown property',
+  );
+  push(errors, isNonBlank(value.protocol), '/method/protocol is required');
+  push(errors, isNonBlank(value.acceptance), '/method/acceptance is required');
+  if (value.deviations !== undefined) {
+    push(errors, uniqueNonBlankStrings(value.deviations), '/method/deviations is invalid');
+  }
+};
+
+const validateInputs = (value: unknown, errors: string[]): void => {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    errors.push('/inputs must be an array');
+    return;
+  }
+  value.forEach((input, index) => {
+    if (!isObject(input)) {
+      errors.push(`/inputs/${index} must be an object`);
+      return;
+    }
+    push(
+      errors,
+      hasOnlyKeys(input, new Set(['ref', 'role', 'sha256'])),
+      `/inputs/${index} contains an unknown property`,
+    );
+    push(errors, isNonBlank(input.ref), `/inputs/${index}/ref is required`);
+    push(errors, isNonBlank(input.role), `/inputs/${index}/role is required`);
+    if (input.sha256 !== undefined) {
+      push(errors, isSha256(input.sha256), `/inputs/${index}/sha256 is invalid`);
+    }
+  });
+};
+
+const validateObservations = (value: unknown, errors: string[]): void => {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    errors.push('/observations must be an array');
+    return;
+  }
+  value.forEach((observation, index) => {
+    if (!isObject(observation)) {
+      errors.push(`/observations/${index} must be an object`);
+      return;
+    }
+    push(
+      errors,
+      hasOnlyKeys(observation, new Set(['statement', 'status', 'sourceRef'])),
+      `/observations/${index} contains an unknown property`,
+    );
+    push(
+      errors,
+      isNonBlank(observation.statement),
+      `/observations/${index}/statement is required`,
+    );
+    push(
+      errors,
+      ['observed', 'interpreted', 'unverified'].includes(String(observation.status)),
+      `/observations/${index}/status is invalid`,
+    );
+    if (observation.sourceRef !== undefined) {
+      push(
+        errors,
+        isNonBlank(observation.sourceRef),
+        `/observations/${index}/sourceRef is invalid`,
+      );
+    }
+  });
+};
+
+const validateMeasurements = (value: unknown, errors: string[]): void => {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    errors.push('/measurements must be an array');
+    return;
+  }
+  value.forEach((measurement, index) => {
+    if (!isObject(measurement)) {
+      errors.push(`/measurements/${index} must be an object`);
+      return;
+    }
+    push(
+      errors,
+      hasOnlyKeys(
+        measurement,
+        new Set(['parameterRef', 'value', 'unit', 'uncertainty', 'sampleCount']),
+      ),
+      `/measurements/${index} contains an unknown property`,
+    );
+    push(
+      errors,
+      isNonBlank(measurement.parameterRef),
+      `/measurements/${index}/parameterRef is required`,
+    );
+    push(
+      errors,
+      typeof measurement.value === 'number' && Number.isFinite(measurement.value),
+      `/measurements/${index}/value is invalid`,
+    );
+    push(errors, isNonBlank(measurement.unit), `/measurements/${index}/unit is required`);
+    push(
+      errors,
+      typeof measurement.uncertainty === 'number' &&
+        Number.isFinite(measurement.uncertainty) &&
+        measurement.uncertainty >= 0,
+      `/measurements/${index}/uncertainty is invalid`,
+    );
+    if (measurement.sampleCount !== undefined) {
+      push(
+        errors,
+        Number.isInteger(measurement.sampleCount) && Number(measurement.sampleCount) >= 1,
+        `/measurements/${index}/sampleCount is invalid`,
+      );
+    }
+  });
+};
+
+const validateArtifacts = (value: unknown, errors: string[]): void => {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    errors.push('/artifacts must be an array');
+    return;
+  }
+  value.forEach((artifact, index) => {
+    if (!isObject(artifact)) {
+      errors.push(`/artifacts/${index} must be an object`);
+      return;
+    }
+    push(
+      errors,
+      hasOnlyKeys(
+        artifact,
+        new Set(['path', 'uri', 'sha256', 'mediaType', 'description']),
+      ),
+      `/artifacts/${index} contains an unknown property`,
+    );
+    push(
+      errors,
+      isNonBlank(artifact.mediaType),
+      `/artifacts/${index}/mediaType is required`,
+    );
+    const path = isNonBlank(artifact.path) ? artifact.path : undefined;
+    const uri = isNonBlank(artifact.uri) ? artifact.uri : undefined;
+    push(
+      errors,
+      (path !== undefined) !== (uri !== undefined),
+      `/artifacts/${index} requires path xor uri`,
+    );
+    push(
+      errors,
+      isSha256(artifact.sha256),
+      `/artifacts/${index}/sha256 is required for path and uri artifacts`,
+    );
+    if (path !== undefined) {
+      push(
+        errors,
+        !path.startsWith('/') && !path.split('/').includes('..'),
+        `/artifacts/${index}/path is invalid`,
+      );
+    }
+    if (uri !== undefined) {
+      try {
+        new URL(uri);
+      } catch {
+        errors.push(`/artifacts/${index}/uri is invalid`);
+      }
+    }
+    if (artifact.description !== undefined) {
+      push(
+        errors,
+        isNonBlank(artifact.description),
+        `/artifacts/${index}/description is invalid`,
+      );
+    }
+  });
+};
+
+const validateAdmissions = (value: unknown, errors: string[]): void => {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    errors.push('/admissions must be an array');
+    return;
+  }
+  value.forEach((admission, index) => {
+    if (!isObject(admission)) {
+      errors.push(`/admissions/${index} must be an object`);
+      return;
+    }
+    push(
+      errors,
+      hasOnlyKeys(
+        admission,
+        new Set(['claimRef', 'kind', 'text', 'target', 'projectionBinding']),
+      ),
+      `/admissions/${index} contains an unknown property`,
+    );
+    push(
+      errors,
+      isNonBlank(admission.claimRef),
+      `/admissions/${index}/claimRef is required`,
+    );
+    const kind = String(admission.kind);
+    push(
+      errors,
+      ['observation', 'structure', 'mechanism', 'function', 'analog'].includes(kind),
+      `/admissions/${index}/kind is invalid`,
+    );
+    push(errors, isNonBlank(admission.text), `/admissions/${index}/text is required`);
+    if (kind === 'analog') {
+      push(errors, isNonBlank(admission.target), `/admissions/${index}/target is required`);
+    } else {
+      push(
+        errors,
+        admission.target === undefined,
+        `/admissions/${index}/target is allowed only for analog`,
+      );
+    }
+    if (admission.projectionBinding !== undefined) {
+      if (!isObject(admission.projectionBinding)) {
+        errors.push(`/admissions/${index}/projectionBinding must be an object`);
+      } else {
+        const binding = admission.projectionBinding;
+        push(
+          errors,
+          hasOnlyKeys(
+            binding,
+            new Set(['evidenceId', 'claimRef', 'admissionText', 'reviewStatus']),
+          ),
+          `/admissions/${index}/projectionBinding contains an unknown property`,
+        );
+        push(
+          errors,
+          isNonBlank(binding.evidenceId),
+          `/admissions/${index}/projectionBinding/evidenceId is required`,
+        );
+        push(
+          errors,
+          binding.claimRef === admission.claimRef,
+          `/admissions/${index}/projectionBinding/claimRef must equal admission claimRef`,
+        );
+        push(
+          errors,
+          binding.admissionText === admission.text,
+          `/admissions/${index}/projectionBinding/admissionText must equal admission text`,
+        );
+        push(
+          errors,
+          binding.reviewStatus === 'accepted',
+          `/admissions/${index}/projectionBinding/reviewStatus must be accepted`,
+        );
+      }
+    }
+  });
+};
+
+const validateResult = (value: unknown, errors: string[]): void => {
+  if (!isObject(value)) {
+    errors.push('/result must be an object');
+    return;
+  }
+  push(
+    errors,
+    hasOnlyKeys(value, new Set(['disposition', 'summary', 'limitations'])),
+    '/result contains an unknown property',
+  );
+  push(
+    errors,
+    ['supports', 'contradicts', 'inconclusive', 'not-run'].includes(
+      String(value.disposition),
+    ),
+    '/result/disposition is invalid',
+  );
+  push(errors, isNonBlank(value.summary), '/result/summary is required');
+  push(
+    errors,
+    uniqueNonBlankStrings(value.limitations, 1),
+    '/result/limitations requires at least one item',
+  );
+};
+
+const validateReview = (value: unknown, errors: string[]): void => {
+  if (!isObject(value)) {
+    errors.push('/review must be an object');
+    return;
+  }
+  push(
+    errors,
+    hasOnlyKeys(value, new Set(['status', 'reviewer', 'reviewedAt', 'notes'])),
+    '/review contains an unknown property',
+  );
+  const status = String(value.status);
+  push(
+    errors,
+    ['pending', 'accepted', 'rejected', 'superseded'].includes(status),
+    '/review/status is invalid',
+  );
+  if (status === 'accepted' || status === 'rejected') {
+    push(errors, isNonBlank(value.reviewer), '/review/reviewer is required');
+    push(errors, isDateTime(value.reviewedAt), '/review/reviewedAt is required');
+  }
+  if (value.reviewer !== undefined) {
+    push(errors, isNonBlank(value.reviewer), '/review/reviewer is invalid');
+  }
+  if (value.reviewedAt !== undefined) {
+    push(errors, isDateTime(value.reviewedAt), '/review/reviewedAt is invalid');
+  }
+  if (value.notes !== undefined) {
+    push(errors, isNonBlank(value.notes), '/review/notes is invalid');
+  }
+};
+
+const validateRecord = (
+  input: unknown,
+): SchemaValidation => {
+  const errors: string[] = [];
+  if (!isObject(input)) {
+    return { valid: false, errors: ['/ must be an object'] };
+  }
+
+  const allowed = new Set([
+    '$schema',
+    'schemaVersion',
+    'kind',
+    'evidenceId',
+    'workspaceRef',
+    'contextRef',
+    'claimRefs',
+    'parameterRefs',
+    'sourceClass',
+    'recordedAt',
+    'producer',
+    'environment',
+    'method',
+    'inputs',
+    'observations',
+    'measurements',
+    'artifacts',
+    'admissions',
+    'result',
+    'review',
+  ]);
+  push(errors, hasOnlyKeys(input, allowed), '/ contains an unknown property');
+  if (input.$schema !== undefined) {
+    push(errors, isNonBlank(input.$schema), '/$schema must be a string');
+  }
+  push(errors, input.schemaVersion === '1.0.0', '/schemaVersion must equal 1.0.0');
+  push(errors, input.kind === 'EvidenceRecord', '/kind must equal EvidenceRecord');
+  push(
+    errors,
+    typeof input.evidenceId === 'string' && /^[a-z][a-z0-9.-]*$/.test(input.evidenceId),
+    '/evidenceId is invalid',
+  );
+  push(
+    errors,
+    input.workspaceRef === 'biomemetics.mantis',
+    '/workspaceRef must equal biomemetics.mantis',
+  );
+  if (input.contextRef !== undefined) {
+    push(errors, isNonBlank(input.contextRef), '/contextRef is invalid');
+  }
+  push(errors, uniqueNonBlankStrings(input.claimRefs, 1), '/claimRefs is invalid');
+  if (input.parameterRefs !== undefined) {
+    push(errors, uniqueNonBlankStrings(input.parameterRefs), '/parameterRefs is invalid');
+  }
+  const sourceClass = String(input.sourceClass);
+  push(
+    errors,
+    ['measured', 'simulated', 'calculated', 'observed', 'external-source'].includes(
+      sourceClass,
+    ),
+    '/sourceClass is invalid',
+  );
+  push(errors, isDateTime(input.recordedAt), '/recordedAt is invalid');
+  validateProducer(input.producer, errors);
+  validateEnvironment(input.environment, errors);
+  validateMethod(input.method, errors);
+  validateInputs(input.inputs, errors);
+  validateObservations(input.observations, errors);
+  validateMeasurements(input.measurements, errors);
+  validateArtifacts(input.artifacts, errors);
+  validateAdmissions(input.admissions, errors);
+  validateResult(input.result, errors);
+  validateReview(input.review, errors);
+
+  const inputs = Array.isArray(input.inputs) ? input.inputs : [];
+  const observations = Array.isArray(input.observations) ? input.observations : [];
+  const measurements = Array.isArray(input.measurements) ? input.measurements : [];
+  const artifacts = Array.isArray(input.artifacts) ? input.artifacts : [];
+  const admissions = Array.isArray(input.admissions) ? input.admissions : [];
+  const claimRefs = Array.isArray(input.claimRefs) ? input.claimRefs : [];
+  const review = isObject(input.review) ? input.review : {};
+  admissions.forEach((admission, index) => {
+    if (isObject(admission)) {
+      push(
+        errors,
+        claimRefs.includes(admission.claimRef),
+        `/admissions/${index}/claimRef must occur in /claimRefs`,
+      );
+      if (admission.projectionBinding !== undefined) {
+        push(
+          errors,
+          review.status === 'accepted',
+          `/admissions/${index}/projectionBinding requires /review/status accepted`,
+        );
+        if (isObject(admission.projectionBinding)) {
+          push(
+            errors,
+            admission.projectionBinding.evidenceId === input.evidenceId,
+            `/admissions/${index}/projectionBinding/evidenceId must equal /evidenceId`,
+          );
+        }
+      }
+    }
+  });
+  if (sourceClass === 'measured') {
+    push(errors, measurements.length >= 1, '/measurements is required for measured');
+  } else if (sourceClass === 'observed') {
+    push(
+      errors,
+      observations.some(
+        (observation) => isObject(observation) && observation.status === 'observed',
+      ),
+      '/observations requires an observed item for observed',
+    );
+  } else if (sourceClass === 'simulated' || sourceClass === 'calculated') {
+    push(errors, inputs.length >= 1, '/inputs is required for model evidence');
+    push(errors, artifacts.length >= 1, '/artifacts is required for model evidence');
+  } else if (sourceClass === 'external-source') {
+    push(errors, inputs.length >= 1, '/inputs is required for external-source');
+    push(
+      errors,
+      observations.length >= 1 || artifacts.length >= 1,
+      '/observations or /artifacts is required for external-source',
+    );
+  }
+
+  return errors.length === 0
+    ? { valid: true, value: input as unknown as ValidatedEvidenceRecord }
+    : { valid: false, errors };
+};
+
+export const loadEvidenceSchemaGate = (): EvidenceSchemaGate => {
+  const rawSchema = readFileSync(schemaUrl, 'utf8');
+  const digest = createHash('sha256').update(rawSchema).digest('hex');
+  if (digest !== EVIDENCE_SCHEMA_SHA256) {
+    throw new Error(
+      `${EVIDENCE_SCHEMA_PATH} digest changed; review the contract and validator together`,
+    );
+  }
+  const schema = JSON.parse(rawSchema) as JsonObject;
+  if (
+    schema.$id !== 'urn:specimendb:biomemetics:mantis:contracts:evidence:v1' ||
+    !Array.isArray(schema.allOf)
+  ) {
+    throw new Error(`${EVIDENCE_SCHEMA_PATH} identity or source-class gates are invalid`);
+  }
+  const validator: EvidenceSchemaGate = Object.freeze({
+    schemaPath: EVIDENCE_SCHEMA_PATH,
+    schemaSha256: EVIDENCE_SCHEMA_SHA256 as SchemaDigest,
+    validate: validateRecord,
+  });
+  validators.add(validator);
+  return validator;
+};
+
+export const isTrustedEvidenceSchemaGate = (
+  validator: EvidenceSchemaGate,
+): boolean => validators.has(validator);

--- a/projects/biomemetics/labs/mantis/assistant/evidence/test/queue.test.ts
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/test/queue.test.ts
@@ -1,0 +1,252 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import {
+  adversarialReviewer,
+  createEvidenceQueue,
+  curator,
+  governedReviewer,
+  type EvidenceQueue,
+  type GovernedReviewer,
+  type PacketId,
+} from '../src/index.ts';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const loadJson = (relative: string): unknown =>
+  JSON.parse(readFileSync(path.join(here, relative), 'utf8'));
+
+const author = curator('curator@lab');
+const reviewer = governedReviewer('reviewer@lab');
+const attacker = adversarialReviewer('red-team@lab');
+const clock = { now: () => '2026-08-21T00:00:00Z' };
+
+const measuredRecord = (): unknown =>
+  loadJson('../fixtures/positive/accepted-measured.json');
+
+const intake = (origin: string, record: unknown): unknown => ({ origin, record });
+
+const queue = (): EvidenceQueue =>
+  createEvidenceQueue({ queueId: 'mantis-a5', clock });
+
+const advanceToPending = (
+  q: EvidenceQueue,
+  record: unknown = measuredRecord(),
+  origin = 'canonical-record',
+): PacketId => {
+  const drafted = q.enqueueDraft(author, intake(origin, record));
+  assert.equal(drafted.ok, true);
+  if (drafted.ok !== true) throw new TypeError('expected draft');
+  const closed = q.validate(drafted.packet.packetId);
+  assert.equal(closed.ok, true);
+  if (closed.ok !== true) throw new TypeError('expected validated');
+  const submitted = q.submit(closed.packet.packetId, author);
+  assert.equal(submitted.ok, true);
+  if (submitted.ok !== true) throw new TypeError('expected pending-review');
+  return submitted.packet.packetId;
+};
+
+test('curator drafts a measured record; independent reviewer accepts it', () => {
+  const q = queue();
+  const packetId = advanceToPending(q);
+  const flagged = q.flagDefect(packetId, attacker, 'measurement sampleCount is 1');
+  assert.equal(flagged.ok, true);
+  if (flagged.ok === true) {
+    assert.equal(flagged.packet.state, 'pending-review');
+    assert.equal(flagged.packet.defects.length, 1);
+  }
+  const accepted = q.accept(packetId, reviewer);
+  assert.equal(accepted.ok, true);
+  if (accepted.ok !== true) return;
+  assert.equal(accepted.packet.state, 'accepted');
+  assert.equal(accepted.packet.reviewer.actorId, 'reviewer@lab');
+  assert.equal(accepted.packet.record.review.status, 'accepted');
+  assert.equal(accepted.packet.record.review.reviewer, 'reviewer@lab');
+  const admission = accepted.packet.record.admissions?.[0];
+  assert.equal(admission?.text, 'Coupon exposes twelve contacts.');
+  assert.equal(admission?.projectionBinding?.admissionText, admission?.text);
+  const again = q.accept(packetId, reviewer);
+  assert.equal(again.ok, true);
+  if (again.ok === true) {
+    assert.equal(again.packet.record.review.reviewedAt, '2026-08-21T00:00:00Z');
+  }
+});
+
+test('incoming accepted review is discarded so fixtures cannot self-admit', () => {
+  const q = queue();
+  const drafted = q.enqueueDraft(author, intake('canonical-record', measuredRecord()));
+  assert.equal(drafted.ok, true);
+  if (drafted.ok !== true) return;
+  assert.equal(drafted.packet.state, 'draft');
+  const record = drafted.packet.record as { review: { status: string } };
+  assert.equal(record.review.status, 'pending');
+  const closed = q.validate(drafted.packet.packetId);
+  assert.equal(closed.ok, true);
+});
+
+test('curator cannot accept; same actorId as author is reviewer-is-author', () => {
+  const q = queue();
+  const packetId = advanceToPending(q);
+  const asReviewer = author as unknown as GovernedReviewer;
+  const attempt = q.accept(packetId, asReviewer);
+  assert.equal(attempt.ok, false);
+  if (attempt.ok === false) {
+    assert.ok(
+      attempt.reasons.includes('curator-cannot-accept') ||
+        attempt.reasons.includes('reviewer-is-author'),
+    );
+  }
+  assert.equal(q.get(packetId)?.state, 'pending-review');
+});
+
+test('governed reviewer whose actorId equals the author is refused', () => {
+  const q = queue();
+  const same = governedReviewer('curator@lab');
+  const packetId = advanceToPending(q);
+  const attempt = q.accept(packetId, same);
+  assert.equal(attempt.ok, false);
+  if (attempt.ok === false) {
+    assert.ok(attempt.reasons.includes('reviewer-is-author'));
+  }
+});
+
+test('adversarial reviewer cannot accept and flagDefect does not admit', () => {
+  const q = queue();
+  const packetId = advanceToPending(q);
+  const asReviewer = attacker as unknown as GovernedReviewer;
+  const attempt = q.accept(packetId, asReviewer);
+  assert.equal(attempt.ok, false);
+  if (attempt.ok === false) {
+    assert.ok(attempt.reasons.includes('adversarial-cannot-accept'));
+  }
+  const flagged = q.flagDefect(packetId, attacker, 'thin admission');
+  assert.equal(flagged.ok, true);
+  assert.equal(q.get(packetId)?.state, 'pending-review');
+});
+
+test('OM, chat, recommendation, telemetry, and taxon hypothesis never become packets', () => {
+  const q = queue();
+  const cases = [
+    ['observational-memory', '../fixtures/negative/om.json'],
+    ['chat', '../fixtures/negative/chat.json'],
+    ['recommendation', '../fixtures/negative/recommendation.json'],
+    ['raw-telemetry', '../fixtures/negative/raw-telemetry.json'],
+    ['taxon-hypothesis', '../fixtures/negative/taxon-hypothesis.json'],
+    ['photo-only-taxon', '../fixtures/negative/photo-only-taxon.json'],
+    ['photo-only-location', '../fixtures/negative/photo-only-location.json'],
+  ] as const;
+  for (const [origin, file] of cases) {
+    const loaded = loadJson(file);
+    const input = origin === 'observational-memory' ? loaded : intake(origin, loaded);
+    const result = q.enqueueDraft(author, input);
+    assert.equal(result.ok, false, origin);
+    if (result.ok === false && 'reasons' in result) {
+      assert.ok(
+        result.reasons.some((reason) =>
+          String(reason).includes(`origin-inadmissible:${origin}`),
+        ),
+        origin,
+      );
+    }
+  }
+  assert.equal(q.list().length, 0);
+});
+
+test('canonical record that smuggles locality keys is refused at intake', () => {
+  const q = queue();
+  const result = q.enqueueDraft(author, loadJson('../fixtures/negative/invented-locality.json'));
+  assert.equal(result.ok, false);
+  if (result.ok === false) {
+    const reasons: readonly string[] = result.reasons;
+    assert.ok(reasons.includes('taxon-or-locality-keys-present'));
+  }
+});
+
+test('claim-unbound is refused at validate', () => {
+  const q = queue();
+  const drafted = q.enqueueDraft(
+    author,
+    intake('canonical-record', loadJson('../fixtures/negative/claim-unbound.json')),
+  );
+  assert.equal(drafted.ok, true);
+  if (drafted.ok !== true) return;
+  const closed = q.validate(drafted.packet.packetId);
+  assert.equal(closed.ok, false);
+  if (closed.ok === false) {
+    assert.ok(closed.reasons.includes('claim-unbound'));
+  }
+});
+
+test('digest-missing is refused at validate', () => {
+  const q = queue();
+  const drafted = q.enqueueDraft(
+    author,
+    intake('canonical-record', loadJson('../fixtures/negative/digest-missing.json')),
+  );
+  assert.equal(drafted.ok, true);
+  if (drafted.ok !== true) return;
+  const closed = q.validate(drafted.packet.packetId);
+  assert.equal(closed.ok, false);
+  if (closed.ok === false) {
+    assert.ok(closed.reasons.includes('digest-missing'));
+  }
+});
+
+test('reject and retainInconclusive are terminal and stay in the queue', () => {
+  const q = queue();
+  const rejectedId = advanceToPending(
+    q,
+    loadJson('../fixtures/negative/rejected.json'),
+  );
+  const rejected = q.reject(rejectedId, reviewer);
+  assert.equal(rejected.ok, true);
+  if (rejected.ok === true) {
+    assert.equal(rejected.packet.state, 'rejected');
+  }
+  assert.equal(q.get(rejectedId)?.state, 'rejected');
+  assert.equal(q.accept(rejectedId, reviewer).ok, false);
+
+  const inconclusiveId = advanceToPending(
+    q,
+    loadJson('../fixtures/negative/inconclusive.json'),
+  );
+  const accepted = q.accept(inconclusiveId, reviewer);
+  assert.equal(accepted.ok, false);
+  if (accepted.ok === false) {
+    assert.ok(accepted.reasons.includes('disposition-not-supportable'));
+  }
+  const retained = q.retainInconclusive(inconclusiveId, reviewer);
+  assert.equal(retained.ok, true);
+  if (retained.ok === true) {
+    assert.equal(retained.packet.state, 'retained-inconclusive');
+    assert.equal(retained.packet.record.review.status, 'pending');
+  }
+});
+
+test('simulated source class cannot be accepted for projection', () => {
+  const measured = measuredRecord() as Record<string, unknown>;
+  const simulated = {
+    ...measured,
+    evidenceId: 'fixture-simulated',
+    sourceClass: 'simulated',
+    inputs: [{ ref: 'model://sim', role: 'source' }],
+  };
+  const q = queue();
+  const packetId = advanceToPending(q, simulated);
+  const attempt = q.accept(packetId, reviewer);
+  assert.equal(attempt.ok, false);
+  if (attempt.ok === false) {
+    assert.ok(attempt.reasons.includes('source-class-not-projectable'));
+  }
+});
+
+test('failed accept does not delete the pending packet', () => {
+  const q = queue();
+  const packetId = advanceToPending(q);
+  const refused = q.accept(packetId, author as unknown as GovernedReviewer);
+  assert.equal(refused.ok, false);
+  assert.equal(q.get(packetId)?.state, 'pending-review');
+});

--- a/projects/biomemetics/labs/mantis/assistant/evidence/tsconfig.json
+++ b/projects/biomemetics/labs/mantis/assistant/evidence/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "rootDir": ".."
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../projection/src/**/*.ts",
+    "../projection/test/**/*.ts"
+  ]
+}

--- a/projects/biomemetics/labs/mantis/assistant/projection/package-lock.json
+++ b/projects/biomemetics/labs/mantis/assistant/projection/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "@tmnl/mantis-assistant-projection",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@tmnl/mantis-assistant-projection",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^25.0.8",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/projection/package.json
+++ b/projects/biomemetics/labs/mantis/assistant/projection/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tmnl/mantis-assistant-projection",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Governed SpecimenDB projection preview for mantis assistant A5. Empty well; no live attach.",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node --test --experimental-strip-types test/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.8",
+    "typescript": "^5.9.3"
+  }
+}

--- a/projects/biomemetics/labs/mantis/assistant/projection/src/entity-ref.ts
+++ b/projects/biomemetics/labs/mantis/assistant/projection/src/entity-ref.ts
@@ -1,0 +1,57 @@
+export const ENTITY_REF_PATTERN =
+  /^gbg:([a-z][a-z0-9-]*):([A-Za-z0-9._:-]+)(?:@([A-Za-z0-9._-]+))?$/;
+
+export type EntityRef = string & { readonly __brand: 'EntityRef' };
+
+export type HonestyClass = 'projected';
+
+export type MintedEntity = {
+  readonly ref: EntityRef;
+  readonly kind: 'preview' | 'receipt';
+  readonly honestyClass: HonestyClass;
+};
+
+const brandRef = (value: string): EntityRef => {
+  if (!ENTITY_REF_PATTERN.test(value)) {
+    throw new TypeError(`entity ref must match ${ENTITY_REF_PATTERN.source}`);
+  }
+  return value as EntityRef;
+};
+
+export function mintPreviewRef(input: {
+  readonly evidenceId: string;
+  readonly targetId: string;
+  readonly payloadDigest: string;
+}): MintedEntity {
+  return {
+    ref: brandRef(
+      `gbg:preview:${input.evidenceId}:${input.targetId}@${input.payloadDigest}`,
+    ),
+    kind: 'preview',
+    honestyClass: 'projected',
+  };
+}
+
+export function mintReceiptRef(input: {
+  readonly evidenceId: string;
+  readonly targetId: string;
+  readonly payloadDigest: string;
+}): MintedEntity {
+  return {
+    ref: brandRef(
+      `gbg:receipt:${input.evidenceId}:${input.targetId}@${input.payloadDigest}`,
+    ),
+    kind: 'receipt',
+    honestyClass: 'projected',
+  };
+}
+
+export function parseEntityRef(
+  ref: string,
+): { readonly kind: string; readonly local: string; readonly rev: string | undefined } | undefined {
+  const match = ENTITY_REF_PATTERN.exec(ref);
+  if (match === null || match[1] === undefined || match[2] === undefined) {
+    return undefined;
+  }
+  return { kind: match[1], local: match[2], rev: match[3] };
+}

--- a/projects/biomemetics/labs/mantis/assistant/projection/src/index.ts
+++ b/projects/biomemetics/labs/mantis/assistant/projection/src/index.ts
@@ -1,0 +1,30 @@
+export {
+  mintPreviewRef,
+  mintReceiptRef,
+  parseEntityRef,
+  ENTITY_REF_PATTERN,
+  type EntityRef,
+  type HonestyClass,
+  type MintedEntity,
+} from './entity-ref.ts';
+export {
+  probeAttachWell,
+  PUBLISHED_SPECIMEN_RPCS,
+  type AttachWell,
+  type EmptyAttachWell,
+  type GatedAttachWell,
+  type ObservedRpcName,
+} from './well.ts';
+export {
+  parseExistingTarget,
+  payloadFromAccepted,
+  planAttach,
+  previewAccepted,
+  projectAccepted,
+  isTargetRefusal,
+  type ExistingCatalogTarget,
+  type ExistingSpecimenId,
+  type ProjectionComponent,
+  type ProjectionPayload,
+  type ProjectionPreview,
+} from './preview.ts';

--- a/projects/biomemetics/labs/mantis/assistant/projection/src/preview.ts
+++ b/projects/biomemetics/labs/mantis/assistant/projection/src/preview.ts
@@ -1,0 +1,225 @@
+import { createHash } from 'node:crypto';
+
+import type {
+  AcceptedPacket,
+  EvidenceQueue,
+  PacketId,
+  PreviewRefusal,
+  PreviewRefusalReason,
+} from '../../evidence/src/index.ts';
+import type { EvidenceAdmission } from '../../evidence/src/schema-gate.ts';
+import {
+  mintPreviewRef,
+  mintReceiptRef,
+  type EntityRef,
+  type MintedEntity,
+} from './entity-ref.ts';
+import { probeAttachWell, type AttachWell } from './well.ts';
+
+export type ExistingSpecimenId = string & { readonly __brand: 'ExistingSpecimenId' };
+
+export type ExistingCatalogTarget = {
+  readonly specimenId: ExistingSpecimenId;
+  readonly ref: EntityRef;
+};
+
+export type ProjectionComponent =
+  | { readonly _tag: 'Observation'; readonly text: string }
+  | { readonly _tag: 'Structure'; readonly text: string }
+  | { readonly _tag: 'Mechanism'; readonly text: string }
+  | { readonly _tag: 'Function'; readonly text: string }
+  | { readonly _tag: 'AnalogLink'; readonly target: string; readonly note: string };
+
+export type ProjectionPayload = {
+  readonly components: readonly ProjectionComponent[];
+  readonly digest: string;
+};
+
+export type ProjectionPreview = {
+  readonly ok: true;
+  readonly packetId: PacketId;
+  readonly evidenceId: string;
+  readonly target: ExistingCatalogTarget;
+  readonly payload: ProjectionPayload;
+  readonly previewEntity: MintedEntity;
+  readonly receiptEntity: MintedEntity;
+  readonly well: AttachWell;
+  readonly executable: false;
+  readonly storeWrite: false;
+  readonly localityMutated: false;
+  readonly taxonMutated: false;
+  readonly specimenMinted: false;
+  readonly blocker: 'specimendb-attach-unavailable' | 'attach-not-live-in-a5';
+};
+
+const LAB_AS_SPECIMEN = new Set([
+  'biomemetics.mantis',
+  'mantis-lab',
+  'projects/biomemetics/labs/mantis',
+]);
+
+const PROSE_KEYS = new Set(['component', 'components', 'analogTarget']);
+const LOCALITY_KEYS = new Set([
+  'locality',
+  'gps',
+  'geo',
+  'latitude',
+  'longitude',
+  'altitudeMeters',
+]);
+const TAXON_KEYS = new Set(['taxon']);
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const previewRefuse = (reasons: readonly PreviewRefusalReason[]): PreviewRefusal => ({
+  ok: false,
+  reasons,
+});
+
+export const isTargetRefusal = (
+  value: ExistingCatalogTarget | PreviewRefusal,
+): value is PreviewRefusal => 'ok' in value;
+
+const forbiddenKeys = (value: object): PreviewRefusalReason | undefined => {
+  for (const key of Object.keys(value)) {
+    if (PROSE_KEYS.has(key)) return 'caller-component-prose';
+    if (LOCALITY_KEYS.has(key)) return 'invented-locality';
+    if (TAXON_KEYS.has(key)) return 'invented-taxon';
+  }
+  return undefined;
+};
+
+export function parseExistingTarget(
+  id: string,
+): ExistingCatalogTarget | PreviewRefusal {
+  const trimmed = id.trim();
+  if (trimmed === '') return previewRefuse(['invented-target']);
+  if (LAB_AS_SPECIMEN.has(trimmed)) return previewRefuse(['lab-as-specimen']);
+  if (trimmed.startsWith('gbg:preview:') || trimmed.startsWith('gbg:receipt:')) {
+    return previewRefuse(['invented-target']);
+  }
+  if (!/^[A-Za-z0-9._:-]+$/.test(trimmed)) {
+    return previewRefuse(['invented-target']);
+  }
+  return {
+    specimenId: trimmed as ExistingSpecimenId,
+    ref: `gbg:specimen:${trimmed}` as EntityRef,
+  };
+}
+
+const componentFromAdmission = (
+  admission: EvidenceAdmission,
+): ProjectionComponent | undefined => {
+  switch (admission.kind) {
+    case 'observation':
+      return { _tag: 'Observation', text: admission.text };
+    case 'structure':
+      return { _tag: 'Structure', text: admission.text };
+    case 'mechanism':
+      return { _tag: 'Mechanism', text: admission.text };
+    case 'function':
+      return { _tag: 'Function', text: admission.text };
+    case 'analog':
+      if (admission.target === undefined) return undefined;
+      return { _tag: 'AnalogLink', target: admission.target, note: admission.text };
+    default: {
+      const _exhaustive: never = admission.kind;
+      return _exhaustive;
+    }
+  }
+};
+
+export function payloadFromAccepted(
+  packet: AcceptedPacket,
+): ProjectionPayload | PreviewRefusal {
+  const sourceClass = packet.record.sourceClass;
+  if (sourceClass !== 'observed' && sourceClass !== 'measured') {
+    return previewRefuse(['source-class-not-projectable']);
+  }
+  if (packet.record.result.disposition !== 'supports') {
+    return previewRefuse(['result-does-not-support']);
+  }
+  const admissions = packet.record.admissions ?? [];
+  if (admissions.length === 0) {
+    return previewRefuse(['admission-text-missing']);
+  }
+  const byClaim = new Map<string, EvidenceAdmission[]>();
+  for (const admission of admissions) {
+    const list = byClaim.get(admission.claimRef) ?? [];
+    list.push(admission);
+    byClaim.set(admission.claimRef, list);
+  }
+  for (const list of byClaim.values()) {
+    if (list.length !== 1) return previewRefuse(['admission-text-missing']);
+  }
+  for (const claimRef of packet.record.claimRefs) {
+    if (!byClaim.has(claimRef)) return previewRefuse(['claim-unbound']);
+  }
+  const components: ProjectionComponent[] = [];
+  for (const admission of admissions) {
+    const component = componentFromAdmission(admission);
+    if (component === undefined) {
+      return previewRefuse(['admission-text-missing']);
+    }
+    components.push(component);
+  }
+  return {
+    components,
+    digest: createHash('sha256').update(JSON.stringify(components)).digest('hex'),
+  };
+}
+
+export function projectAccepted(
+  packet: AcceptedPacket,
+  target: ExistingCatalogTarget,
+  well: AttachWell,
+): ProjectionPreview | PreviewRefusal {
+  if (isObject(target)) {
+    const smuggled = forbiddenKeys(target);
+    if (smuggled !== undefined) return previewRefuse([smuggled]);
+  }
+  const payload = payloadFromAccepted(packet);
+  if ('ok' in payload) return payload;
+  const mintInput = {
+    evidenceId: packet.evidenceId,
+    targetId: target.specimenId,
+    payloadDigest: payload.digest,
+  };
+  return {
+    ok: true,
+    packetId: packet.packetId,
+    evidenceId: packet.evidenceId,
+    target,
+    payload,
+    previewEntity: mintPreviewRef(mintInput),
+    receiptEntity: mintReceiptRef(mintInput),
+    well,
+    executable: false,
+    storeWrite: false,
+    localityMutated: false,
+    taxonMutated: false,
+    specimenMinted: false,
+    blocker: well.reason,
+  };
+}
+
+export function previewAccepted(
+  queue: Pick<EvidenceQueue, 'requireAccepted'>,
+  packetId: PacketId,
+  target: ExistingCatalogTarget,
+  well: AttachWell,
+): ProjectionPreview | PreviewRefusal {
+  const accepted = queue.requireAccepted(packetId);
+  if (accepted.ok === false) return accepted;
+  return projectAccepted(accepted.packet, target, well);
+}
+
+export function planAttach(
+  queue: Pick<EvidenceQueue, 'requireAccepted'>,
+  packetId: PacketId,
+  target: ExistingCatalogTarget,
+  port: unknown,
+): ProjectionPreview | PreviewRefusal {
+  return previewAccepted(queue, packetId, target, probeAttachWell(port));
+}

--- a/projects/biomemetics/labs/mantis/assistant/projection/src/well.ts
+++ b/projects/biomemetics/labs/mantis/assistant/projection/src/well.ts
@@ -1,0 +1,52 @@
+export type ObservedRpcName = string;
+
+export type EmptyAttachWell = {
+  readonly kind: 'empty-well';
+  readonly attachCallable: false;
+  readonly reason: 'specimendb-attach-unavailable';
+  readonly observedRpcNames: readonly ObservedRpcName[];
+};
+
+export type GatedAttachWell = {
+  readonly kind: 'gated-well';
+  readonly attachCallable: true;
+  readonly reason: 'attach-not-live-in-a5';
+  readonly observedRpcNames: readonly ObservedRpcName[];
+};
+
+export type AttachWell = EmptyAttachWell | GatedAttachWell;
+
+export const PUBLISHED_SPECIMEN_RPCS = ['Intake', 'Get', 'List', 'Promote'] as const;
+
+const functionNames = (port: object): readonly ObservedRpcName[] =>
+  Object.getOwnPropertyNames(port).filter((name) => {
+    const value = (port as Record<string, unknown>)[name];
+    return typeof value === 'function';
+  });
+
+export function probeAttachWell(port: unknown): AttachWell {
+  if (typeof port !== 'object' || port === null) {
+    return {
+      kind: 'empty-well',
+      attachCallable: false,
+      reason: 'specimendb-attach-unavailable',
+      observedRpcNames: [],
+    };
+  }
+  const observedRpcNames = functionNames(port);
+  const candidate = port as { readonly attach?: unknown; readonly Attach?: unknown };
+  if (typeof candidate.attach === 'function' || typeof candidate.Attach === 'function') {
+    return {
+      kind: 'gated-well',
+      attachCallable: true,
+      reason: 'attach-not-live-in-a5',
+      observedRpcNames,
+    };
+  }
+  return {
+    kind: 'empty-well',
+    attachCallable: false,
+    reason: 'specimendb-attach-unavailable',
+    observedRpcNames,
+  };
+}

--- a/projects/biomemetics/labs/mantis/assistant/projection/test/isolation.test.ts
+++ b/projects/biomemetics/labs/mantis/assistant/projection/test/isolation.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const SRC_ROOTS = [
+  path.resolve(here, '../../evidence/src'),
+  path.resolve(here, '../src'),
+];
+
+const SKIP_DIRS = new Set(['node_modules']);
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(full);
+      continue;
+    }
+    yield full;
+  }
+}
+
+test('write-set source has no store driver, leftover specimens table, or attach invocation', () => {
+  const patterns: ReadonlyArray<{ readonly name: string; readonly re: RegExp }> =
+    [
+      { name: 'pglite', re: /pglite/i },
+      {
+        name: 'postgres-driver',
+        re: /from ['"]postgres['"]|require\(['"]postgres['"]\)/,
+      },
+      { name: 'sql-pglite', re: /sql-pglite/i },
+      { name: 'specimens-table', re: /create\s+table\s+specimens\b/i },
+      { name: 'specimendb-repos', re: /@tmnl\/specimendb\/repos/ },
+      { name: 'specimendb-pkg', re: /@tmnl\/specimendb['"]/ },
+      { name: 'mantis-lab-pkg', re: /@tmnl\/mantis-lab|mantis-lab\/src/ },
+      { name: 'specimendb-path', re: /packages\/specimendb/ },
+      {
+        name: 'attach-call',
+        re: /\b(?:attach|Attach|Intake|List|Promote|Get)\s*\(/,
+      },
+    ];
+  const hits: string[] = [];
+  for (const root of SRC_ROOTS) {
+    for (const file of walk(root)) {
+      const text = readFileSync(file, 'utf8');
+      for (const pattern of patterns) {
+        if (pattern.re.test(text)) {
+          hits.push(
+            `${pattern.name}: ${path.relative(path.resolve(here, '../..'), file)}`,
+          );
+        }
+      }
+    }
+  }
+  assert.deepEqual(hits, []);
+});

--- a/projects/biomemetics/labs/mantis/assistant/projection/test/preview.test.ts
+++ b/projects/biomemetics/labs/mantis/assistant/projection/test/preview.test.ts
@@ -1,0 +1,332 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import {
+  createEvidenceQueue,
+  curator,
+  governedReviewer,
+  type EvidenceQueue,
+  type PacketId,
+} from '../../evidence/src/index.ts';
+import {
+  PUBLISHED_SPECIMEN_RPCS,
+  isTargetRefusal,
+  parseExistingTarget,
+  planAttach,
+  previewAccepted,
+  probeAttachWell,
+} from '../src/index.ts';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const loadJson = (relative: string): unknown =>
+  JSON.parse(readFileSync(path.join(here, relative), 'utf8'));
+
+const author = curator('curator@lab');
+const reviewer = governedReviewer('reviewer@lab');
+const clock = { now: () => '2026-08-21T00:00:00Z' };
+
+const queue = (): EvidenceQueue =>
+  createEvidenceQueue({ queueId: 'mantis-a5-preview', clock });
+
+const acceptMeasured = (q: EvidenceQueue): PacketId => {
+  const drafted = q.enqueueDraft(author, {
+    origin: 'canonical-record',
+    record: loadJson('../../evidence/fixtures/positive/accepted-measured.json'),
+  });
+  assert.equal(drafted.ok, true);
+  if (drafted.ok !== true) throw new TypeError('expected draft');
+  const closed = q.validate(drafted.packet.packetId);
+  assert.equal(closed.ok, true);
+  if (closed.ok !== true) throw new TypeError('expected validated');
+  const submitted = q.submit(closed.packet.packetId, author);
+  assert.equal(submitted.ok, true);
+  if (submitted.ok !== true) throw new TypeError('expected pending');
+  const accepted = q.accept(submitted.packet.packetId, reviewer);
+  assert.equal(accepted.ok, true);
+  if (accepted.ok !== true) throw new TypeError('expected accepted');
+  return accepted.packet.packetId;
+};
+
+test('accepted measured record previews admission text, not the result summary', () => {
+  const q = queue();
+  const packetId = acceptMeasured(q);
+  const well = probeAttachWell({ Attach: undefined, Get: () => {} });
+  assert.equal(well.kind, 'empty-well');
+  const target = parseExistingTarget('caller-supplied-existing-id');
+  assert.equal(isTargetRefusal(target), false);
+  if (isTargetRefusal(target)) return;
+  const preview = previewAccepted(q, packetId, target, well);
+  assert.equal(preview.ok, true);
+  if (preview.ok !== true) return;
+  const first = preview.payload.components[0];
+  assert.equal(first?._tag, 'Structure');
+  if (first?._tag === 'Structure') {
+    assert.equal(first.text, 'Coupon exposes twelve contacts.');
+    assert.notEqual(
+      first.text,
+      'Positive Draft 2020-12 fixture with digested path and URI artifacts.',
+    );
+  }
+  assert.equal(preview.executable, false);
+  assert.equal(preview.storeWrite, false);
+  assert.equal(preview.localityMutated, false);
+  assert.equal(preview.taxonMutated, false);
+  assert.equal(preview.specimenMinted, false);
+  assert.equal(preview.previewEntity.honestyClass, 'projected');
+  assert.equal(preview.receiptEntity.honestyClass, 'projected');
+  assert.match(
+    preview.previewEntity.ref,
+    /^gbg:preview:fixture-positive-measured:caller-supplied-existing-id@[a-f0-9]{64}$/,
+  );
+  assert.match(
+    preview.receiptEntity.ref,
+    /^gbg:receipt:fixture-positive-measured:caller-supplied-existing-id@[a-f0-9]{64}$/,
+  );
+  assert.equal(preview.well.kind, 'empty-well');
+  assert.equal(preview.evidenceId, 'fixture-positive-measured');
+});
+
+test('retry of the same accepted packet and target mints identical refs', () => {
+  const q = queue();
+  const packetId = acceptMeasured(q);
+  const target = parseExistingTarget('caller-supplied-existing-id');
+  if (isTargetRefusal(target)) return;
+  const well = probeAttachWell(undefined);
+  const first = previewAccepted(q, packetId, target, well);
+  const second = previewAccepted(q, packetId, target, well);
+  assert.equal(first.ok, true);
+  assert.equal(second.ok, true);
+  if (first.ok !== true || second.ok !== true) return;
+  assert.equal(first.previewEntity.ref, second.previewEntity.ref);
+  assert.equal(first.receiptEntity.ref, second.receiptEntity.ref);
+});
+
+test('empty well when Attach is missing, including default undefined', () => {
+  const missing = probeAttachWell(undefined);
+  assert.equal(missing.kind, 'empty-well');
+  assert.equal(missing.reason, 'specimendb-attach-unavailable');
+  assert.deepEqual(missing.observedRpcNames, []);
+  const getOnly = probeAttachWell({ Get: () => {} });
+  assert.equal(getOnly.kind, 'empty-well');
+  assert.deepEqual(getOnly.observedRpcNames, ['Get']);
+  assert.ok(!getOnly.observedRpcNames.includes('Attach'));
+  assert.equal(probeAttachWell({ Attach: undefined }).kind, 'empty-well');
+  assert.deepEqual(PUBLISHED_SPECIMEN_RPCS, ['Intake', 'Get', 'List', 'Promote']);
+});
+
+test('injecting a callable attach still does not invoke it', () => {
+  const q = queue();
+  const packetId = acceptMeasured(q);
+  const target = parseExistingTarget('caller-supplied-existing-id');
+  if (isTargetRefusal(target)) return;
+  let attachCalls = 0;
+  let getCalls = 0;
+  let intakeCalls = 0;
+  let listCalls = 0;
+  let promoteCalls = 0;
+  const port = {
+    Attach: () => {
+      attachCalls += 1;
+    },
+    Get: () => {
+      getCalls += 1;
+    },
+    Intake: () => {
+      intakeCalls += 1;
+    },
+    List: () => {
+      listCalls += 1;
+    },
+    Promote: () => {
+      promoteCalls += 1;
+    },
+  };
+  const preview = planAttach(q, packetId, target, port);
+  assert.equal(preview.ok, true);
+  if (preview.ok === true) {
+    assert.equal(preview.executable, false);
+    assert.equal(preview.well.kind, 'gated-well');
+    assert.equal(preview.blocker, 'attach-not-live-in-a5');
+  }
+  assert.equal(attachCalls, 0);
+  assert.equal(getCalls, 0);
+  assert.equal(intakeCalls, 0);
+  assert.equal(listCalls, 0);
+  assert.equal(promoteCalls, 0);
+});
+
+test('blank and lab-as-specimen ids are refused; no fabricated specimen id', () => {
+  const blank = parseExistingTarget('');
+  assert.equal(isTargetRefusal(blank), true);
+  if (isTargetRefusal(blank)) {
+    assert.ok(blank.reasons.includes('invented-target'));
+  }
+  for (const specimenId of [
+    'biomemetics.mantis',
+    'mantis-lab',
+    'projects/biomemetics/labs/mantis',
+  ]) {
+    const parsed = parseExistingTarget(specimenId);
+    assert.equal(isTargetRefusal(parsed), true, specimenId);
+    if (isTargetRefusal(parsed)) {
+      assert.ok(parsed.reasons.includes('lab-as-specimen'));
+    }
+  }
+});
+
+test('caller component prose on the target is refused', () => {
+  const q = queue();
+  const packetId = acceptMeasured(q);
+  const target = parseExistingTarget('caller-supplied-existing-id');
+  if (isTargetRefusal(target)) return;
+  const smuggled = {
+    ...target,
+    component: { _tag: 'Structure', text: 'Caller-invented prose.' },
+  };
+  const preview = previewAccepted(q, packetId, smuggled, probeAttachWell(undefined));
+  assert.equal(preview.ok, false);
+  if (preview.ok === false) {
+    assert.ok(preview.reasons.includes('caller-component-prose'));
+  }
+});
+
+test('draft, pending, rejected, and retained-inconclusive packets cannot preview', () => {
+  const q = queue();
+  const well = probeAttachWell(undefined);
+  const target = parseExistingTarget('caller-supplied-existing-id');
+  if (isTargetRefusal(target)) return;
+  const drafted = q.enqueueDraft(author, {
+    origin: 'canonical-record',
+    record: loadJson('../../evidence/fixtures/positive/accepted-measured.json'),
+  });
+  assert.equal(drafted.ok, true);
+  if (drafted.ok !== true) return;
+  const draftPreview = previewAccepted(q, drafted.packet.packetId, target, well);
+  assert.equal(draftPreview.ok, false);
+  if (draftPreview.ok === false) {
+    assert.ok(draftPreview.reasons.includes('packet-draft'));
+  }
+
+  const closed = q.validate(drafted.packet.packetId);
+  assert.equal(closed.ok, true);
+  if (closed.ok !== true) return;
+  const submitted = q.submit(closed.packet.packetId, author);
+  assert.equal(submitted.ok, true);
+  if (submitted.ok !== true) return;
+  const pendingPreview = previewAccepted(q, submitted.packet.packetId, target, well);
+  assert.equal(pendingPreview.ok, false);
+  if (pendingPreview.ok === false) {
+    assert.ok(pendingPreview.reasons.includes('packet-pending-review'));
+  }
+
+  const rejectedDraft = q.enqueueDraft(author, {
+    origin: 'canonical-record',
+    record: loadJson('../../evidence/fixtures/negative/rejected.json'),
+  });
+  assert.equal(rejectedDraft.ok, true);
+  if (rejectedDraft.ok !== true) return;
+  const rejectedClosed = q.validate(rejectedDraft.packet.packetId);
+  assert.equal(rejectedClosed.ok, true);
+  if (rejectedClosed.ok !== true) return;
+  const rejectedSubmitted = q.submit(rejectedClosed.packet.packetId, author);
+  assert.equal(rejectedSubmitted.ok, true);
+  if (rejectedSubmitted.ok !== true) return;
+  const rejected = q.reject(rejectedSubmitted.packet.packetId, reviewer);
+  assert.equal(rejected.ok, true);
+  const rejectedPreview = previewAccepted(
+    q,
+    rejectedSubmitted.packet.packetId,
+    target,
+    well,
+  );
+  assert.equal(rejectedPreview.ok, false);
+  if (rejectedPreview.ok === false) {
+    assert.ok(rejectedPreview.reasons.includes('packet-rejected'));
+  }
+  assert.equal(q.get(rejectedSubmitted.packet.packetId)?.state, 'rejected');
+
+  const inconclusiveDraft = q.enqueueDraft(author, {
+    origin: 'canonical-record',
+    record: loadJson('../../evidence/fixtures/negative/inconclusive.json'),
+  });
+  assert.equal(inconclusiveDraft.ok, true);
+  if (inconclusiveDraft.ok !== true) return;
+  const inconclusiveClosed = q.validate(inconclusiveDraft.packet.packetId);
+  assert.equal(inconclusiveClosed.ok, true);
+  if (inconclusiveClosed.ok !== true) return;
+  const inconclusiveSubmitted = q.submit(inconclusiveClosed.packet.packetId, author);
+  assert.equal(inconclusiveSubmitted.ok, true);
+  if (inconclusiveSubmitted.ok !== true) return;
+  const retained = q.retainInconclusive(inconclusiveSubmitted.packet.packetId, reviewer);
+  assert.equal(retained.ok, true);
+  const inconclusivePreview = previewAccepted(
+    q,
+    inconclusiveSubmitted.packet.packetId,
+    target,
+    well,
+  );
+  assert.equal(inconclusivePreview.ok, false);
+  if (inconclusivePreview.ok === false) {
+    assert.ok(inconclusivePreview.reasons.includes('packet-retained-inconclusive'));
+  }
+});
+
+test('failed preview does not delete the accepted packet', () => {
+  const q = queue();
+  const packetId = acceptMeasured(q);
+  const lab = parseExistingTarget('biomemetics.mantis');
+  assert.equal(isTargetRefusal(lab), true);
+  assert.equal(q.get(packetId)?.state, 'accepted');
+});
+
+test('observed supporting accepted records are preview-eligible', () => {
+  const measured = loadJson(
+    '../../evidence/fixtures/positive/accepted-measured.json',
+  ) as Record<string, unknown>;
+  const { measurements: _measurements, ...rest } = measured;
+  const observed = {
+    ...rest,
+    evidenceId: 'fixture-positive-observed',
+    sourceClass: 'observed',
+    observations: [
+      {
+        statement: 'Twelve contacts are exposed.',
+        status: 'observed',
+      },
+    ],
+    admissions: [
+      {
+        claimRef: 'claim:rail:contact-count',
+        kind: 'structure',
+        text: 'Coupon exposes twelve contacts.',
+      },
+    ],
+  };
+  const q = queue();
+  const drafted = q.enqueueDraft(author, { origin: 'canonical-record', record: observed });
+  assert.equal(drafted.ok, true);
+  if (drafted.ok !== true) return;
+  const closed = q.validate(drafted.packet.packetId);
+  assert.equal(closed.ok, true);
+  if (closed.ok !== true) return;
+  const submitted = q.submit(closed.packet.packetId, author);
+  assert.equal(submitted.ok, true);
+  if (submitted.ok !== true) return;
+  const accepted = q.accept(submitted.packet.packetId, reviewer);
+  assert.equal(accepted.ok, true);
+  const target = parseExistingTarget('caller-supplied-existing-id');
+  if (isTargetRefusal(target)) return;
+  const preview = previewAccepted(q, submitted.packet.packetId, target, probeAttachWell({}));
+  assert.equal(preview.ok, true);
+  if (preview.ok === true) {
+    const first = preview.payload.components[0];
+    assert.equal(first?._tag, 'Structure');
+    if (first?._tag === 'Structure') {
+      assert.equal(first.text, 'Coupon exposes twelve contacts.');
+    }
+  }
+});

--- a/projects/biomemetics/labs/mantis/assistant/projection/tsconfig.json
+++ b/projects/biomemetics/labs/mantis/assistant/projection/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

gbg#55 needs a review queue so conversation, memory, telemetry, and photo guesses cannot become catalog writes. The assistant may draft and validate. It may not accept its own evidence, invent a target, mint a Specimen, or call Attach.

This cut stops at preview. Catalog attach stays gated until governed #16 exists as a callable RPC on the caller-supplied port.

## Scope

Adds `projects/biomemetics/labs/mantis/assistant/evidence/**` and `assistant/projection/**`, plus A5 docs under `assistant/docs/`. Adds `.github/workflows/mantis-assistant-a5.yml` as the merge gate for that write-set.

`createEvidenceQueue` owns packet ids. Packets move `draft → validated → pending-review → accepted | rejected | retained-inconclusive`. `parseIntake` admits only `canonical-record` and `lab-artifact`. Incoming `review.status` is discarded to `pending` and `projectionBinding` is stripped, so a fixture cannot self-admit. `accept` takes `GovernedReviewer` only and refuses when `actorId` equals the author.

`previewAccepted` builds payload text from `admission.text`, not `result.summary`. It mints `gbg:preview:<evidenceId>:<targetId>@<digest>` and `gbg:receipt:…`. `probeAttachWell` returns `empty-well` unless `attach`/`Attach` is a function, and still does not call it. `executable` is the literal `false`.

The CI job `Mantis Assistant A5 / evidence and projection` runs `npm ci`, `npm run typecheck`, and `npm test` in `assistant/evidence`. Path filters cover evidence, projection, the pinned evidence schema, A5 docs, and the workflow file. There is no `master`/`main` branch gate, so stacked lab PRs still get the check.

Out of this PR: `app/**`, golden-care, A0 `tooling/typescript/mantis-assistant` and A0 contracts/policies/tools/evals/workflows, A3 `assistant/workflows/**`, `packages/specimendb`, `OFFLINE.md`. No leftover specimens table. No PGlite. No `@tmnl/specimendb` or `@tmnl/mantis-lab` import.

## Tradeoffs

Queue-as-aggregate won over envelope-as-only-aggregate. A record that already says `review.status: accepted` would otherwise preview itself. The queue is the extra object, and that is the point.

The schema gate is a path-adjusted copy of the lab validator, pinned to digest `bf38331eb8f66d1152e0ef16ab003ebc6fb4c5d9ec9b06cf395860e2f3485cf1`. Copying avoids a `@tmnl/mantis-lab` import that would pull the lab's optional specimendb peer. Drift is a real cost. The pin fails the process if the contract bytes change.

A dedicated workflow won over grafting onto ctl or spikectl CI. Those jobs use bun, Nix, and a `master`/`main` filter that would skip this PR's base `feat/mantis-biomemetics-lab`.

## Blast Radius

Lab tests and a later CLI can import these modules. The Lab PWA and shop pack do not. Failed preview leaves the accepted packet in the queue. Empty well is a preview field, not a deleted record.

Sibling write-sets stay untouched. A0 PR 100, A1 PR 98, and A3 workflows are disjoint.

GitHub will not block merge on this check until a repo admin adds `Mantis Assistant A5 / evidence and projection` as required. This draft stays unmerged until that job is green.

## Verification

From `projects/biomemetics/labs/mantis/assistant/evidence` after `npm ci`:

- `npm run typecheck` passed.
- `npm test` passed 22/22.

Checks covered accepted preview bytes and identical refs on retry, intake refusals for OM/chat/recommendation/telemetry/taxon/photo-only origins, claim-unbound and digest-missing at validate, curator/self-accept refusals, empty well vs gated well with zero Attach calls, lab-as-specimen and blank target refusals, and a static scan of `src/**` for pglite, `@tmnl/specimendb`, and `packages/specimendb`.

Draft on purpose. Do not merge. Not shop-release. Not A6.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b86b3596-1c65-412b-8956-144f5fd83f99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b86b3596-1c65-412b-8956-144f5fd83f99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

