### PR TITLE
feat(specimendb): Postgres SQL SourceAdapter returns Arrow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -378,6 +378,7 @@
       "dependencies": {
         "@effect/sql-pg": "4.0.0-beta.93",
         "@tmnl/stx": "workspace:*",
+        "apache-arrow": "21.2.0",
         "effect": "4.0.0-beta.93",
       },
       "devDependencies": {
@@ -3980,6 +3981,8 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
+    "apache-arrow": ["apache-arrow@21.2.0", "", { "dependencies": { "@types/node": "^25.2.0", "flatbuffers": "^25.1.24", "json-with-bigint": "^3.5.3", "tslib": "^2.6.2" }, "bin": { "arrow2csv": "bin/arrow2csv.js" } }, "sha512-Hxe6Agq26gQOM954qpzYSllJBPJl+e16U5CkfuMUhLrNba+5nKkttIVlflaovN6oaTratqMGAO8H5u/aNhmHWQ=="],
+
     "apache-md5": ["apache-md5@1.1.8", "", {}, "sha512-FCAJojipPn0bXjuEpjOOOMN8FZDkxfWWp4JGN9mifU2IhxvKyXZYqpzPHdnTSUpmPDy+tsslB6Z1g+Vg6nVbYA=="],
 
     "append-field": ["append-field@1.0.0", "", {}, "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="],
@@ -5167,6 +5170,8 @@
     "flat": ["flat@5.0.2", "", { "bin": { "flat": "cli.js" } }, "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="],
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
 
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
@@ -9618,6 +9623,8 @@
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "apache-arrow/@types/node": ["@types/node@25.9.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ=="],
+
     "archive-type/file-type": ["file-type@4.4.0", "", {}, "sha512-f2UbFQEk7LXgWpi5ntcO86OeA/cC80fuDDDaX/fZ2ZGel+AF7leRQqBBW1eJNiiQkrZlAoM6P+VYP5P6bOlDEQ=="],
 
     "archiver/tar-stream": ["tar-stream@3.1.7", "", { "dependencies": { "b4a": "^1.6.4", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ=="],
@@ -12187,6 +12194,8 @@
     "@yarnpkg/parsers/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "@yarnpkg/parsers/js-yaml/esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "apache-arrow/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "archiver-utils/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 

--- a/packages/specimendb/README.md
+++ b/packages/specimendb/README.md
@@ -14,6 +14,10 @@ CAD-01 and HLR are minted from in-tree files on this ref. Not an invented specim
 
 The assembly STEP is `kind=solid` `type=assembly`. Part STEPs are `type=part`. Sheets S00-S11 are `type=projected` or `type=diagram` (S08/S09 diagram). The HLR activity (`type=hlr`) Uses the STEP and Generates S00-S11. who/how is `generate_schematics.py`, where is `unknown`, why is `#58`. Bytes cites path + sha256 + git SHA. Seed does not copy STEP or SVG into the specimen AssetStore.
 
+## EVA
+
+EVA is a Postgres SQL SourceAdapter (`kind=sql`). `query(sql)` returns an Apache Arrow table over `entities` and `components` after CAD-01/HLR seed. The adapter matches the AVA SourceAdapter contract in `packages/tmnl/src-ava` (`kind`, `id`, `query` → Arrow). It does not run the Rust AVA runtime. The graph well stays empty.
+
 ## Empty wells
 
 Empty wells are drawn regions with a missing component. The chrome is on the page. The component is not. Do not invent one to look complete.

--- a/packages/specimendb/package.json
+++ b/packages/specimendb/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@effect/sql-pg": "4.0.0-beta.93",
     "@tmnl/stx": "workspace:*",
+    "apache-arrow": "21.2.0",
     "effect": "4.0.0-beta.93"
   },
   "peerDependencies": {

--- a/packages/specimendb/src/eva/arrow.ts
+++ b/packages/specimendb/src/eva/arrow.ts
@@ -1,0 +1,33 @@
+import { tableFromArrays, tableFromJSON, type Table } from 'apache-arrow';
+
+const cell = (value: unknown): string | null => {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  if (value instanceof Date) return value.toISOString();
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+export const emptyArrowTable = (): Table => tableFromJSON([]) as unknown as Table;
+
+export const rowsToArrow = (rows: ReadonlyArray<Record<string, unknown>>): Table => {
+  if (rows.length === 0) return emptyArrowTable();
+  const keys = Object.keys(rows[0]!);
+  const columns: Record<string, Array<string | null>> = {};
+  for (const key of keys) {
+    columns[key] = rows.map((row) => cell(row[key]));
+  }
+  return tableFromArrays(columns);
+};
+
+export const columnValues = (table: Table, name: string): ReadonlyArray<string | null> => {
+  const child = table.getChild(name);
+  if (child === null || child === undefined) return [];
+  return [...child.toArray()].map((value) => (value === null || value === undefined ? null : String(value)));
+};

--- a/packages/specimendb/src/eva/errors.ts
+++ b/packages/specimendb/src/eva/errors.ts
@@ -1,0 +1,16 @@
+/**
+ * EVA source errors. Shape mined from ava-domain SourceError. Not tmnl.
+ *
+ * @module @tmnl/specimendb/eva/errors
+ */
+
+import * as Schema from 'effect/Schema';
+
+export class SourceError extends Schema.TaggedErrorClass<SourceError>(
+  '@tmnl/specimendb/eva/SourceError',
+)('SourceError', {
+  sourceId: Schema.String,
+  operation: Schema.String,
+  message: Schema.String,
+  cause: Schema.optional(Schema.Unknown),
+}) {}

--- a/packages/specimendb/src/eva/index.ts
+++ b/packages/specimendb/src/eva/index.ts
@@ -1,0 +1,11 @@
+/**
+ * EVA: Entity View Agent at the catalog seam. Postgres SourceAdapter only.
+ * Do not import tmnl. Do not rebuild DataFusion.
+ *
+ * @module @tmnl/specimendb/eva
+ */
+
+export { emptyArrowTable, rowsToArrow, columnValues } from './arrow.js';
+export { SourceError } from './errors.js';
+export { PostgresSqlSource } from './postgres.js';
+export { SOURCE_KIND_VALUES, type SourceAdapterShape, type SourceKind } from './source.js';

--- a/packages/specimendb/src/eva/postgres.ts
+++ b/packages/specimendb/src/eva/postgres.ts
@@ -1,0 +1,83 @@
+/**
+ * Postgres SourceAdapter. SqlClient is already connected. query(sql) returns Arrow.
+ *
+ * @module @tmnl/specimendb/eva/postgres
+ */
+
+import * as Context from 'effect/Context';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import { SqlClient } from 'effect/unstable/sql/SqlClient';
+import type { SqlError } from 'effect/unstable/sql/SqlError';
+import { EvaSourceTag } from '../tags.js';
+import { rowsToArrow } from './arrow.js';
+import { SourceError } from './errors.js';
+import type { SourceAdapterShape } from './source.js';
+
+const asRecords = (rows: unknown): ReadonlyArray<Record<string, unknown>> => {
+  if (!Array.isArray(rows)) return [];
+  return rows as ReadonlyArray<Record<string, unknown>>;
+};
+
+const isReadOnlySql = (sqlText: string): boolean => {
+  const stripped = sqlText
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/--[^\n]*/g, ' ')
+    .trim();
+  const keyword = stripped.split(/\s+/, 1)[0]?.toUpperCase();
+  if (keyword !== 'SELECT' && keyword !== 'WITH') return false;
+  const withoutStrings = stripped.replace(/'[^']*'/g, "''");
+  return !/\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|GRANT|REVOKE|COPY|CALL)\b/i.test(
+    withoutStrings,
+  );
+};
+
+const fail = (operation: string, message: string, cause?: unknown) =>
+  new SourceError({
+    sourceId: EvaSourceTag,
+    operation,
+    message,
+    ...(cause !== undefined ? { cause } : {}),
+  });
+
+const mapSql = (operation: string) => (cause: SqlError) =>
+  fail(operation, cause.message, cause);
+
+export class PostgresSqlSource extends Context.Service<PostgresSqlSource, SourceAdapterShape>()(
+  EvaSourceTag,
+) {
+  static readonly layer = Layer.effect(
+    PostgresSqlSource,
+    Effect.gen(function* () {
+      const sql = yield* SqlClient;
+
+      const query: SourceAdapterShape['query'] = (sqlText) =>
+        Effect.gen(function* () {
+          if (!isReadOnlySql(sqlText)) {
+            return yield* fail('query', 'only SELECT / WITH queries are allowed');
+          }
+          const rows = yield* sql.unsafe(sqlText).pipe(Effect.mapError(mapSql('query')));
+          return rowsToArrow(asRecords(rows));
+        });
+
+      const schema: SourceAdapterShape['schema'] = () =>
+        Effect.gen(function* () {
+          const rows = yield* sql<Record<string, unknown>>`
+            SELECT table_name, column_name, data_type
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name IN ('entities', 'components')
+            ORDER BY table_name, ordinal_position
+          `.pipe(Effect.mapError(mapSql('schema')));
+          return rowsToArrow(asRecords(rows));
+        });
+
+      return {
+        kind: 'sql' as const,
+        id: EvaSourceTag,
+        query,
+        schema,
+      } satisfies SourceAdapterShape;
+    }),
+  );
+}

--- a/packages/specimendb/src/eva/source.ts
+++ b/packages/specimendb/src/eva/source.ts
@@ -1,0 +1,28 @@
+/**
+ * EVA SourceAdapter at the catalog seam.
+ * Shape mined from packages/tmnl/src-ava ava-domain (kind + id + query → Arrow).
+ * Do not import tmnl. Do not rebuild DataFusion. No wasm gate.
+ *
+ * @module @tmnl/specimendb/eva/source
+ */
+
+import type { Table } from 'apache-arrow';
+import type * as Effect from 'effect/Effect';
+import type { SourceError } from './errors.js';
+
+export const SOURCE_KIND_VALUES = [
+  'sql',
+  'stream',
+  'api',
+  'graph',
+  'lake',
+  'cache',
+] as const;
+export type SourceKind = (typeof SOURCE_KIND_VALUES)[number];
+
+export interface SourceAdapterShape {
+  readonly kind: SourceKind;
+  readonly id: string;
+  readonly query: (sqlText: string) => Effect.Effect<Table, SourceError>;
+  readonly schema: () => Effect.Effect<Table, SourceError>;
+}

--- a/packages/specimendb/src/index.ts
+++ b/packages/specimendb/src/index.ts
@@ -11,5 +11,6 @@ export * from './repos/index.js';
 export * from './rpc/index.js';
 export * from './state/index.js';
 export * from './tags.js';
+export * from './eva/index.js';
 export { CatalogPersistenceLive, CatalogStateLive, SpecimenCatalogLive, layer } from './layers.js';
 export { localityView, specimenSurface, type LocalityView } from './surface.js';

--- a/packages/specimendb/src/tags.ts
+++ b/packages/specimendb/src/tags.ts
@@ -32,6 +32,7 @@ export const IntakeAdapterTag = '@tmnl/specimendb/IntakeAdapter' as const;
 export const EntityRepoTag = '@tmnl/specimendb/EntityRepo' as const;
 export const ComponentRepoTag = '@tmnl/specimendb/ComponentRepo' as const;
 export const CatalogConfigTagName = '@tmnl/specimendb/Config' as const;
+export const EvaSourceTag = '@tmnl/specimendb/eva/PostgresSqlSource' as const;
 
 export type CatalogEntityTag = typeof CatalogEntityTag;
 export type IntakeTag = typeof IntakeTag;

--- a/packages/specimendb/test/eva.test.ts
+++ b/packages/specimendb/test/eva.test.ts
@@ -1,0 +1,76 @@
+/**
+ * EVA Postgres SourceAdapter over seeded CAD-01 / HLR rows.
+ * query(sql) returns Arrow. No wasm. No DataFusion rebuild.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import { SqlClient } from 'effect/unstable/sql/SqlClient';
+import { CAD01_PROJECT_REF, CAD01_SOLID_REF, seedCad01Hlr } from '../src/adapters/cad01-seed.js';
+import { columnValues } from '../src/eva/arrow.js';
+import { PostgresSqlSource } from '../src/eva/postgres.js';
+import { testCatalogLayer } from './catalog-pg.js';
+
+const pgUnavailable = (cause: unknown): Error => {
+  const detail = cause instanceof Error ? cause.message : String(cause);
+  return new Error(
+    `EVA tests need Postgres at SPECIMENDB_PG_* (default 127.0.0.1:5434). ${detail}`,
+    { cause },
+  );
+};
+
+const evaLayer = (assetsRoot: string) =>
+  PostgresSqlSource.layer.pipe(Layer.provideMerge(testCatalogLayer(assetsRoot)));
+
+const runEva = async (program: Effect.Effect<unknown, unknown, never>) => {
+  const root = await mkdtemp(join(tmpdir(), 'specimendb-eva-'));
+  try {
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient;
+          yield* sql.unsafe(`TRUNCATE TABLE components, entities CASCADE`);
+          yield* program;
+        }),
+      ).pipe(Effect.provide(evaLayer(join(root, 'assets')))) as Effect.Effect<unknown>,
+    );
+  } catch (cause) {
+    throw pgUnavailable(cause);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+};
+
+describe('EVA Postgres SourceAdapter', () => {
+  it('query(sql) returns Arrow for CAD-01 assembly and HLR Used', async () => {
+    await runEva(
+      Effect.gen(function* () {
+        yield* seedCad01Hlr();
+        const source = yield* PostgresSqlSource;
+        expect(source.kind).toBe('sql');
+
+        const assemblies = yield* source.query(
+          `SELECT id, kind, type FROM entities WHERE type = 'assembly'`,
+        );
+        expect(columnValues(assemblies, 'id')).toContain(CAD01_SOLID_REF);
+        expect(columnValues(assemblies, 'kind')).toContain('solid');
+        expect(columnValues(assemblies, 'type')).toContain('assembly');
+
+        const used = yield* source.query(
+          `SELECT entity_id, payload->>'target' AS target FROM components WHERE kind = 'Used'`,
+        );
+        expect(columnValues(used, 'entity_id')).toContain(CAD01_PROJECT_REF);
+        expect(columnValues(used, 'target')).toContain(CAD01_SOLID_REF);
+
+        const schema = yield* source.schema();
+        const tables = columnValues(schema, 'table_name');
+        expect(tables).toContain('entities');
+        expect(tables).toContain('components');
+      }),
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

#82 after the CAD-01/HLR seed (PR 96): EVA is a Postgres SQL `SourceAdapter` over `entities` / `components`. `query(sql)` returns Arrow. Graph stays an empty well. `packages/getbygraph` stays dead.

## Scope

- `packages/specimendb/src/eva/*`: SourceAdapter shape mined from `packages/tmnl/src-ava` ava-domain (`kind`, `id`, `query` → Arrow). Postgres implementation on the existing `@effect/sql-pg` `SqlClient`. SELECT / WITH only.
- `apache-arrow@21.2.0` on `@tmnl/specimendb`.
- `test/eva.test.ts`: seed CAD-01, query the assembly and HLR Used rows, `schema()` lists `entities` and `components`.
- README EVA section.

Out of this cut:

- Importing `@tmnl/tmnl` or invoking the Rust AVA runtime (no napi/FFI; specimendb forbids the tmnl import)
- Minting a view-run activity (#61 owns leftover activity mint/query)
- `packages/specimendb/src/ui` (PR 97)
- Growing `packages/getbygraph`
- Filling organism wells on a STEP

## Tradeoffs

AVA is adopted as the TypeScript contract (`SourceKind::Sql`, `query` → Arrow). The Rust adapters live in `src-ava` and cannot be called from specimendb in-process. This PR does not claim HydrationService ran. Graph well stays empty.

## Blast Radius

`@tmnl/specimendb` only. Catalog DDL, CAD-01 seed, activity adapters, and UI are untouched. Production `layer()` still does not leak `SqlClient`; tests provide `PostgresSqlSource.layer` on the catalog test layer.

## Verification

```
cd packages/specimendb
bun run typecheck:ci
bun run test:run
```

Needs Postgres at `SPECIMENDB_PG_*` (default `127.0.0.1:5434`), same as the catalog tests.

Draft. Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7100f667-44a9-42e3-914a-70d1f568b540?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7100f667-44a9-42e3-914a-70d1f568b540&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

