### PR TITLE
feat(specimendb): leftover activity-as-entity

### DIFF
--- a/packages/specimendb/README.md
+++ b/packages/specimendb/README.md
@@ -12,7 +12,7 @@ Intake still files a JPEG as Status `raw`. Locality is `unknown` unless EXIF or 
 
 CAD-01 and HLR are minted from in-tree files on this ref. Not an invented specimen.
 
-The assembly STEP is `kind=solid` `type=assembly`. Part STEPs are `type=part`. Sheets S00-S11 are `type=projected` or `type=diagram` (S08/S09 diagram). The HLR activity (`type=hlr`) Uses the STEP and Generates S00-S11. who/how is `generate_schematics.py`, where is `unknown`, why is `#58`. Bytes cites path + sha256 + git SHA. Seed does not copy STEP or SVG into the specimen AssetStore.
+The assembly STEP is `kind=solid` `type=assembly`. Part STEPs are `type=part`. Sheets S00-S11 are `type=projected` or `type=diagram` (S08/S09 diagram). The HLR activity (`type=hlr`) Uses the STEP and Generates S00-S06. A separate export activity (`type=export`) Generates the CAD-01 assembly STEP. who/how on HLR is `generate_schematics.py`, on export is `freecad-part-occt`. where is `unknown`. why is `#58` (HLR) and `#20` (export). Bytes cites path + sha256 + git SHA. Seed does not copy STEP or SVG into the specimen AssetStore.
 
 ## Empty wells
 
@@ -30,7 +30,7 @@ Empty wells are drawn regions with a missing component. The chrome is on the pag
 | `Project` | HLR: Used(step) Generated(svgs/sheets). |
 | `Doctor` | Mint an activity for a run; Generated defaults to the run. |
 | `AppendActivity` | Append-only activity: refuse to rewrite a ref; corrections append a new one with Supersedes. |
-| `GetByRef` | Activities whose id, Used, Generated, or Supersedes target matches. |
+| `GetByRef` | Activities whose id, Used, Generated, or Supersedes target matches `{ ref }`. Walk Who / Why / When by `{ who }`, `{ why }`, `{ gitSha }`, or `{ startedAt }`. |
 | `GetEntity` / `ListEntities` / `GetComponents` | Read an entity and the components keyed by `entity_id`. |
 | `Attach` | Attach one component to an existing entity. |
 | `MintEntity` | Mint a catalog entity and attach the components the caller walked. Seed uses this. |

--- a/packages/specimendb/src/adapters/activity.ts
+++ b/packages/specimendb/src/adapters/activity.ts
@@ -1,5 +1,6 @@
 /**
  * Activity systems. Used / Generated / Supersedes hang on the activity's entity_id.
+ * W7 hangs as Who / When / Where / Why / How when it arrived. What is Used + Generated.
  * Corrections append a new ref. There is no lab_activities / lab_used / lab_generated table.
  *
  * @module @tmnl/specimendb/adapters/activity
@@ -9,10 +10,15 @@ import * as Effect from 'effect/Effect';
 import {
   BytesComponent,
   GeneratedComponent,
+  HowComponent,
   KindComponent,
   TypeComponent,
   SupersedesComponent,
   UsedComponent,
+  WhenComponent,
+  WhereComponent,
+  WhoComponent,
+  WhyComponent,
   relationTargets,
   type Component,
 } from '../schemas/components.js';
@@ -22,7 +28,7 @@ import {
   EntityNotFoundError,
 } from '../schemas/errors.js';
 import { parseEntityRef, trustEntityRef, type EntityRef } from '../schemas/identifiers.js';
-import type { EntityKind, EntityType, LabEntity } from '../schemas/provenance.js';
+import type { Agent, EntityKind, EntityType, LabEntity, ProvenanceWhen } from '../schemas/provenance.js';
 import type { ContentAddress } from '../schemas/provenance.js';
 import type { CatalogRecord } from '../schemas/entity.js';
 import type { EntityStateShape, EntityMint } from '../state/EntityState.js';
@@ -32,6 +38,21 @@ export interface ActivityRelations {
   readonly generated: ReadonlyArray<EntityRef>;
   readonly supersedes?: EntityRef;
 }
+
+export interface ActivityW7 {
+  readonly who?: ReadonlyArray<Agent>;
+  readonly when?: ProvenanceWhen;
+  readonly where?: string;
+  readonly why?: string;
+  readonly how?: string;
+}
+
+export type ActivityQuery =
+  | { readonly ref: EntityRef }
+  | { readonly who: string }
+  | { readonly why: string }
+  | { readonly gitSha: string }
+  | { readonly startedAt: string };
 
 export const uniqueEntityRefs = (refs: ReadonlyArray<EntityRef>): ReadonlyArray<EntityRef> => {
   const seen = new Set<string>();
@@ -51,6 +72,14 @@ export const relationsFromLabEntity = (entity: LabEntity): ActivityRelations => 
   ...(entity.supersedes !== undefined ? { supersedes: entity.supersedes } : {}),
 });
 
+export const w7FromLabEntity = (entity: LabEntity): ActivityW7 => ({
+  ...(entity.who !== undefined ? { who: entity.who } : {}),
+  ...(entity.when !== undefined ? { when: entity.when } : {}),
+  ...(entity.where !== undefined ? { where: entity.where } : {}),
+  ...(entity.why !== undefined ? { why: entity.why } : {}),
+  ...(entity.how !== undefined ? { how: entity.how } : {}),
+});
+
 export const declarationComponents = (input: {
   readonly kind: EntityKind;
   readonly type?: EntityType;
@@ -66,7 +95,43 @@ export const declarationComponents = (input: {
   return out;
 };
 
-export const activityComponents = (relations: ActivityRelations, type?: EntityType): ReadonlyArray<Component> => {
+export const w7Components = (w7: ActivityW7): ReadonlyArray<Component> => {
+  const out: Array<Component> = [];
+  for (const agent of w7.who ?? []) {
+    out.push(
+      new WhoComponent({
+        agentType: agent.agentType,
+        label: agent.label,
+        ...(agent.ref !== undefined ? { ref: agent.ref } : {}),
+      }),
+    );
+  }
+  if (w7.when !== undefined) {
+    out.push(
+      new WhenComponent({
+        startedAt: w7.when.startedAt,
+        ...(w7.when.completedAt !== undefined ? { completedAt: w7.when.completedAt } : {}),
+        ...(w7.when.gitSha !== undefined ? { gitSha: w7.when.gitSha } : {}),
+      }),
+    );
+  }
+  if (w7.where !== undefined) {
+    out.push(new WhereComponent({ value: w7.where }));
+  }
+  if (w7.why !== undefined) {
+    out.push(new WhyComponent({ value: w7.why }));
+  }
+  if (w7.how !== undefined) {
+    out.push(new HowComponent({ value: w7.how }));
+  }
+  return out;
+};
+
+export const activityComponents = (
+  relations: ActivityRelations,
+  type?: EntityType,
+  w7?: ActivityW7,
+): ReadonlyArray<Component> => {
   const out: Array<Component> = [...declarationComponents({ kind: 'activity', type })];
   for (const target of uniqueEntityRefs(relations.used)) {
     out.push(new UsedComponent({ target }));
@@ -77,10 +142,13 @@ export const activityComponents = (relations: ActivityRelations, type?: EntityTy
   if (relations.supersedes !== undefined) {
     out.push(new SupersedesComponent({ target: relations.supersedes }));
   }
+  if (w7 !== undefined) {
+    out.push(...w7Components(w7));
+  }
   return out;
 };
 
-/** Kind + Type + Bytes. Honesty / Claim / Used / Generated stay gated. */
+/** Kind + Type + Bytes. Honesty stays gated. W7 attaches when it arrived. */
 export const labEntityComponents = (entity: LabEntity): ReadonlyArray<Component> => {
   const declared = declarationComponents({
     kind: entity.kind,
@@ -88,9 +156,11 @@ export const labEntityComponents = (entity: LabEntity): ReadonlyArray<Component>
     bytes: entity.bytes,
   });
   if (entity.kind === 'activity') {
-    const relations = activityComponents(relationsFromLabEntity(entity), entity.type).filter(
-      (component) => component._tag !== 'Kind' && component._tag !== 'Type',
-    );
+    const relations = activityComponents(
+      relationsFromLabEntity(entity),
+      entity.type,
+      w7FromLabEntity(entity),
+    ).filter((component) => component._tag !== 'Kind' && component._tag !== 'Type');
     return [...declared, ...relations];
   }
   return declared;
@@ -126,6 +196,19 @@ export const requireTargets = (
     }
   });
 
+const optionalW7 = (input: ActivityW7): ActivityW7 | undefined => {
+  if (
+    input.who === undefined &&
+    input.when === undefined &&
+    input.where === undefined &&
+    input.why === undefined &&
+    input.how === undefined
+  ) {
+    return undefined;
+  }
+  return input;
+};
+
 export const runActivitySystem = (
   state: EntityStateShape,
   input: {
@@ -136,6 +219,11 @@ export const runActivitySystem = (
     readonly supersedes?: EntityRef;
     readonly createdAt?: string;
     readonly requireTargets?: boolean;
+    readonly who?: ReadonlyArray<Agent>;
+    readonly when?: ProvenanceWhen;
+    readonly where?: string;
+    readonly why?: string;
+    readonly how?: string;
   },
 ): Effect.Effect<CatalogRecord, CatalogError | EntityNotFoundError> => {
   const relations: ActivityRelations = {
@@ -143,6 +231,13 @@ export const runActivitySystem = (
     generated: uniqueEntityRefs(input.generated ?? []),
     ...(input.supersedes !== undefined ? { supersedes: input.supersedes } : {}),
   };
+  const w7 = optionalW7({
+    ...(input.who !== undefined ? { who: input.who } : {}),
+    ...(input.when !== undefined ? { when: input.when } : {}),
+    ...(input.where !== undefined ? { where: input.where } : {}),
+    ...(input.why !== undefined ? { why: input.why } : {}),
+    ...(input.how !== undefined ? { how: input.how } : {}),
+  });
   return Effect.gen(function* () {
     if (input.requireTargets !== false) {
       yield* requireTargets(state, [
@@ -158,14 +253,14 @@ export const runActivitySystem = (
         ...(input.type !== undefined ? { type: input.type } : {}),
         createdAt: input.createdAt ?? new Date().toISOString(),
       },
-      activityComponents(relations, input.type),
+      activityComponents(relations, input.type, w7),
     );
   });
 };
 
 /**
  * PR 92 `ActivityRepo.append` invariant, as a system:
- * refuse to rewrite a ref; corrections append a new one; attach Used/Generated/Supersedes.
+ * refuse to rewrite a ref; corrections append a new one; attach Used/Generated/Supersedes and W7.
  */
 export const appendActivity = (
   state: EntityStateShape,
@@ -220,18 +315,70 @@ export const appendActivity = (
     );
   });
 
+const listActivities = (
+  state: EntityStateShape,
+  matches: (row: CatalogRecord) => boolean,
+): Effect.Effect<ReadonlyArray<CatalogRecord>, CatalogError> =>
+  state.list('activity').pipe(Effect.map((rows) => rows.filter(matches)));
+
 export const activitiesByRef = (
   state: EntityStateShape,
   ref: EntityRef,
 ): Effect.Effect<ReadonlyArray<CatalogRecord>, CatalogError> =>
-  state.list('activity').pipe(
-    Effect.map((rows) =>
-      rows.filter(
-        (row) =>
-          row.id === ref ||
-          relationTargets(row.components, 'Used').includes(ref) ||
-          relationTargets(row.components, 'Generated').includes(ref) ||
-          relationTargets(row.components, 'Supersedes').includes(ref),
-      ),
+  listActivities(
+    state,
+    (row) =>
+      row.id === ref ||
+      relationTargets(row.components, 'Used').includes(ref) ||
+      relationTargets(row.components, 'Generated').includes(ref) ||
+      relationTargets(row.components, 'Supersedes').includes(ref),
+  );
+
+export const activitiesByWho = (
+  state: EntityStateShape,
+  label: string,
+): Effect.Effect<ReadonlyArray<CatalogRecord>, CatalogError> =>
+  listActivities(state, (row) =>
+    row.components.some((component) => component._tag === 'Who' && component.label === label),
+  );
+
+export const activitiesByWhy = (
+  state: EntityStateShape,
+  issue: string,
+): Effect.Effect<ReadonlyArray<CatalogRecord>, CatalogError> =>
+  listActivities(state, (row) =>
+    row.components.some((component) => component._tag === 'Why' && component.value === issue),
+  );
+
+export const activitiesBySha = (
+  state: EntityStateShape,
+  gitSha: string,
+): Effect.Effect<ReadonlyArray<CatalogRecord>, CatalogError> =>
+  listActivities(state, (row) =>
+    row.components.some(
+      (component) =>
+        (component._tag === 'When' && component.gitSha === gitSha) ||
+        (component._tag === 'Bytes' && component.gitSha === gitSha),
     ),
   );
+
+export const activitiesByWhen = (
+  state: EntityStateShape,
+  startedAt: string,
+): Effect.Effect<ReadonlyArray<CatalogRecord>, CatalogError> =>
+  listActivities(state, (row) =>
+    row.components.some((component) => component._tag === 'When' && component.startedAt === startedAt),
+  );
+
+export const queryActivities = (
+  state: EntityStateShape,
+  query: ActivityQuery,
+): Effect.Effect<ReadonlyArray<CatalogRecord>, CatalogError> => {
+  if ('ref' in query) return activitiesByRef(state, query.ref);
+  if ('who' in query) return activitiesByWho(state, query.who);
+  if ('why' in query) return activitiesByWhy(state, query.why);
+  if ('gitSha' in query) return activitiesBySha(state, query.gitSha);
+  if ('startedAt' in query) return activitiesByWhen(state, query.startedAt);
+  const _exhaustive: never = query;
+  return _exhaustive;
+};

--- a/packages/specimendb/src/adapters/activity.ts
+++ b/packages/specimendb/src/adapters/activity.ts
@@ -1,6 +1,5 @@
 /**
  * Activity systems. Used / Generated / Supersedes hang on the activity's entity_id.
- * W7 hangs as Who / When / Where / Why / How when it arrived. What is Used + Generated.
  * Corrections append a new ref. There is no lab_activities / lab_used / lab_generated table.
  *
  * @module @tmnl/specimendb/adapters/activity
@@ -28,8 +27,15 @@ import {
   EntityNotFoundError,
 } from '../schemas/errors.js';
 import { parseEntityRef, trustEntityRef, type EntityRef } from '../schemas/identifiers.js';
-import type { Agent, EntityKind, EntityType, LabEntity, ProvenanceWhen } from '../schemas/provenance.js';
-import type { ContentAddress } from '../schemas/provenance.js';
+import type {
+  Agent,
+  ContentAddress,
+  EntityKind,
+  EntityType,
+  GetByRefPayload,
+  LabEntity,
+  ProvenanceWhen,
+} from '../schemas/provenance.js';
 import type { CatalogRecord } from '../schemas/entity.js';
 import type { EntityStateShape, EntityMint } from '../state/EntityState.js';
 
@@ -47,13 +53,6 @@ export interface ActivityW7 {
   readonly how?: string;
 }
 
-export type ActivityQuery =
-  | { readonly ref: EntityRef }
-  | { readonly who: string }
-  | { readonly why: string }
-  | { readonly gitSha: string }
-  | { readonly startedAt: string };
-
 export const uniqueEntityRefs = (refs: ReadonlyArray<EntityRef>): ReadonlyArray<EntityRef> => {
   const seen = new Set<string>();
   const out: Array<EntityRef> = [];
@@ -65,7 +64,6 @@ export const uniqueEntityRefs = (refs: ReadonlyArray<EntityRef>): ReadonlyArray<
   return out;
 };
 
-/** Copy used/generated from LabEntity (`what.used ?? used`). */
 export const relationsFromLabEntity = (entity: LabEntity): ActivityRelations => ({
   used: uniqueEntityRefs([...(entity.what?.used ?? []), ...(entity.used ?? [])]),
   generated: uniqueEntityRefs([...(entity.what?.generated ?? []), ...(entity.generated ?? [])]),
@@ -148,7 +146,6 @@ export const activityComponents = (
   return out;
 };
 
-/** Kind + Type + Bytes. Honesty stays gated. W7 attaches when it arrived. */
 export const labEntityComponents = (entity: LabEntity): ReadonlyArray<Component> => {
   const declared = declarationComponents({
     kind: entity.kind,
@@ -258,10 +255,6 @@ export const runActivitySystem = (
   });
 };
 
-/**
- * PR 92 `ActivityRepo.append` invariant, as a system:
- * refuse to rewrite a ref; corrections append a new one; attach Used/Generated/Supersedes and W7.
- */
 export const appendActivity = (
   state: EntityStateShape,
   entity: LabEntity,
@@ -372,7 +365,7 @@ export const activitiesByWhen = (
 
 export const queryActivities = (
   state: EntityStateShape,
-  query: ActivityQuery,
+  query: GetByRefPayload,
 ): Effect.Effect<ReadonlyArray<CatalogRecord>, CatalogError> => {
   if ('ref' in query) return activitiesByRef(state, query.ref);
   if ('who' in query) return activitiesByWho(state, query.who);

--- a/packages/specimendb/src/adapters/cad01-seed.ts
+++ b/packages/specimendb/src/adapters/cad01-seed.ts
@@ -71,8 +71,11 @@ export const CAD01_SHEET_REFS: ReadonlyArray<EntityRef> = SHEETS.map((sheet) =>
   trustEntityRef(`gbg:sheet:${sheet.local}@pr58`),
 );
 
-/** S00–S06. S07 is topology; S08/S09 are diagram; PDF is not an HLR output. */
-export const CAD01_HLR_SHEET_REFS: ReadonlyArray<EntityRef> = CAD01_SHEET_REFS.slice(0, 7);
+const HLR_SHEET_LOCALS = new Set(['S00', 'S01', 'S02', 'S03', 'S04', 'S05', 'S06']);
+
+export const CAD01_HLR_SHEET_REFS: ReadonlyArray<EntityRef> = SHEETS.filter((sheet) =>
+  HLR_SHEET_LOCALS.has(sheet.local),
+).map((sheet) => trustEntityRef(`gbg:sheet:${sheet.local}@pr58`));
 
 const PART_STEPS: ReadonlyArray<{ readonly local: string; readonly path: string }> = [
   { local: 'B01', path: `${TERRARIUM}/cad/src/frame/exports/B01-corner-block.step` },

--- a/packages/specimendb/src/adapters/cad01-seed.ts
+++ b/packages/specimendb/src/adapters/cad01-seed.ts
@@ -30,7 +30,7 @@ import { seedGeneratingNote } from './generating-note.js';
 /** Commit that added the terrarium / analog / contract trees on this ref. */
 export const CAD01_TREE_SHA = '60abe9434a4236baf17de2e9e6569b1b8a734298';
 const CAD01_REV = CAD01_TREE_SHA.slice(0, 8);
-const CAD01_COMMITTED_AT = '2026-08-21T01:58:40Z';
+export const CAD01_COMMITTED_AT = '2026-08-21T01:58:40Z';
 
 const TERRARIUM = 'projects/biomemetics/labs/mantis/terrarium';
 const MANTIS = 'projects/biomemetics/labs/mantis';
@@ -40,6 +40,7 @@ const MANIFEST_PATH = `${TERRARIUM}/MANIFEST.sha256`;
 const SCHEMATICS = `${TERRARIUM}/schematics`;
 
 export const CAD01_SOLID_REF = trustEntityRef(`gbg:step:CAD01@${CAD01_REV}`);
+export const CAD01_EXPORT_REF = trustEntityRef(`gbg:activity:export-cad01@${CAD01_REV}`);
 export const CAD01_PROJECT_REF = trustEntityRef('gbg:activity:project-cad01@pr58');
 export const CAD01_PDF_REF = trustEntityRef('gbg:sheet:schematics-pdf@pr58');
 
@@ -69,6 +70,9 @@ const SHEETS: ReadonlyArray<{
 export const CAD01_SHEET_REFS: ReadonlyArray<EntityRef> = SHEETS.map((sheet) =>
   trustEntityRef(`gbg:sheet:${sheet.local}@pr58`),
 );
+
+/** S00–S06. S07 is topology; S08/S09 are diagram; PDF is not an HLR output. */
+export const CAD01_HLR_SHEET_REFS: ReadonlyArray<EntityRef> = CAD01_SHEET_REFS.slice(0, 7);
 
 const PART_STEPS: ReadonlyArray<{ readonly local: string; readonly path: string }> = [
   { local: 'B01', path: `${TERRARIUM}/cad/src/frame/exports/B01-corner-block.step` },
@@ -418,6 +422,7 @@ export type Cad01Pack = {
   readonly solid: DeclaredEntity;
   readonly sheets: ReadonlyArray<DeclaredEntity>;
   readonly pdf: DeclaredEntity;
+  readonly exportActivity: LabEntity;
   readonly activity: LabEntity;
   readonly declared: ReadonlyArray<DeclaredEntity>;
 };
@@ -438,7 +443,47 @@ export const loadCad01Pack = (repoRoot: string = repoRootFromHere()): Cad01Pack 
     throw new Error('schematics.pdf missing from declared set');
   }
 
-  const generated = [...CAD01_SHEET_REFS];
+  const exportActivity = decodeLabEntity({
+    _tag: 'LabEntity',
+    ref: CAD01_EXPORT_REF,
+    kind: 'activity',
+    type: 'export',
+    label: 'CAD-01 STEP export',
+    class: 'theoretical',
+    bytes: {
+      gitSha: CAD01_TREE_SHA,
+      path: `${TERRARIUM}/cad/src/frame/exports/occt-export-report.json`,
+    },
+    who: [
+      {
+        _tag: 'Agent',
+        agentType: 'software',
+        label: 'freecad-part-occt',
+      },
+    ],
+    what: {
+      used: [],
+      generated: [CAD01_SOLID_REF],
+    },
+    when: {
+      startedAt: CAD01_COMMITTED_AT,
+      gitSha: CAD01_TREE_SHA,
+    },
+    where: 'unknown',
+    why: '#20',
+    how: 'freecad-part-occt',
+    used: [],
+    generated: [CAD01_SOLID_REF],
+    wasAssociatedWith: [
+      {
+        _tag: 'Agent',
+        agentType: 'software',
+        label: 'freecad-part-occt',
+      },
+    ],
+  });
+
+  const generated = [...CAD01_HLR_SHEET_REFS];
   const activity = decodeLabEntity({
     _tag: 'LabEntity',
     ref: CAD01_PROJECT_REF,
@@ -479,7 +524,7 @@ export const loadCad01Pack = (repoRoot: string = repoRootFromHere()): Cad01Pack 
     ],
   });
 
-  return { solid, sheets, pdf, activity, declared };
+  return { solid, sheets, pdf, exportActivity, activity, declared };
 };
 
 const seedDeclared = (
@@ -504,6 +549,7 @@ export const seedCad01Hlr = (): Effect.Effect<
   {
     readonly pack: Cad01Pack;
     readonly records: ReadonlyArray<CatalogRecord>;
+    readonly exportActivity: CatalogRecord;
     readonly activity: CatalogRecord;
     readonly note: CatalogRecord;
   },
@@ -522,7 +568,8 @@ export const seedCad01Hlr = (): Effect.Effect<
     });
     const records = yield* seedDeclared(pack.declared);
     const state = yield* EntityState;
+    const exportActivity = yield* appendActivity(state, pack.exportActivity);
     const activity = yield* appendActivity(state, pack.activity);
     const generating = yield* seedGeneratingNote();
-    return { pack, records, activity, note: generating.note };
+    return { pack, records, exportActivity, activity, note: generating.note };
   });

--- a/packages/specimendb/src/adapters/index.ts
+++ b/packages/specimendb/src/adapters/index.ts
@@ -3,17 +3,29 @@ export { IntakeAdapter, type IntakeAdapterShape, type PreparedIntake } from './i
 export { CatalogRepositoriesLive, EntityStateSqlLayer } from './sql.js';
 export {
   activitiesByRef,
+  activitiesBySha,
+  activitiesByWhen,
+  activitiesByWho,
+  activitiesByWhy,
   activityComponents,
   appendActivity,
   declarationComponents,
   doctorActivityRef,
   projectActivityRef,
+  queryActivities,
   relationsFromLabEntity,
   runActivitySystem,
+  w7Components,
+  w7FromLabEntity,
+  type ActivityQuery,
   type ActivityRelations,
+  type ActivityW7,
 } from './activity.js';
 export { seedLabEntities, seedLabEntity } from './seed.js';
 export {
+  CAD01_COMMITTED_AT,
+  CAD01_EXPORT_REF,
+  CAD01_HLR_SHEET_REFS,
   CAD01_PDF_REF,
   CAD01_PROJECT_REF,
   CAD01_SHEET_REFS,

--- a/packages/specimendb/src/adapters/index.ts
+++ b/packages/specimendb/src/adapters/index.ts
@@ -17,7 +17,6 @@ export {
   runActivitySystem,
   w7Components,
   w7FromLabEntity,
-  type ActivityQuery,
   type ActivityRelations,
   type ActivityW7,
 } from './activity.js';

--- a/packages/specimendb/src/adapters/seed.ts
+++ b/packages/specimendb/src/adapters/seed.ts
@@ -14,6 +14,7 @@ import {
   mintFromLabEntity,
   relationsFromLabEntity,
   runActivitySystem,
+  w7FromLabEntity,
 } from './activity.js';
 
 export const seedLabEntity = (
@@ -23,6 +24,7 @@ export const seedLabEntity = (
     const state = yield* EntityState;
     if (entity.kind === 'activity') {
       const relations = relationsFromLabEntity(entity);
+      const w7 = w7FromLabEntity(entity);
       return yield* runActivitySystem(state, {
         id: entity.ref,
         type: entity.type,
@@ -30,6 +32,11 @@ export const seedLabEntity = (
         generated: relations.generated,
         createdAt: mintFromLabEntity(entity).createdAt,
         requireTargets: false,
+        ...(w7.who !== undefined ? { who: w7.who } : {}),
+        ...(w7.when !== undefined ? { when: w7.when } : {}),
+        ...(w7.where !== undefined ? { where: w7.where } : {}),
+        ...(w7.why !== undefined ? { why: w7.why } : {}),
+        ...(w7.how !== undefined ? { how: w7.how } : {}),
       });
     }
     return yield* state.ensure(mintFromLabEntity(entity), labEntityComponents(entity));

--- a/packages/specimendb/src/models/_migrations.ts
+++ b/packages/specimendb/src/models/_migrations.ts
@@ -17,6 +17,7 @@ export const catalogMigrations = {
   '0005_entity_kinds': syncEntityKindCheck,
   '0006_entity_type': addEntityTypeColumn,
   '0007_component_kinds': syncComponentKindCheck,
+  '0008_component_kinds': syncComponentKindCheck,
 } as const;
 
 export type CatalogMigrationKey = keyof typeof catalogMigrations;

--- a/packages/specimendb/src/rpc/SpecimenRpcs.ts
+++ b/packages/specimendb/src/rpc/SpecimenRpcs.ts
@@ -11,7 +11,7 @@ import * as Schema from 'effect/Schema';
 import * as Rpc from 'effect/unstable/rpc/Rpc';
 import * as RpcGroup from 'effect/unstable/rpc/RpcGroup';
 import {
-  activitiesByRef,
+  queryActivities,
   appendActivity,
   doctorActivityRef,
   projectActivityRef,
@@ -135,7 +135,7 @@ export const SpecimenRpcsLive = SpecimenRpcs.toLayer(
           generated: payload.generated ?? [payload.run],
         }),
       AppendActivity: (payload) => appendActivity(state, payload),
-      GetByRef: (payload) => activitiesByRef(state, payload.ref),
+      GetByRef: (payload) => queryActivities(state, payload),
     });
   }),
 );

--- a/packages/specimendb/src/schemas/components.ts
+++ b/packages/specimendb/src/schemas/components.ts
@@ -143,7 +143,6 @@ export class ObservationComponent extends Schema.TaggedClass<ObservationComponen
   text: Schema.String,
 }) {}
 
-/** W7 who. What is Used + Generated; there is no WhatComponent. */
 export class WhoComponent extends Schema.TaggedClass<WhoComponent>()('Who', {
   agentType: AgentType,
   label: Schema.String.check(Schema.isMinLength(1)),
@@ -156,7 +155,7 @@ export class WhenComponent extends Schema.TaggedClass<WhenComponent>()('When', {
   gitSha: Schema.optional(Schema.String),
 }) {}
 
-/** `unknown` is a legal value. Do not invent GPS. */
+/** The string `unknown` is a value. Do not omit. Do not invent GPS. */
 export class WhereComponent extends Schema.TaggedClass<WhereComponent>()('Where', {
   value: Schema.String.check(Schema.isMinLength(1)),
 }) {}

--- a/packages/specimendb/src/schemas/components.ts
+++ b/packages/specimendb/src/schemas/components.ts
@@ -9,7 +9,7 @@
 
 import * as Schema from 'effect/Schema';
 import { EntityRef } from './identifiers.js';
-import { EntityKind, EntityType, HonestyClass } from './provenance.js';
+import { AgentType, EntityKind, EntityType, HonestyClass } from './provenance.js';
 
 export const SpecimenStatus = Schema.Literals(['raw', 'filed', 'working', 'dead'] as const);
 export type SpecimenStatus = typeof SpecimenStatus.Type;
@@ -143,6 +143,32 @@ export class ObservationComponent extends Schema.TaggedClass<ObservationComponen
   text: Schema.String,
 }) {}
 
+/** W7 who. What is Used + Generated; there is no WhatComponent. */
+export class WhoComponent extends Schema.TaggedClass<WhoComponent>()('Who', {
+  agentType: AgentType,
+  label: Schema.String.check(Schema.isMinLength(1)),
+  ref: Schema.optional(Schema.String),
+}) {}
+
+export class WhenComponent extends Schema.TaggedClass<WhenComponent>()('When', {
+  startedAt: Schema.String.check(Schema.isMinLength(1)),
+  completedAt: Schema.optional(Schema.String),
+  gitSha: Schema.optional(Schema.String),
+}) {}
+
+/** `unknown` is a legal value. Do not invent GPS. */
+export class WhereComponent extends Schema.TaggedClass<WhereComponent>()('Where', {
+  value: Schema.String.check(Schema.isMinLength(1)),
+}) {}
+
+export class WhyComponent extends Schema.TaggedClass<WhyComponent>()('Why', {
+  value: Schema.String.check(Schema.isMinLength(1)),
+}) {}
+
+export class HowComponent extends Schema.TaggedClass<HowComponent>()('How', {
+  value: Schema.String.check(Schema.isMinLength(1)),
+}) {}
+
 /**
  * Relationships are components a system walks (`Used` / `Generated` / …).
  * Each holds a target EntityRef. There is no third table.
@@ -209,6 +235,11 @@ export const Component = Schema.Union([
   TagComponent,
   QuestionComponent,
   ObservationComponent,
+  WhoComponent,
+  WhenComponent,
+  WhereComponent,
+  WhyComponent,
+  HowComponent,
   UsedComponent,
   GeneratedComponent,
   ExhibitsComponent,
@@ -241,6 +272,11 @@ export const COMPONENT_KIND_VALUES = [
   'Tag',
   'Question',
   'Observation',
+  'Who',
+  'When',
+  'Where',
+  'Why',
+  'How',
   'Used',
   'Generated',
   'Exhibits',
@@ -278,6 +314,25 @@ export const sameComponent = (left: Component, right: Component): boolean => {
   }
   if (left._tag === 'Bytes' && right._tag === 'Bytes') {
     return left.gitSha === right.gitSha && left.digest === right.digest && left.path === right.path;
+  }
+  if (left._tag === 'Who' && right._tag === 'Who') {
+    return left.agentType === right.agentType && left.label === right.label && left.ref === right.ref;
+  }
+  if (left._tag === 'When' && right._tag === 'When') {
+    return (
+      left.startedAt === right.startedAt &&
+      left.completedAt === right.completedAt &&
+      left.gitSha === right.gitSha
+    );
+  }
+  if (left._tag === 'Where' && right._tag === 'Where') {
+    return left.value === right.value;
+  }
+  if (left._tag === 'Why' && right._tag === 'Why') {
+    return left.value === right.value;
+  }
+  if (left._tag === 'How' && right._tag === 'How') {
+    return left.value === right.value;
   }
   return true;
 };

--- a/packages/specimendb/src/schemas/provenance.ts
+++ b/packages/specimendb/src/schemas/provenance.ts
@@ -10,8 +10,7 @@
  * Honesty class lives on the generated entity. Operations are entities.
  *
  * Catalog SoT is Postgres (`entities` + `components`). Activity append is a
- * system: Used / Generated / Supersedes and W7 (Who / When / Where / Why / How)
- * hang on `entity_id`. What is Used + Generated.
+ * system: Used / Generated / Supersedes hang on `entity_id`.
  *
  * @module @tmnl/specimendb/schemas/provenance
  */
@@ -229,7 +228,6 @@ export const decodeDoctorReportPayload = Schema.decodeUnknownSync(DoctorReportPa
 
 const queryString = Schema.String.check(Schema.isMinLength(1));
 
-/** Single-key query. `{ ref }` callers stay valid. Walks activity components. */
 export const GetByRefPayload = Schema.Union([
   Schema.Struct({ ref: EntityRef }),
   Schema.Struct({ who: queryString }),

--- a/packages/specimendb/src/schemas/provenance.ts
+++ b/packages/specimendb/src/schemas/provenance.ts
@@ -10,7 +10,8 @@
  * Honesty class lives on the generated entity. Operations are entities.
  *
  * Catalog SoT is Postgres (`entities` + `components`). Activity append is a
- * system: Used / Generated / Supersedes hang on `entity_id`.
+ * system: Used / Generated / Supersedes and W7 (Who / When / Where / Why / How)
+ * hang on `entity_id`. What is Used + Generated.
  *
  * @module @tmnl/specimendb/schemas/provenance
  */
@@ -226,8 +227,14 @@ export const LabEntityRecord = LabEntity.pipe(Schema.check(activityHasW7));
 export const decodeLabEntity = Schema.decodeUnknownSync(LabEntityRecord);
 export const decodeDoctorReportPayload = Schema.decodeUnknownSync(DoctorReportPayload);
 
-/** Get-by-ref: the activity itself, Used target, Generated target, or Supersedes. */
-export const GetByRefPayload = Schema.Struct({
-  ref: EntityRef,
-});
+const queryString = Schema.String.check(Schema.isMinLength(1));
+
+/** Single-key query. `{ ref }` callers stay valid. Walks activity components. */
+export const GetByRefPayload = Schema.Union([
+  Schema.Struct({ ref: EntityRef }),
+  Schema.Struct({ who: queryString }),
+  Schema.Struct({ why: queryString }),
+  Schema.Struct({ gitSha: queryString }),
+  Schema.Struct({ startedAt: queryString }),
+]);
 export type GetByRefPayload = typeof GetByRefPayload.Type;

--- a/packages/specimendb/test/activity-log.test.ts
+++ b/packages/specimendb/test/activity-log.test.ts
@@ -1,8 +1,3 @@
-/**
- * Append-only activity system: Used / Generated / Supersedes on entity_id.
- * Port of PR 92 ActivityRepo.append invariant. No lab_activities table.
- */
-
 import { mkdtemp, rm } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -14,9 +9,20 @@ import * as Result from 'effect/Result';
 import * as RpcTest from 'effect/unstable/rpc/RpcTest';
 import { SqlClient } from 'effect/unstable/sql/SqlClient';
 import { SpecimenRpcs } from '../src/rpc/SpecimenRpcs.js';
+import { CatalogRpcs } from '../src/rpc/CatalogRpcs.js';
 import { decodeLabEntity } from '../src/schemas/provenance.js';
 import { relationTargets } from '../src/schemas/components.js';
 import { trustEntityRef } from '../src/schemas/identifiers.js';
+import {
+  CAD01_COMMITTED_AT,
+  CAD01_HLR_SHEET_REFS,
+  CAD01_PROJECT_REF,
+  CAD01_SOLID_REF,
+  CAD01_TREE_SHA,
+  loadCad01Pack,
+} from '../src/adapters/cad01-seed.js';
+import { declarationComponents } from '../src/adapters/activity.js';
+import { MemoryCatalogLive } from '../testbed/memory-rpc.js';
 import { testCatalogLayer } from './catalog-pg.js';
 
 const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'provenance');
@@ -228,6 +234,81 @@ describe('AppendActivity / GetByRef', () => {
         });
         expect(rows).toEqual([]);
       }) as Effect.Effect<unknown, unknown, never>,
+    );
+  });
+});
+
+describe('AppendActivity / GetByRef (memory)', () => {
+  it('walks W7 and a CAD-01 HLR correction as a new ref', async () => {
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const catalog = yield* RpcTest.makeClient(CatalogRpcs);
+          const client = yield* RpcTest.makeClient(SpecimenRpcs);
+          const activity = originalActivity();
+          const appended = yield* client.AppendActivity(activity);
+          expect(appended.components.some((c) => c._tag === 'Who')).toBe(true);
+          const byWho = yield* client.GetByRef({ who: 'freecad-part-occt' });
+          expect(byWho.map((row) => row.id)).toEqual([activity.ref]);
+
+          const pack = loadCad01Pack();
+          for (const row of pack.declared) {
+            yield* catalog.MintEntity({
+              id: row.mint.id,
+              kind: row.mint.kind,
+              type: row.mint.type,
+              createdAt: row.mint.createdAt,
+              components: [
+                ...declarationComponents({
+                  kind: row.mint.kind,
+                  type: row.mint.type,
+                  bytes: row.bytes,
+                }),
+              ],
+            });
+          }
+          yield* client.AppendActivity(pack.exportActivity);
+          const hlr = yield* client.AppendActivity(pack.activity);
+          const generated = relationTargets(hlr.components, 'Generated');
+          expect(generated).toEqual([...CAD01_HLR_SHEET_REFS]);
+
+          const correction = decodeLabEntity({
+            _tag: 'LabEntity',
+            ref: 'gbg:activity:project-cad01-corrected@pr58',
+            kind: 'activity',
+            type: 'hlr',
+            label: 'HLR/project CAD-01 sheets (correction)',
+            class: 'theoretical',
+            who: [
+              {
+                _tag: 'Agent',
+                agentType: 'software',
+                label: 'generate_schematics.py',
+              },
+            ],
+            what: {
+              used: [CAD01_SOLID_REF],
+              generated: [...CAD01_HLR_SHEET_REFS],
+            },
+            when: { startedAt: CAD01_COMMITTED_AT, gitSha: CAD01_TREE_SHA },
+            where: 'unknown',
+            why: '#58',
+            how: 'generate_schematics.py',
+            used: [CAD01_SOLID_REF],
+            generated: [...CAD01_HLR_SHEET_REFS],
+            supersedes: CAD01_PROJECT_REF,
+          });
+          yield* client.AppendActivity(correction);
+          const history = yield* client.GetByRef({ ref: CAD01_PROJECT_REF });
+          expect(history.map((row) => row.id)).toEqual(
+            expect.arrayContaining([CAD01_PROJECT_REF, correction.ref]),
+          );
+          const original = history.find((row) => row.id === CAD01_PROJECT_REF);
+          expect(relationTargets(original?.components ?? [], 'Generated')).toEqual(generated);
+          const dup = yield* Effect.result(client.AppendActivity(pack.activity));
+          expect(Result.isFailure(dup)).toBe(true);
+        }),
+      ).pipe(Effect.provide(MemoryCatalogLive)) as Effect.Effect<unknown>,
     );
   });
 });

--- a/packages/specimendb/test/activity-log.test.ts
+++ b/packages/specimendb/test/activity-log.test.ts
@@ -69,6 +69,13 @@ describe('AppendActivity / GetByRef', () => {
         expect(relationTargets(appended.components, 'Generated')).toEqual([
           'gbg:step:B01@fe8f875a',
         ]);
+        expect(appended.components.some((c) => c._tag === 'Who')).toBe(true);
+        expect(appended.components.some((c) => c._tag === 'When')).toBe(true);
+        expect(appended.components.some((c) => c._tag === 'Where')).toBe(true);
+        expect(appended.components.some((c) => c._tag === 'Why')).toBe(true);
+        expect(appended.components.some((c) => c._tag === 'How')).toBe(true);
+        const who = appended.components.find((c) => c._tag === 'Who');
+        expect(who?._tag === 'Who' && who.label).toBe('freecad-part-occt');
 
         const byActivity = yield* client.GetByRef({
           ref: trustEntityRef('gbg:activity:freecad-part-occt@fe8f875a'),
@@ -84,6 +91,17 @@ describe('AppendActivity / GetByRef', () => {
         expect(relationTargets(byGenerated[0]?.components ?? [], 'Generated')).toContain(
           'gbg:step:B01@fe8f875a',
         );
+
+        const byWho = yield* client.GetByRef({ who: 'freecad-part-occt' });
+        expect(byWho.map((row) => row.id)).toEqual(['gbg:activity:freecad-part-occt@fe8f875a']);
+        const byWhy = yield* client.GetByRef({ why: '#28' });
+        expect(byWhy.map((row) => row.id)).toEqual(['gbg:activity:freecad-part-occt@fe8f875a']);
+        const bySha = yield* client.GetByRef({
+          gitSha: 'fe8f875a80b37a1003f05f3a0190fbe2f0417842',
+        });
+        expect(bySha.map((row) => row.id)).toEqual(['gbg:activity:freecad-part-occt@fe8f875a']);
+        const byWhen = yield* client.GetByRef({ startedAt: '2026-08-20T10:05:07Z' });
+        expect(byWhen.map((row) => row.id)).toEqual(['gbg:activity:freecad-part-occt@fe8f875a']);
       }) as Effect.Effect<unknown, unknown, never>,
     );
   });

--- a/packages/specimendb/test/cad01-seed.test.ts
+++ b/packages/specimendb/test/cad01-seed.test.ts
@@ -1,6 +1,6 @@
 /**
- * In-repo lab files as cheap entities (kind + type). HLR activity is gated.
- * No specimen. No GPS/taxon/SKU. Honesty is not attached on mint.
+ * In-repo lab files as cheap entities (kind + type). HLR and STEP export are
+ * gated activities. No specimen. No GPS/taxon/SKU. Honesty is not attached on mint.
  */
 
 import { existsSync, readFileSync } from 'node:fs';
@@ -11,9 +11,13 @@ import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import * as Effect from 'effect/Effect';
+import * as Result from 'effect/Result';
 import * as RpcTest from 'effect/unstable/rpc/RpcTest';
 import { SqlClient } from 'effect/unstable/sql/SqlClient';
 import {
+  CAD01_COMMITTED_AT,
+  CAD01_EXPORT_REF,
+  CAD01_HLR_SHEET_REFS,
   CAD01_PDF_REF,
   CAD01_PROJECT_REF,
   CAD01_SHEET_REFS,
@@ -30,14 +34,96 @@ import {
   QUARRY_PR95_REF,
   WORKER_REF,
 } from '../src/adapters/generating-note.js';
-import { declarationComponents } from '../src/adapters/activity.js';
-import { relationTargets } from '../src/schemas/components.js';
+import { activityComponents, declarationComponents } from '../src/adapters/activity.js';
+import {
+  HowComponent,
+  WhenComponent,
+  WhereComponent,
+  WhoComponent,
+  WhyComponent,
+  relationTargets,
+  sameComponent,
+} from '../src/schemas/components.js';
+import type { CatalogRecord } from '../src/schemas/entity.js';
+import { decodeLabEntity } from '../src/schemas/provenance.js';
+import { trustEntityRef } from '../src/schemas/identifiers.js';
 import { CatalogRpcs } from '../src/rpc/CatalogRpcs.js';
 import { SpecimenRpcs } from '../src/rpc/SpecimenRpcs.js';
 import { MemoryCatalogLive } from '../testbed/memory-rpc.js';
 import { testCatalogLayer } from './catalog-pg.js';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+const CAD01_CORRECTION_REF = trustEntityRef('gbg:activity:project-cad01-corrected@pr58');
+const MINT_ACTIVITY_REF = trustEntityRef('gbg:activity:mint-w7@test');
+
+const ids = (rows: ReadonlyArray<{ id: string }>): ReadonlyArray<string> =>
+  rows.map((row) => row.id);
+
+const expectW7 = (
+  record: CatalogRecord,
+  expected: { readonly who: string; readonly why: string; readonly how: string },
+): void => {
+  const who = record.components.find((component) => component._tag === 'Who');
+  expect(who?._tag === 'Who' && who.agentType).toBe('software');
+  expect(who?._tag === 'Who' && who.label).toBe(expected.who);
+  expect(
+    record.components.some(
+      (component) =>
+        component._tag === 'When' &&
+        component.startedAt === CAD01_COMMITTED_AT &&
+        component.gitSha === CAD01_TREE_SHA,
+    ),
+  ).toBe(true);
+  expect(
+    record.components.some(
+      (component) => component._tag === 'Where' && component.value === 'unknown',
+    ),
+  ).toBe(true);
+  expect(
+    record.components.some(
+      (component) => component._tag === 'Why' && component.value === expected.why,
+    ),
+  ).toBe(true);
+  expect(
+    record.components.some(
+      (component) => component._tag === 'How' && component.value === expected.how,
+    ),
+  ).toBe(true);
+  expect(record.components.some((component) => component._tag === 'What')).toBe(false);
+  expect(record.components.some((component) => component._tag === 'Honesty')).toBe(false);
+};
+
+const cad01Correction = () =>
+  decodeLabEntity({
+    _tag: 'LabEntity',
+    ref: CAD01_CORRECTION_REF,
+    kind: 'activity',
+    type: 'hlr',
+    label: 'HLR/project CAD-01 sheets (correction)',
+    class: 'theoretical',
+    who: [
+      {
+        _tag: 'Agent',
+        agentType: 'software',
+        label: 'generate_schematics.py',
+      },
+    ],
+    what: {
+      used: [CAD01_SOLID_REF],
+      generated: [...CAD01_HLR_SHEET_REFS],
+    },
+    when: {
+      startedAt: CAD01_COMMITTED_AT,
+      gitSha: CAD01_TREE_SHA,
+    },
+    where: 'unknown',
+    why: '#58',
+    how: 'generate_schematics.py',
+    used: [CAD01_SOLID_REF],
+    generated: [...CAD01_HLR_SHEET_REFS],
+    supersedes: CAD01_PROJECT_REF,
+  });
 
 const pgUnavailable = (cause: unknown): Error => {
   const detail = cause instanceof Error ? cause.message : String(cause);
@@ -66,12 +152,100 @@ const runCatalog = async (program: Effect.Effect<unknown, unknown, never>) => {
   }
 };
 
-const typeOf = (record: { type?: string; components: ReadonlyArray<{ _tag: string; value?: string }> }) => {
+const runMemory = (program: Effect.Effect<unknown, unknown, never>) =>
+  Effect.runPromise(
+    Effect.scoped(program).pipe(Effect.provide(MemoryCatalogLive)) as Effect.Effect<unknown>,
+  );
+
+const typeOf = (record: {
+  type?: string;
+  components: ReadonlyArray<{ _tag: string; value?: string }>;
+}) => {
   const fromRow = record.type;
   const fromComponent = record.components.find((c) => c._tag === 'Type');
   const componentValue = fromComponent?._tag === 'Type' ? fromComponent.value : undefined;
   return { fromRow, componentValue };
 };
+
+const proveCad01Activities = Effect.gen(function* () {
+  const catalog = yield* RpcTest.makeClient(CatalogRpcs);
+  const specimens = yield* RpcTest.makeClient(SpecimenRpcs);
+
+  const exportRecord = yield* catalog.GetEntity({ entityId: CAD01_EXPORT_REF });
+  expect(exportRecord.kind).toBe('activity');
+  expect(exportRecord.type).toBe('export');
+  expect(relationTargets(exportRecord.components, 'Generated')).toEqual([CAD01_SOLID_REF]);
+  expect(relationTargets(exportRecord.components, 'Used')).toEqual([]);
+  expectW7(exportRecord, {
+    who: 'freecad-part-occt',
+    why: '#20',
+    how: 'freecad-part-occt',
+  });
+
+  const hlr = yield* catalog.GetEntity({ entityId: CAD01_PROJECT_REF });
+  expect(hlr.kind).toBe('activity');
+  expect(hlr.type).toBe('hlr');
+  expect(relationTargets(hlr.components, 'Used')).toEqual([CAD01_SOLID_REF]);
+  expect(relationTargets(hlr.components, 'Generated')).toEqual([...CAD01_HLR_SHEET_REFS]);
+  expect(relationTargets(hlr.components, 'Generated')).toHaveLength(7);
+  expect(relationTargets(hlr.components, 'Generated').includes(CAD01_SHEET_REFS[7]!)).toBe(false);
+  expect(relationTargets(hlr.components, 'Generated').includes(CAD01_PDF_REF)).toBe(false);
+  expectW7(hlr, {
+    who: 'generate_schematics.py',
+    why: '#58',
+    how: 'generate_schematics.py',
+  });
+
+  const byStep = yield* specimens.GetByRef({ ref: CAD01_SOLID_REF });
+  expect(ids(byStep)).toEqual(expect.arrayContaining([CAD01_EXPORT_REF, CAD01_PROJECT_REF]));
+  expect(byStep).toHaveLength(2);
+
+  const byS00 = yield* specimens.GetByRef({ ref: CAD01_SHEET_REFS[0]! });
+  expect(ids(byS00)).toEqual([CAD01_PROJECT_REF]);
+  const byS06 = yield* specimens.GetByRef({ ref: CAD01_SHEET_REFS[6]! });
+  expect(ids(byS06)).toEqual([CAD01_PROJECT_REF]);
+  const byS07 = yield* specimens.GetByRef({ ref: CAD01_SHEET_REFS[7]! });
+  expect(ids(byS07).includes(CAD01_PROJECT_REF)).toBe(false);
+
+  const byWhoHlr = yield* specimens.GetByRef({ who: 'generate_schematics.py' });
+  expect(ids(byWhoHlr)).toContain(CAD01_PROJECT_REF);
+  const byWhoExport = yield* specimens.GetByRef({ who: 'freecad-part-occt' });
+  expect(ids(byWhoExport)).toContain(CAD01_EXPORT_REF);
+  const byWhy58 = yield* specimens.GetByRef({ why: '#58' });
+  expect(ids(byWhy58)).toContain(CAD01_PROJECT_REF);
+  const byWhy20 = yield* specimens.GetByRef({ why: '#20' });
+  expect(ids(byWhy20)).toContain(CAD01_EXPORT_REF);
+  const bySha = yield* specimens.GetByRef({ gitSha: CAD01_TREE_SHA });
+  expect(ids(bySha)).toEqual(expect.arrayContaining([CAD01_EXPORT_REF, CAD01_PROJECT_REF]));
+  const byWhen = yield* specimens.GetByRef({ startedAt: CAD01_COMMITTED_AT });
+  expect(ids(byWhen)).toEqual(expect.arrayContaining([CAD01_EXPORT_REF, CAD01_PROJECT_REF]));
+
+  const specimensListed = yield* specimens.List();
+  expect(specimensListed).toEqual([]);
+  const specimenEntities = yield* catalog.ListEntities({ kind: 'specimen' });
+  expect(specimenEntities).toEqual([]);
+});
+
+describe('W7 sameComponent', () => {
+  it('does not collapse two Who agents that share a tag', () => {
+    const left = new WhoComponent({ agentType: 'software', label: 'generate_schematics.py' });
+    const right = new WhoComponent({ agentType: 'software', label: 'freecad-part-occt' });
+    expect(sameComponent(left, right)).toBe(false);
+    expect(sameComponent(left, left)).toBe(true);
+    expect(
+      sameComponent(
+        new WhyComponent({ value: '#58' }),
+        new WhyComponent({ value: '#20' }),
+      ),
+    ).toBe(false);
+    expect(
+      sameComponent(
+        new WhenComponent({ startedAt: CAD01_COMMITTED_AT, gitSha: CAD01_TREE_SHA }),
+        new WhenComponent({ startedAt: CAD01_COMMITTED_AT, gitSha: 'deadbeef' }),
+      ),
+    ).toBe(false);
+  });
+});
 
 describe('CAD-01 files on this ref', () => {
   it('finds in-repo solids, sheets, reports, contracts, catalogs', () => {
@@ -99,6 +273,14 @@ describe('CAD-01 files on this ref', () => {
       'projected',
       'projected',
     ]);
+    expect(pack.exportActivity.ref).toBe(CAD01_EXPORT_REF);
+    expect(pack.exportActivity.type).toBe('export');
+    expect(pack.exportActivity.who?.[0]?.label).toBe('freecad-part-occt');
+    expect(pack.exportActivity.how).toBe('freecad-part-occt');
+    expect(pack.exportActivity.why).toBe('#20');
+    expect(pack.exportActivity.where).toBe('unknown');
+    expect(pack.exportActivity.what?.generated).toEqual([CAD01_SOLID_REF]);
+    expect(pack.exportActivity.what?.used).toEqual([]);
     expect(pack.activity.type).toBe('hlr');
     expect(pack.activity.who?.[0]?.agentType).toBe('software');
     expect(pack.activity.who?.[0]?.label).toBe('generate_schematics.py');
@@ -106,7 +288,9 @@ describe('CAD-01 files on this ref', () => {
     expect(pack.activity.why).toBe('#58');
     expect(pack.activity.how).toBe('generate_schematics.py');
     expect(pack.activity.what?.used).toEqual([CAD01_SOLID_REF]);
-    expect(pack.activity.what?.generated).toEqual([...CAD01_SHEET_REFS]);
+    expect(pack.activity.what?.generated).toEqual([...CAD01_HLR_SHEET_REFS]);
+    expect(pack.activity.what?.generated).toHaveLength(7);
+    expect(pack.activity.what?.generated.includes(CAD01_SHEET_REFS[7]!)).toBe(false);
     expect(pack.activity.what?.generated.includes(CAD01_PDF_REF)).toBe(false);
     const manifest = readFileSync(
       join(repoRoot, 'projects/biomemetics/labs/mantis/terrarium/MANIFEST.sha256'),
@@ -130,21 +314,23 @@ describe('CAD-01 files on this ref', () => {
   });
 });
 
-describe('CAD-01 seed (cheap mint, gated HLR)', () => {
-  it('mints kind+type over Postgres; HLR Used/Generated stay gated; #81 note is cheap', async () => {
+describe('CAD-01 seed (cheap mint, gated HLR + export)', () => {
+  it('mints kind+type over Postgres; walks Used/Generated and W7; #81 note is cheap', async () => {
     await runCatalog(
       Effect.gen(function* () {
         const catalog = yield* RpcTest.makeClient(CatalogRpcs);
         const specimens = yield* RpcTest.makeClient(SpecimenRpcs);
         const seeded = yield* seedCad01Hlr();
 
+        expect(seeded.exportActivity.id).toBe(CAD01_EXPORT_REF);
         expect(seeded.activity.id).toBe(CAD01_PROJECT_REF);
         expect(seeded.activity.type).toBe('hlr');
         expect(relationTargets(seeded.activity.components, 'Used')).toEqual([CAD01_SOLID_REF]);
         expect(relationTargets(seeded.activity.components, 'Generated')).toEqual([
-          ...CAD01_SHEET_REFS,
+          ...CAD01_HLR_SHEET_REFS,
         ]);
         expect(seeded.activity.components.some((c) => c._tag === 'Honesty')).toBe(false);
+        expect(seeded.exportActivity.components.some((c) => c._tag === 'Honesty')).toBe(false);
 
         const solid = yield* catalog.GetEntity({ entityId: CAD01_SOLID_REF });
         expect(solid.kind).toBe('solid');
@@ -187,13 +373,7 @@ describe('CAD-01 seed (cheap mint, gated HLR)', () => {
         const sheets = yield* catalog.ListEntities({ kind: 'sheet' });
         expect(sheets.length).toBeGreaterThanOrEqual(17);
 
-        const specimensListed = yield* specimens.List();
-        expect(specimensListed).toEqual([]);
-        const specimenEntities = yield* catalog.ListEntities({ kind: 'specimen' });
-        expect(specimenEntities).toEqual([]);
-
-        const byStep = yield* specimens.GetByRef({ ref: CAD01_SOLID_REF });
-        expect(byStep.map((row) => row.id)).toEqual([CAD01_PROJECT_REF]);
+        yield* proveCad01Activities;
 
         expect(seeded.note.id).toBe(NOTE81_REF);
         expect(seeded.note.kind).toBe('activity');
@@ -216,42 +396,126 @@ describe('CAD-01 seed (cheap mint, gated HLR)', () => {
         expect(worker.kind).toBe('activity');
         expect(worker.type).toBe('worker');
         expect(worker.components.some((c) => c._tag === 'Used' || c._tag === 'Generated')).toBe(false);
+
+        const minted = yield* catalog.MintEntity({
+          id: MINT_ACTIVITY_REF,
+          kind: 'activity',
+          type: 'note',
+          createdAt: CAD01_COMMITTED_AT,
+          components: [
+            ...activityComponents({ used: [], generated: [] }, 'note'),
+            new WhoComponent({ agentType: 'software', label: 'generate_schematics.py' }),
+            new WhenComponent({ startedAt: CAD01_COMMITTED_AT, gitSha: CAD01_TREE_SHA }),
+            new WhereComponent({ value: 'unknown' }),
+            new WhyComponent({ value: '#58' }),
+            new HowComponent({ value: 'generate_schematics.py' }),
+          ],
+        });
+        expect(minted.kind).toBe('activity');
+        expectW7(minted, {
+          who: 'generate_schematics.py',
+          why: '#58',
+          how: 'generate_schematics.py',
+        });
+
+        const originalGenerated = relationTargets(seeded.activity.components, 'Generated');
+        yield* specimens.AppendActivity(cad01Correction());
+        const history = yield* specimens.GetByRef({ ref: CAD01_PROJECT_REF });
+        expect(ids(history)).toEqual(
+          expect.arrayContaining([CAD01_PROJECT_REF, CAD01_CORRECTION_REF]),
+        );
+        expect(history).toHaveLength(2);
+        const original = history.find((row) => row.id === CAD01_PROJECT_REF);
+        expect(relationTargets(original?.components ?? [], 'Generated')).toEqual(originalGenerated);
+        expect(relationTargets(original?.components ?? [], 'Used')).toEqual([CAD01_SOLID_REF]);
+        const correction = history.find((row) => row.id === CAD01_CORRECTION_REF);
+        expect(relationTargets(correction?.components ?? [], 'Supersedes')).toEqual([
+          CAD01_PROJECT_REF,
+        ]);
+
+        const dup = yield* Effect.result(specimens.AppendActivity(seeded.pack.activity));
+        expect(Result.isFailure(dup)).toBe(true);
+        if (Result.isFailure(dup)) {
+          expect(dup.failure._tag).toBe('ActivityAppendError');
+        }
       }) as Effect.Effect<unknown, unknown, never>,
     );
   });
 
   it('mints declarations through Catalog.MintEntity, then AppendActivity', async () => {
-    await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const catalog = yield* RpcTest.makeClient(CatalogRpcs);
-          const specimens = yield* RpcTest.makeClient(SpecimenRpcs);
-          const pack = loadCad01Pack(repoRoot);
-          for (const row of pack.declared) {
-            yield* catalog.MintEntity({
-              id: row.mint.id,
-              kind: row.mint.kind,
-              type: row.mint.type,
-              createdAt: row.mint.createdAt,
-              components: [...declarationComponents({
+    await runMemory(
+      Effect.gen(function* () {
+        const catalog = yield* RpcTest.makeClient(CatalogRpcs);
+        const specimens = yield* RpcTest.makeClient(SpecimenRpcs);
+        const pack = loadCad01Pack(repoRoot);
+        for (const row of pack.declared) {
+          yield* catalog.MintEntity({
+            id: row.mint.id,
+            kind: row.mint.kind,
+            type: row.mint.type,
+            createdAt: row.mint.createdAt,
+            components: [
+              ...declarationComponents({
                 kind: row.mint.kind,
                 type: row.mint.type,
                 bytes: row.bytes,
-              })],
-            });
-          }
-          const appended = yield* specimens.AppendActivity(pack.activity);
-          expect(appended.kind).toBe('activity');
-          expect(appended.type).toBe('hlr');
-          expect(relationTargets(appended.components, 'Used')).toEqual([CAD01_SOLID_REF]);
-          expect(relationTargets(appended.components, 'Generated')).toHaveLength(12);
-          const listed = yield* specimens.List();
-          expect(listed).toEqual([]);
-          const mintedSolid = yield* catalog.GetEntity({ entityId: CAD01_SOLID_REF });
-          expect(mintedSolid.type).toBe('assembly');
-          expect(mintedSolid.components.some((c) => c._tag === 'Honesty')).toBe(false);
-        }),
-      ).pipe(Effect.provide(MemoryCatalogLive)) as Effect.Effect<unknown>,
+              }),
+            ],
+          });
+        }
+        const exported = yield* specimens.AppendActivity(pack.exportActivity);
+        expect(exported.kind).toBe('activity');
+        expect(exported.type).toBe('export');
+        expect(relationTargets(exported.components, 'Generated')).toEqual([CAD01_SOLID_REF]);
+        const appended = yield* specimens.AppendActivity(pack.activity);
+        expect(appended.kind).toBe('activity');
+        expect(appended.type).toBe('hlr');
+        expect(relationTargets(appended.components, 'Used')).toEqual([CAD01_SOLID_REF]);
+        expect(relationTargets(appended.components, 'Generated')).toHaveLength(7);
+        const listed = yield* specimens.List();
+        expect(listed).toEqual([]);
+        const mintedSolid = yield* catalog.GetEntity({ entityId: CAD01_SOLID_REF });
+        expect(mintedSolid.type).toBe('assembly');
+        expect(mintedSolid.components.some((c) => c._tag === 'Honesty')).toBe(false);
+
+        yield* proveCad01Activities;
+
+        const minted = yield* catalog.MintEntity({
+          id: MINT_ACTIVITY_REF,
+          kind: 'activity',
+          type: 'note',
+          createdAt: CAD01_COMMITTED_AT,
+          components: [
+            ...activityComponents({ used: [], generated: [] }, 'note'),
+            new WhoComponent({ agentType: 'software', label: 'generate_schematics.py' }),
+            new WhenComponent({ startedAt: CAD01_COMMITTED_AT, gitSha: CAD01_TREE_SHA }),
+            new WhereComponent({ value: 'unknown' }),
+            new WhyComponent({ value: '#58' }),
+            new HowComponent({ value: 'generate_schematics.py' }),
+          ],
+        });
+        expect(minted.kind).toBe('activity');
+        expectW7(minted, {
+          who: 'generate_schematics.py',
+          why: '#58',
+          how: 'generate_schematics.py',
+        });
+
+        yield* specimens.AppendActivity(cad01Correction());
+        const history = yield* specimens.GetByRef({ ref: CAD01_PROJECT_REF });
+        expect(ids(history)).toEqual(
+          expect.arrayContaining([CAD01_PROJECT_REF, CAD01_CORRECTION_REF]),
+        );
+        const original = history.find((row) => row.id === CAD01_PROJECT_REF);
+        expect(relationTargets(original?.components ?? [], 'Generated')).toEqual([
+          ...CAD01_HLR_SHEET_REFS,
+        ]);
+        const dup = yield* Effect.result(specimens.AppendActivity(pack.activity));
+        expect(Result.isFailure(dup)).toBe(true);
+        if (Result.isFailure(dup)) {
+          expect(dup.failure._tag).toBe('ActivityAppendError');
+        }
+      }) as Effect.Effect<unknown, unknown, never>,
     );
   });
 });

--- a/packages/specimendb/test/cad01-seed.test.ts
+++ b/packages/specimendb/test/cad01-seed.test.ts
@@ -1,8 +1,3 @@
-/**
- * In-repo lab files as cheap entities (kind + type). HLR and STEP export are
- * gated activities. No specimen. No GPS/taxon/SKU. Honesty is not attached on mint.
- */
-
 import { existsSync, readFileSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Draft. Do not merge. Leftover of gbg#61. Activity is an entity. This is not EVA and not the catalog UI.

## Why

PR 96 already minted activities through `EntityMint`. W7 lived on the `LabEntity` input and then dropped. A view could not read who, when, where, why, or how from `GetEntity`. The CAD-01 STEP export was a solid row with no generating activity. HLR claimed S00-S11, including topology and diagram sheets.

This leftover keeps the same mint path. It attaches W7 as components. It seeds the STEP export as its own activity. HLR Generates S00-S06. A correction is a new ref.

## Scope

- `WhoComponent`, `WhenComponent`, `WhereComponent`, `WhyComponent`, `HowComponent` on `packages/specimendb/src/schemas/components.ts`. What stays `Used` + `Generated`.
- `0008_component_kinds` widens the Postgres CHECK.
- `appendActivity` still calls `state.mint`. `labEntityComponents` attaches W7 when it arrived.
- `GetByRef` walks `{ ref }` as before, plus `{ who }`, `{ why }`, `{ gitSha }`, `{ startedAt }`.
- `CAD01_EXPORT_REF` (`gbg:activity:export-cad01@60abe943`) Generates the assembly STEP. HLR Generates `CAD01_HLR_SHEET_REFS` (S00-S06 by local name).
- Tests mint CAD-01/HLR the same way as any entity, walk Used/Generated to the STEP and sheets, and append a superseding correction.

Out of this PR: `packages/specimendb/src/ui/**` (PR 97), `sql.ts` / EVA (#82), viewer, WASM, capture, `docker/`.

## Tradeoffs

W7 is five TaggedClass components, not Tag/Claim reuse. Query lists `kind=activity` and filters in the system. SQL/Arrow search is #82.

Cheap `type=note` / `type=worker` activities still mint without W7. They did not arrive with it.

## Blast Radius

Catalog readers that decode the `Component` union must accept the new tags. Existing `{ ref }` `GetByRef` callers stay valid. Seeded HLR Generated shrinks from twelve sheets to seven. S07-S11 remain declared sheets.

Safe as a draft on master. Do not merge until CI on Postgres 5434 is green.

## Verification

Local, this environment:

- `bun run typecheck:ci` in `packages/specimendb`. Pass.
- `bun run test:run` in `packages/specimendb`. 8 files, 64 tests, pass. Postgres 16 at `127.0.0.1:5432` with `SPECIMENDB_PG_*`. CI uses 5434.

Covered: `Catalog.MintEntity` for an activity with W7, `AppendActivity` for CAD-01 export and HLR, `GetByRef` walks Used/Generated/Who/Why/SHA/time, a superseding correction is a new ref, original Generated unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccf222d6-45eb-4eb6-91ae-36dfe0f6ada4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccf222d6-45eb-4eb6-91ae-36dfe0f6ada4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

