### PR TITLE
Add paper-mcp headless MCP to the Cursor cloud-agent environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,7 @@
 // Cursor Cloud: install puts the official Paper Desktop AppImage on PATH as `paper`.
 // Paper MCP is http://127.0.0.1:29979/mcp and needs a signed-in Desktop with a file open.
 // Sign-in is a one-time environment/snapshot step; this config does not fake a session.
+// The repo flake does not package Paper. Cursor cloud VMs do not ship nix; this does not apt-get around that.
 {
   "name": "gbg (Paper Desktop)",
   "install": "bash .cursor/scripts/install-paper.sh",

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,8 @@
+// Cursor Cloud: install puts the official Paper Desktop AppImage on PATH as `paper`.
+// Paper MCP is http://127.0.0.1:29979/mcp and needs a signed-in Desktop with a file open.
+// Sign-in is a one-time environment/snapshot step; this config does not fake a session.
+{
+  "name": "gbg (Paper Desktop)",
+  "install": "bash .cursor/scripts/install-paper.sh",
+  "start": "bash .cursor/scripts/start-paper.sh"
+}

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,9 +1,8 @@
-// Cursor Cloud: install puts the official Paper Desktop AppImage on PATH as `paper`.
-// Paper MCP is http://127.0.0.1:29979/mcp and needs a signed-in Desktop with a file open.
-// Sign-in is a one-time environment/snapshot step; this config does not fake a session.
-// The repo flake does not package Paper. Cursor cloud VMs do not ship nix; this does not apt-get around that.
+// Cursor Cloud: install puts paper-mcp on PATH. start launches headless MCP, not the headed board.
+// Paper MCP is http://127.0.0.1:29979/mcp. It has no cookie session and 401s without a bearer.
+// Agents need a Paper bearer (env/secret), not Desktop Google cookies. This config does not invent a token.
 {
-  "name": "gbg (Paper Desktop)",
+  "name": "gbg (paper-mcp)",
   "install": "bash .cursor/scripts/install-paper.sh",
   "start": "bash .cursor/scripts/start-paper.sh"
 }

--- a/.cursor/scripts/install-paper.sh
+++ b/.cursor/scripts/install-paper.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
-# Cursor Cloud: install puts the official Paper Desktop AppImage on PATH as `paper`.
-# Paper MCP is http://127.0.0.1:29979/mcp and needs a signed-in Desktop with a file open.
-# Sign-in is a one-time environment/snapshot step; this script does not fake a session.
+# Cursor Cloud: install puts the official Paper Desktop AppImage on PATH as `paper-mcp`.
+# Cloud agents use headless MCP (PAPER_HEADLESS_MCP=true), not the headed board window.
+# MCP is http://127.0.0.1:29979/mcp. It has no cookie session and 401s without a bearer.
+# Agents need a Paper bearer (env/secret). This script does not invent a token.
 #
 # This repo is a flake (`.envrc` → `use flake`, `nix/devshell.nix`). Paper Desktop
-# is not a flake output. The official Linux binary is the AppImage. Cursor cloud
-# VMs do not ship `nix`; do not apt-get around that. Xvfb and fonts are already
-# on the default Ubuntu image. Missing FUSE uses APPIMAGE_EXTRACT_AND_RUN on
-# this same AppImage.
+# is not a flake output. Cursor cloud VMs do not ship `nix`. Missing FUSE uses
+# APPIMAGE_EXTRACT_AND_RUN on this same AppImage.
 set -euo pipefail
 
 PAPER_URL="https://download.paper.design/linux/appImage"
@@ -15,25 +14,23 @@ MIN_BYTES=10485760
 
 if sudo -n true >/dev/null 2>&1; then
   PAPER_LIB=/usr/local/lib/paper
-  PAPER_BIN=/usr/local/bin/paper
+  PAPER_BIN_DIR=/usr/local/bin
   as_root() { sudo "$@"; }
 else
   PAPER_LIB="${HOME}/.local/lib/paper"
-  PAPER_BIN="${HOME}/.local/bin/paper"
+  PAPER_BIN_DIR="${HOME}/.local/bin"
   as_root() { "$@"; }
-  mkdir -p "${HOME}/.local/bin"
+  mkdir -p "${PAPER_BIN_DIR}"
 fi
 
 PAPER_APPIMAGE="${PAPER_LIB}/Paper.AppImage"
+PAPER_MCP_BIN="${PAPER_BIN_DIR}/paper-mcp"
+PAPER_BIN="${PAPER_BIN_DIR}/paper"
 
 if command -v nix >/dev/null 2>&1; then
-  echo "install-paper: nix is on PATH; leave fuse/xvfb/fonts to the flake or host"
+  echo "install-paper: nix is on PATH; leave fuse to the flake or host"
 else
   echo "install-paper: no nix on this VM (repo flake is unused here)"
-fi
-
-if ! command -v Xvfb >/dev/null 2>&1; then
-  echo "install-paper: Xvfb is not on PATH; start will log and continue" >&2
 fi
 
 as_root mkdir -p "${PAPER_LIB}"
@@ -63,20 +60,27 @@ if [[ "${need_download}" -eq 1 ]]; then
   as_root chmod 755 "${PAPER_APPIMAGE}"
 fi
 
-# Wrapper, not a symlink: the AppImage file stays the install. Extra args pass through.
-# If FUSE is missing or unusable, extract-and-run still execs this same AppImage.
-as_root tee "${PAPER_BIN}" >/dev/null <<EOF
+# paper-mcp is the cloud launcher: headless MCP, no board window, no open-file requirement.
+as_root tee "${PAPER_MCP_BIN}" >/dev/null <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 APPIMAGE="${PAPER_APPIMAGE}"
-export APPIMAGE_EXTRACT_AND_RUN="\${APPIMAGE_EXTRACT_AND_RUN:-1}"
-exec "\${APPIMAGE}" --no-sandbox --disable-gpu "\$@"
+export PAPER_HEADLESS_MCP=true
+# AppImage FUSE needs libfuse.so.2. /dev/fuse or fusermount3 alone is not enough.
+if [[ ! -c /dev/fuse ]] || ! grep -q 'libfuse.so.2' <<<"\$(ldconfig -p 2>/dev/null)"; then
+  export APPIMAGE_EXTRACT_AND_RUN=1
+fi
+exec "\${APPIMAGE}" --no-sandbox --disable-gpu --headless "\$@"
 EOF
-as_root chmod 755 "${PAPER_BIN}"
+as_root chmod 755 "${PAPER_MCP_BIN}"
 
-if ! command -v paper >/dev/null 2>&1; then
-  echo "install-paper: ${PAPER_BIN} is not on PATH" >&2
+# Keep `paper` as an alias to the same headless MCP launcher so PATH is unambiguous.
+as_root rm -f "${PAPER_BIN}"
+as_root ln -sfn "${PAPER_MCP_BIN}" "${PAPER_BIN}"
+
+if ! command -v paper-mcp >/dev/null 2>&1; then
+  echo "install-paper: ${PAPER_MCP_BIN} is not on PATH" >&2
   exit 1
 fi
 
-echo "install-paper: paper -> ${PAPER_BIN} (AppImage ${PAPER_APPIMAGE})"
+echo "install-paper: paper-mcp -> ${PAPER_MCP_BIN} (AppImage ${PAPER_APPIMAGE})"

--- a/.cursor/scripts/install-paper.sh
+++ b/.cursor/scripts/install-paper.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Cursor Cloud: install puts the official Paper Desktop AppImage on PATH as `paper`.
+# Paper MCP is http://127.0.0.1:29979/mcp and needs a signed-in Desktop with a file open.
+# Sign-in is a one-time environment/snapshot step; this script does not fake a session.
+set -euo pipefail
+
+PAPER_URL="https://download.paper.design/linux/appImage"
+MIN_BYTES=10485760
+
+if sudo -n true >/dev/null 2>&1; then
+  PAPER_LIB=/usr/local/lib/paper
+  PAPER_BIN=/usr/local/bin/paper
+  as_root() { sudo "$@"; }
+else
+  PAPER_LIB="${HOME}/.local/lib/paper"
+  PAPER_BIN="${HOME}/.local/bin/paper"
+  as_root() { "$@"; }
+  mkdir -p "${HOME}/.local/bin"
+fi
+
+PAPER_APPIMAGE="${PAPER_LIB}/Paper.AppImage"
+
+pkg_installed() {
+  dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -q 'install ok installed'
+}
+
+ensure_pkg() {
+  local pkg="$1"
+  if pkg_installed "$pkg"; then
+    return 0
+  fi
+  as_root apt-get update -qq
+  as_root apt-get install -y --no-install-recommends "$pkg"
+}
+
+ensure_one_pkg() {
+  local pkg
+  for pkg in "$@"; do
+    if pkg_installed "$pkg"; then
+      return 0
+    fi
+  done
+  as_root apt-get update -qq
+  for pkg in "$@"; do
+    if as_root apt-get install -y --no-install-recommends "$pkg"; then
+      return 0
+    fi
+  done
+  echo "install-paper: none of $* could be installed; AppImage extract-and-run remains the fallback" >&2
+  return 0
+}
+
+# AppImage runtime wants FUSE 2. Ubuntu 24.04 ships libfuse2t64. fuse3 is a last resort.
+export DEBIAN_FRONTEND=noninteractive
+ensure_one_pkg libfuse2t64 libfuse2 fuse3
+ensure_pkg xvfb
+ensure_one_pkg fonts-liberation fonts-dejavu-core fonts-noto-core
+
+as_root mkdir -p "${PAPER_LIB}"
+
+need_download=1
+if [[ -x "${PAPER_APPIMAGE}" ]]; then
+  size="$(wc -c < "${PAPER_APPIMAGE}")"
+  magic="$(head -c 4 "${PAPER_APPIMAGE}" || true)"
+  if [[ "${size}" -ge "${MIN_BYTES}" && "${magic}" == $'\x7fELF' ]]; then
+    need_download=0
+  fi
+fi
+
+if [[ "${need_download}" -eq 1 ]]; then
+  tmp="$(mktemp "${TMPDIR:-/tmp}/Paper.AppImage.XXXXXX")"
+  cleanup() { rm -f "${tmp}"; }
+  trap cleanup EXIT
+  curl -fL --retry 4 --retry-delay 4 --retry-all-errors -o "${tmp}" "${PAPER_URL}"
+  size="$(wc -c < "${tmp}")"
+  magic="$(head -c 4 "${tmp}" || true)"
+  if [[ "${size}" -lt "${MIN_BYTES}" || "${magic}" != $'\x7fELF' ]]; then
+    echo "install-paper: download is not a usable AppImage (${size} bytes)" >&2
+    exit 1
+  fi
+  as_root mv "${tmp}" "${PAPER_APPIMAGE}"
+  trap - EXIT
+  as_root chmod 755 "${PAPER_APPIMAGE}"
+fi
+
+# Wrapper, not a symlink: the AppImage file stays the install. Extra args pass through.
+# If FUSE is missing or unusable, extract-and-run still execs this same AppImage.
+as_root tee "${PAPER_BIN}" >/dev/null <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+APPIMAGE="${PAPER_APPIMAGE}"
+export APPIMAGE_EXTRACT_AND_RUN="\${APPIMAGE_EXTRACT_AND_RUN:-1}"
+exec "\${APPIMAGE}" --no-sandbox --disable-gpu "\$@"
+EOF
+as_root chmod 755 "${PAPER_BIN}"
+
+if ! command -v paper >/dev/null 2>&1; then
+  echo "install-paper: ${PAPER_BIN} is not on PATH" >&2
+  exit 1
+fi
+
+echo "install-paper: paper -> ${PAPER_BIN} (AppImage ${PAPER_APPIMAGE})"

--- a/.cursor/scripts/install-paper.sh
+++ b/.cursor/scripts/install-paper.sh
@@ -2,6 +2,12 @@
 # Cursor Cloud: install puts the official Paper Desktop AppImage on PATH as `paper`.
 # Paper MCP is http://127.0.0.1:29979/mcp and needs a signed-in Desktop with a file open.
 # Sign-in is a one-time environment/snapshot step; this script does not fake a session.
+#
+# This repo is a flake (`.envrc` → `use flake`, `nix/devshell.nix`). Paper Desktop
+# is not a flake output. The official Linux binary is the AppImage. Cursor cloud
+# VMs do not ship `nix`; do not apt-get around that. Xvfb and fonts are already
+# on the default Ubuntu image. Missing FUSE uses APPIMAGE_EXTRACT_AND_RUN on
+# this same AppImage.
 set -euo pipefail
 
 PAPER_URL="https://download.paper.design/linux/appImage"
@@ -20,41 +26,15 @@ fi
 
 PAPER_APPIMAGE="${PAPER_LIB}/Paper.AppImage"
 
-pkg_installed() {
-  dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -q 'install ok installed'
-}
+if command -v nix >/dev/null 2>&1; then
+  echo "install-paper: nix is on PATH; leave fuse/xvfb/fonts to the flake or host"
+else
+  echo "install-paper: no nix on this VM (repo flake is unused here)"
+fi
 
-ensure_pkg() {
-  local pkg="$1"
-  if pkg_installed "$pkg"; then
-    return 0
-  fi
-  as_root apt-get update -qq
-  as_root apt-get install -y --no-install-recommends "$pkg"
-}
-
-ensure_one_pkg() {
-  local pkg
-  for pkg in "$@"; do
-    if pkg_installed "$pkg"; then
-      return 0
-    fi
-  done
-  as_root apt-get update -qq
-  for pkg in "$@"; do
-    if as_root apt-get install -y --no-install-recommends "$pkg"; then
-      return 0
-    fi
-  done
-  echo "install-paper: none of $* could be installed; AppImage extract-and-run remains the fallback" >&2
-  return 0
-}
-
-# AppImage runtime wants FUSE 2. Ubuntu 24.04 ships libfuse2t64. fuse3 is a last resort.
-export DEBIAN_FRONTEND=noninteractive
-ensure_one_pkg libfuse2t64 libfuse2 fuse3
-ensure_pkg xvfb
-ensure_one_pkg fonts-liberation fonts-dejavu-core fonts-noto-core
+if ! command -v Xvfb >/dev/null 2>&1; then
+  echo "install-paper: Xvfb is not on PATH; start will log and continue" >&2
+fi
 
 as_root mkdir -p "${PAPER_LIB}"
 

--- a/.cursor/scripts/start-paper.sh
+++ b/.cursor/scripts/start-paper.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Cursor Cloud: start Xvfb if DISPLAY is unset, then start Paper so MCP can listen.
+# Paper MCP is http://127.0.0.1:29979/mcp. A missing session is logged; this does not fail the agent.
+# Sign-in is a one-time environment/snapshot step; this script does not fake a session.
+set -u
+
+LOG="${PAPER_LOG:-/tmp/paper-desktop.log}"
+MCP_URL="http://127.0.0.1:29979/mcp"
+export PATH="/usr/local/bin:${HOME}/.local/bin:${PATH}"
+
+mcp_up() {
+  curl -sf --max-time 2 "${MCP_URL}" >/dev/null 2>&1
+}
+
+if mcp_up; then
+  echo "start-paper: MCP already listening at ${MCP_URL}"
+  exit 0
+fi
+
+if [[ -z "${DISPLAY:-}" ]]; then
+  export DISPLAY=:99
+  if ! pgrep -x Xvfb >/dev/null 2>&1; then
+    if ! command -v Xvfb >/dev/null 2>&1; then
+      echo "start-paper: Xvfb is not installed; Paper not started" | tee -a "${LOG}"
+      exit 0
+    fi
+    Xvfb :99 -screen 0 1920x1080x24 >/tmp/xvfb-paper.log 2>&1 &
+    sleep 0.5
+  fi
+fi
+
+if ! command -v paper >/dev/null 2>&1; then
+  echo "start-paper: paper is not on PATH; skip" | tee -a "${LOG}"
+  exit 0
+fi
+
+if pgrep -f 'Paper.AppImage' >/dev/null 2>&1; then
+  echo "start-paper: Paper.AppImage already running"
+  exit 0
+fi
+
+nohup paper >>"${LOG}" 2>&1 &
+paper_pid=$!
+disown "${paper_pid}" 2>/dev/null || true
+echo "start-paper: launched paper pid ${paper_pid} (DISPLAY=${DISPLAY}) log ${LOG}"
+
+i=0
+while [[ "${i}" -lt 5 ]]; do
+  if mcp_up; then
+    echo "start-paper: MCP listening at ${MCP_URL}"
+    exit 0
+  fi
+  if ! kill -0 "${paper_pid}" 2>/dev/null; then
+    echo "start-paper: Paper exited before MCP listened; see ${LOG}" | tee -a "${LOG}"
+    exit 0
+  fi
+  i=$((i + 1))
+  sleep 1
+done
+
+echo "start-paper: Paper is up but MCP is not answering yet at ${MCP_URL} (needs a signed-in Desktop with a file open)"
+exit 0

--- a/.cursor/scripts/start-paper.sh
+++ b/.cursor/scripts/start-paper.sh
@@ -8,11 +8,14 @@ LOG="${PAPER_LOG:-/tmp/paper-desktop.log}"
 MCP_URL="http://127.0.0.1:29979/mcp"
 export PATH="/usr/local/bin:${HOME}/.local/bin:${PATH}"
 
-mcp_up() {
-  curl -sf --max-time 2 "${MCP_URL}" >/dev/null 2>&1
+mcp_listening() {
+  # GET is often 404. Any HTTP status means the port is bound.
+  local code
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 2 "${MCP_URL}" 2>/dev/null || true)"
+  [[ "${code}" =~ ^[1-5][0-9][0-9]$ ]]
 }
 
-if mcp_up; then
+if mcp_listening; then
   echo "start-paper: MCP already listening at ${MCP_URL}"
   exit 0
 fi
@@ -34,7 +37,7 @@ if ! command -v paper >/dev/null 2>&1; then
   exit 0
 fi
 
-if pgrep -f 'Paper.AppImage' >/dev/null 2>&1; then
+if pgrep -x Paper.AppImage >/dev/null 2>&1; then
   echo "start-paper: Paper.AppImage already running"
   exit 0
 fi
@@ -45,9 +48,9 @@ disown "${paper_pid}" 2>/dev/null || true
 echo "start-paper: launched paper pid ${paper_pid} (DISPLAY=${DISPLAY}) log ${LOG}"
 
 i=0
-while [[ "${i}" -lt 5 ]]; do
-  if mcp_up; then
-    echo "start-paper: MCP listening at ${MCP_URL}"
+while [[ "${i}" -lt 30 ]]; do
+  if mcp_listening; then
+    echo "start-paper: MCP listening at ${MCP_URL} (sign-in and a file open are still required for a usable session)"
     exit 0
   fi
   if ! kill -0 "${paper_pid}" 2>/dev/null; then
@@ -58,5 +61,5 @@ while [[ "${i}" -lt 5 ]]; do
   sleep 1
 done
 
-echo "start-paper: Paper is up but MCP is not answering yet at ${MCP_URL} (needs a signed-in Desktop with a file open)"
+echo "start-paper: Paper is up but MCP is not listening yet at ${MCP_URL} (needs a signed-in Desktop with a file open); see ${LOG}"
 exit 0

--- a/.cursor/scripts/start-paper.sh
+++ b/.cursor/scripts/start-paper.sh
@@ -1,39 +1,28 @@
 #!/usr/bin/env bash
-# Cursor Cloud: start Xvfb if DISPLAY is unset, then start Paper so MCP can listen.
-# Paper MCP is http://127.0.0.1:29979/mcp. A missing session is logged; this does not fail the agent.
-# Sign-in is a one-time environment/snapshot step; this script does not fake a session.
+# Cursor Cloud: start paper-mcp (headless MCP). No board window. No open file.
+# MCP is http://127.0.0.1:29979/mcp. It has no cookie session and 401s without a bearer.
+# Agents need a Paper bearer (env/secret), not Desktop Google cookies. This does not invent a token.
+# If Paper exits, the failure is logged and the agent continues.
 set -u
 
-LOG="${PAPER_LOG:-/tmp/paper-desktop.log}"
+LOG="${PAPER_LOG:-/tmp/paper-mcp.log}"
 MCP_URL="http://127.0.0.1:29979/mcp"
 export PATH="/usr/local/bin:${HOME}/.local/bin:${PATH}"
 
 mcp_listening() {
-  # GET is often 404. Any HTTP status means the port is bound.
+  # GET may be 401 (no bearer) or 404. Any HTTP status means the port is bound.
   local code
   code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 2 "${MCP_URL}" 2>/dev/null || true)"
   [[ "${code}" =~ ^[1-5][0-9][0-9]$ ]]
 }
 
 if mcp_listening; then
-  echo "start-paper: MCP already listening at ${MCP_URL}"
+  echo "start-paper: headless MCP already listening at ${MCP_URL}"
   exit 0
 fi
 
-if [[ -z "${DISPLAY:-}" ]]; then
-  export DISPLAY=:99
-  if ! pgrep -x Xvfb >/dev/null 2>&1; then
-    if ! command -v Xvfb >/dev/null 2>&1; then
-      echo "start-paper: Xvfb is not installed; Paper not started" | tee -a "${LOG}"
-      exit 0
-    fi
-    Xvfb :99 -screen 0 1920x1080x24 >/tmp/xvfb-paper.log 2>&1 &
-    sleep 0.5
-  fi
-fi
-
-if ! command -v paper >/dev/null 2>&1; then
-  echo "start-paper: paper is not on PATH; skip" | tee -a "${LOG}"
+if ! command -v paper-mcp >/dev/null 2>&1; then
+  echo "start-paper: paper-mcp is not on PATH; skip" | tee -a "${LOG}"
   exit 0
 fi
 
@@ -42,24 +31,24 @@ if pgrep -x Paper.AppImage >/dev/null 2>&1; then
   exit 0
 fi
 
-nohup paper >>"${LOG}" 2>&1 &
+nohup paper-mcp >>"${LOG}" 2>&1 &
 paper_pid=$!
 disown "${paper_pid}" 2>/dev/null || true
-echo "start-paper: launched paper pid ${paper_pid} (DISPLAY=${DISPLAY}) log ${LOG}"
+echo "start-paper: launched paper-mcp pid ${paper_pid} log ${LOG}"
 
 i=0
-while [[ "${i}" -lt 30 ]]; do
+while [[ "${i}" -lt 60 ]]; do
   if mcp_listening; then
-    echo "start-paper: MCP listening at ${MCP_URL} (sign-in and a file open are still required for a usable session)"
+    echo "start-paper: headless MCP listening at ${MCP_URL} (401 without a Paper bearer is expected; not Desktop cookies)"
     exit 0
   fi
   if ! kill -0 "${paper_pid}" 2>/dev/null; then
-    echo "start-paper: Paper exited before MCP listened; see ${LOG}" | tee -a "${LOG}"
+    echo "start-paper: paper-mcp exited before MCP listened; see ${LOG}" | tee -a "${LOG}"
     exit 0
   fi
   i=$((i + 1))
   sleep 1
 done
 
-echo "start-paper: Paper is up but MCP is not listening yet at ${MCP_URL} (needs a signed-in Desktop with a file open); see ${LOG}"
+echo "start-paper: paper-mcp is up but MCP is not listening yet at ${MCP_URL}; see ${LOG}"
 exit 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cloud agents on this repo use paper-mcp. That is Paper headless MCP, not the headed board window.

`.cursor/environment.json` `install` downloads the official Linux AppImage and puts `paper-mcp` on PATH. The launcher sets `PAPER_HEADLESS_MCP=true`, sets `APPIMAGE_EXTRACT_AND_RUN=1` when libfuse.so.2 is missing, and execs the AppImage with `--no-sandbox --disable-gpu --headless`. `start` runs `paper-mcp`. It does not start a visible window and it does not require an open file.

Headless MCP speaks HTTP at http://127.0.0.1:29979/mcp. It has no cookie session. Without a bearer it returns 401. Agents need a Paper bearer in the environment secrets. Desktop Google cookies do not apply. This PR does not invent a token.

On this VM, `paper-mcp` is on PATH. Start brought the process up as `Paper.AppImage --no-sandbox --disable-gpu --headless`. A GET to `/mcp` returned 401 `Missing bearer token`. That is the missing secret, not a missing binary.

Hold merge until a Paper bearer is in the environment and MCP answers with it.

Draft PR 103 also adds `.cursor/environment.json` (bun + Nx). If that lands first, rebase and keep both install steps.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36f52e46-8289-4c93-b7ea-283ac14c80ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36f52e46-8289-4c93-b7ea-283ac14c80ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

