### PR TITLE
docs(terrarium): record 2026-08-23 authoring packet and parts quest

### DIFF
--- a/projects/biomemetics/labs/mantis/terrarium/docs/2026-08-23-authoring-packet-parts-quest.md
+++ b/projects/biomemetics/labs/mantis/terrarium/docs/2026-08-23-authoring-packet-parts-quest.md
@@ -1,0 +1,37 @@
+# 2026-08-23 authoring, packet, and parts quest
+
+This note records the 23 August 2026 lab latents for the terrarium CAD and EE packet and the open parts quest. It sits next to `metaprompts/` in the existing `terrarium/docs` folder. Leftover S00 through S11 and CAD-01 stay Used extract. Their titles are not this cut.
+
+The work sits under the [gbg#15](https://github.com/creatifcoding/gbg/issues/15) workspace epic. MCAD coordination remains [gbg#17](https://github.com/creatifcoding/gbg/issues/17). EE coordination remains [gbg#18](https://github.com/creatifcoding/gbg/issues/18). Shop-release remains [gbg#31](https://github.com/creatifcoding/gbg/issues/31) and comes later. The live CAD and EE packet is [PR 112](https://github.com/creatifcoding/gbg/pull/112).
+
+## Authoring
+
+Authoring is TypeScript. JSCAD lives at `terrarium/cad/jscad`. tscircuit is at `terrarium/ee/tscircuit`. A `mantis/authoring` tree was rejected. Leftover FreeCAD, OCCT, and KiCad stay emit.
+
+## Skills
+
+Proctors write skills. Writers only run them. Fleet skills for this cut are `jscad-solids` and `mantis-tscircuit`. The official `tscircuit/skill` is extract.
+
+## Composite packet
+
+The CAD and EE packet is one composite entity. Sheets S00 through S11 and CAD-01 remain Used extract. New media comes only from a system that wrote a file.
+
+## CAD now
+
+CAD now is a 250 mm by 250 mm by 500 mm envelope, a bbox, and tests. Render uses `extrusions.project` plus `@jscad/svg-serializer`. That serializer writes front, side, and top SVG. PNG and isometric views are deferred. There is no STL written just to have a file. There is no cuboid shop drawing. S01 stays extract.
+
+## EE now
+
+EE now lives on PR 112 under `packet/`. That directory holds Circuit JSON, schematic SVG, PCB SVG, a 3D snap, glTF, GLB, a netlist, and check stdout. S1, S2, and Q1 have no pin traces. B44 pin2 is `NOT_CONNECTED`. B19 is omitted. MPNs are blank. There is no Gerber.
+
+## Parts quest
+
+The parts quest is open. DigiKey and Octopart were a start, not a limit. Hits land in one procurement PGlite book. sqlite is not that book. A balloon is not a buy. Do not invent manufacturer part numbers. `UNVERIFIED` cannot become an order.
+
+## Print and shop
+
+CAD can do whatever it needs. A local person has Bambu printers. Develop in-house FDM requirements. Do not invent a printer model. Shop outreach is Tuesday 2026-08-25. The packet shown to shops stays DRAFT. Shop-release is [gbg#31](https://github.com/creatifcoding/gbg/issues/31), later.
+
+## Hold merge
+
+Hold merge on [PR 112](https://github.com/creatifcoding/gbg/pull/112) and [PR 108](https://github.com/creatifcoding/gbg/pull/108). No orders.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The 23 August 2026 lab latents belong in the existing `terrarium/docs` folder, next to `metaprompts/`. Authoring, the CAD/EE packet, and the open parts quest need one dated note so leftover sheet titles cannot pretend they are this cut.

## Scope

Adds `projects/biomemetics/labs/mantis/terrarium/docs/2026-08-23-authoring-packet-parts-quest.md`.

The note records that authoring is TypeScript at `terrarium/cad/jscad` and `terrarium/ee/tscircuit`, that `mantis/authoring` was rejected, and that leftover FreeCAD, OCCT, and KiCad stay emit. Proctors write skills. Writers only run them. Fleet skills are `jscad-solids` and `mantis-tscircuit`. Official `tscircuit/skill` is extract.

The CAD and EE packet is one composite entity on [PR 112](https://github.com/creatifcoding/gbg/pull/112). Leftover S00 through S11 and CAD-01 stay Used extract. CAD now is a 250 mm by 250 mm by 500 mm envelope, a bbox, tests, and front/side/top SVG from `extrusions.project` plus `@jscad/svg-serializer`. EE now is Circuit JSON, schematic SVG, PCB SVG, a 3D snap, glTF, GLB, a netlist, and check stdout under `packet/`. S1, S2, and Q1 have no pin traces. B44 pin2 is `NOT_CONNECTED`. B19 is omitted. MPNs are blank. There is no Gerber.

The parts quest stays open in one procurement PGlite book. sqlite is not that book. A balloon is not a buy. `UNVERIFIED` cannot become an order. Shop outreach is Tuesday 2026-08-25. The packet shown to shops stays DRAFT. Shop-release is [gbg#31](https://github.com/creatifcoding/gbg/issues/31), later.

Does not edit `PARAMS.md`, `BOM.md`, `cad/jscad`, or `ee/tscircuit`. Does not create `authoring/`. Does not invent a new tree or package name.

## Blast radius

Readers of `terrarium/docs`. No code, contracts, or generated packet files change. Merge stays held on this PR, on [PR 112](https://github.com/creatifcoding/gbg/pull/112), and on [PR 108](https://github.com/creatifcoding/gbg/pull/108). No orders.

## Verification

Confirmed the note exists under `terrarium/docs`, next to `metaprompts/`. Read the file and checked the eight required facts plus links to [gbg#15](https://github.com/creatifcoding/gbg/issues/15), [gbg#17](https://github.com/creatifcoding/gbg/issues/17), [gbg#18](https://github.com/creatifcoding/gbg/issues/18), [gbg#31](https://github.com/creatifcoding/gbg/issues/31), and [PR 112](https://github.com/creatifcoding/gbg/pull/112). Leftover sheet titles are not this-cut headings. `git diff --stat` shows that one markdown file only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47b29222-bbc2-4736-92f5-cc184c2385ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47b29222-bbc2-4736-92f5-cc184c2385ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

