### PR TITLE
docs(terrarium): leftover BOM balloon hunt notes (UNVERIFIED)

### DIFF
--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B09.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B09.md
@@ -20,6 +20,8 @@ Printed-REF is not a skip. This is a catalog hunt, not a print-file MPN.
 
 McMaster compression-latch index pages did not print a single SKU in the bodies I got.
 
+This pass re-opened https://southco.com/en_us_int/c2-32-15 and got a JS error shell ("Please enable JavaScript"). That open is not a new hit. The prior open that printed C2-32-15 still stands as the candidate record.
+
 ## Candidate vs rejected
 
 Candidate: Southco C2-32-15. Live page prints the SKU and that it is a lever compression latch. Acrylic door is 3.00 mm LOCK, which sits inside the printed 1-5 mm panel range. Latch count in BOM is 2. I am not locking geometry, screw pattern, or nymph-gap interaction.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B09.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B09.md
@@ -1,0 +1,31 @@
+# B09 hunt
+
+- balloon_id: B09
+- BOM: independent mechanical door latch. LOCK count / REF design.
+- Class: UNVERIFIED
+- verdict: catalog candidate Southco C2-32-15. Fit to the printed door is REF.
+
+Printed-REF is not a skip. This is a catalog hunt, not a print-file MPN.
+
+## Queries actually run
+
+1. McMaster Carr nylon door latch Southco C2 compression latch catalog
+2. Southco C2-32-15 compression latch product specifications panel grip
+
+## Sources opened
+
+| source | URL | what printed |
+| --- | --- | --- |
+| Southco C2-32-15 | https://southco.com/en_us_int/c2-32-15 | SKU C2-32-15. Compression Latch, Lever Latch, No Restriction, Raised Trigger, 1-5mm Panel, 1-24mm Grip, Not Sealed, Zinc Alloy, Powder Coat, Black. Min/Max outer panel 0.00 / 5.00 mm. Grip 1.00 / 24.00 mm. Class C2 - Lever Latches. Distributor stock table printed with dates. No unit price on that page. |
+
+McMaster compression-latch index pages did not print a single SKU in the bodies I got.
+
+## Candidate vs rejected
+
+Candidate: Southco C2-32-15. Live page prints the SKU and that it is a lever compression latch. Acrylic door is 3.00 mm LOCK, which sits inside the printed 1-5 mm panel range. Latch count in BOM is 2. I am not locking geometry, screw pattern, or nymph-gap interaction.
+
+Not a latch for B39 magnets. B09 stays a mechanical latch.
+
+## What stays UNVERIFIED
+
+Door cutout, keeper, whether zinc-alloy hardware is acceptable next to husbandry volume, and the REF labyrinth (B07). Design stays REF.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B11.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B11.md
@@ -1,0 +1,29 @@
+# B11 retry
+
+- balloon_id: B11
+- BOM: <=0.8 mm plastic/fiberglass/polyester screen. LOCK constraint.
+- Class: UNVERIFIED
+- prior STOP: no printed aperture. Retry only if a non-walled page prints a real SKU and a printed aperture ≤0.8 mm. Do not calculate from mesh count.
+
+## Queries actually run
+
+1. polyester insect screen 0.8 mm aperture opening size product specification mm
+2. Direct open of AHH 0.8 mm polyester mosquito netting
+
+## Sources opened
+
+| source | URL | what printed |
+| --- | --- | --- |
+| AHH | https://www.ahh.biz/mesh/mesh_mosquito_netting_0_8_mm.php | Product name "0.8 mm Polyester Mosquito Netting". SKU black F03A-PONO-MOSQ-M008-BK, white F03A-PONO-MOSQ-M008-WT. Price $5.15 per Yard (90 cm) before quantity discounts. Spec table on that page does not print a numbered aperture/opening. |
+| JF Screen Mesh | https://jfmaterial.com/pet-screen-mesh/pet-fly-screen-26-mesh/ | "Mesh Opening (Aperture) 0.83mm". That is not ≤0.80 mm. Rejected. |
+| GoldSupplier factory listing | https://www.goldsupplier.com/provide/p173731165.html | "Hole Diameter 0.8 mm". Marketplace factory card, not a distributor SKU I would queue as a buy. |
+
+## Candidate vs rejected
+
+Weak candidate name only: AHH F03A-PONO-MOSQ-M008-BK. The page prints "0.8 mm" in the product name. It does not print an aperture table. I am not treating the name as a measured opening.
+
+Rejected: JF 0.83 mm aperture (above LOCK 0.80 mm). Rejected: calculating opening from mesh count.
+
+## What stays UNVERIFIED
+
+Printed aperture ≤0.80 mm on a selected SKU. Material next to the animal volume. B11 stays UNVERIFIED STOP on aperture.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B19.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B19.md
@@ -1,0 +1,35 @@
+# B19 hunt
+
+- balloon_id: B19
+- BOM: P01-P08 continuous electrode flex plus V-dock pads. UNVERIFIED stack-up.
+- Class: UNVERIFIED
+- verdict: miss. STOP on pads, stack, layer count, copper weight.
+
+## Queries actually run
+
+1. gold finger flex circuit sliding contact electrode strip catalog DigiKey
+2. Molex Premo-Flex gold plated FFC jumper 8 circuit product page
+3. Molex Premo-Flex FFC/FPC family page
+
+## Sources opened
+
+| source | URL | what I got |
+| --- | --- | --- |
+| Molex Premo-Flex family (search hit / curl) | https://www.molex.com/en-us/products/cable-assemblies/flat-flexible-cables-ffc | Search returned FFC/FPC jumper copy, including 90-Ohm USB and 100-Ohm HDMI on the high-speed LVDS line. Direct curl of that host failed HTTP/2. I did not get a DETAIL body for an electrode strip or V-dock pads. |
+| Molex 150210215 DETAIL | https://www.molex.com/en-us/products/part-detail/150210215 | Fetch timed out. Not a hit. |
+
+I did not fetch third-party PDF mirrors. I am not quoting those MPNs.
+
+## Candidate vs rejected
+
+No catalog electrode / V-dock pad SKU from a page body I actually received.
+
+Premo-Flex, as described in the family search hit, is a board-to-board FFC jumper line. That is not P01-P08 electrode geometry and not V-dock pads.
+
+Custom gold-finger flex houses describe a process, not an orderable electrode SKU for this rail.
+
+I did not invent pads, a stack, layer count, or copper weight.
+
+## What stays UNVERIFIED
+
+The B19 flex is still a custom electrode plus V-dock. Stack-up, pad geometry, copper weight, and how P09-P12 sit on that flex stay UNVERIFIED.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B19.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B19.md
@@ -3,33 +3,43 @@
 - balloon_id: B19
 - BOM: P01-P08 continuous electrode flex plus V-dock pads. UNVERIFIED stack-up.
 - Class: UNVERIFIED
-- verdict: miss. STOP on pads, stack, layer count, copper weight.
+- verdict: already queued to procurementbot. Do not re-land as a new SKU. Assembly and stack stay UNVERIFIED.
+
+## Already queued. Do not re-land
+
+Record only:
+
+- Assembly and stack UNVERIFIED.
+- Candidate 319-10-108-00-001000 (8-pos Mill-Max target).
+- Pyralux AP materials only. No stack.
+
+This run did not select a new electrode SKU, a copper weight, a layer count, or a pad geometry.
 
 ## Queries actually run
 
 1. gold finger flex circuit sliding contact electrode strip catalog DigiKey
 2. Molex Premo-Flex gold plated FFC jumper 8 circuit product page
-3. Molex Premo-Flex FFC/FPC family page
+3. Mill-Max 319-10-108-00-001000 8 position target connector
+4. DuPont Pyralux AP all-polyimide copper-clad laminate
 
 ## Sources opened
 
-| source | URL | what I got |
+| source | URL | what printed |
 | --- | --- | --- |
-| Molex Premo-Flex family (search hit / curl) | https://www.molex.com/en-us/products/cable-assemblies/flat-flexible-cables-ffc | Search returned FFC/FPC jumper copy, including 90-Ohm USB and 100-Ohm HDMI on the high-speed LVDS line. Direct curl of that host failed HTTP/2. I did not get a DETAIL body for an electrode strip or V-dock pads. |
+| Morris HK | https://www.morrishk.net/products/01111856/319-10-108-00-001000.html | Manufacturer part 319-10-108-00-001000. Description CONN SPRING TARGET 8POS PCB. Connector Type Mating Target. Number of Contacts 8. Pitch 0.100" (2.54mm). Through hole. That page is a distributor card, not a checkout quote. |
+| DuPont Pyralux AP | https://www.dupont.com/electronics-industrial/pyralux-ap.html | Pyralux AP all-polyimide double-sided copper-clad laminate. Adhesiveless all-polyimide dielectric. Table lists AP8515R, AP9111R, AP9121R, AP9131R, AP9141R, AP9151R, AP9161R with copper and dielectric thicknesses. I did not pick a row as a stack. |
+| Molex Premo-Flex family | https://www.molex.com/en-us/products/cable-assemblies/flat-flexible-cables-ffc | Family FFC jumpers. Not P01-P08 electrode geometry. Not V-dock pads. |
 | Molex 150210215 DETAIL | https://www.molex.com/en-us/products/part-detail/150210215 | Fetch timed out. Not a hit. |
-
-I did not fetch third-party PDF mirrors. I am not quoting those MPNs.
+| mill-max.com /319 | https://www.mill-max.com/products/pin/319 | HTTP 404. Not a hit. |
 
 ## Candidate vs rejected
 
-No catalog electrode / V-dock pad SKU from a page body I actually received.
+Already-queued candidate: Mill-Max 319-10-108-00-001000. The Morris page I opened prints that MPN, Mating Target, and 8 contacts. It is a target for spring pins, not the flex itself.
 
-Premo-Flex, as described in the family search hit, is a board-to-board FFC jumper line. That is not P01-P08 electrode geometry and not V-dock pads.
+Pyralux AP is the material family only. The DuPont page prints several AP*R constructions. No stack is selected. I did not concatenate a dielectric thickness to a copper weight and call it B19.
 
-Custom gold-finger flex houses describe a process, not an orderable electrode SKU for this rail.
-
-I did not invent pads, a stack, layer count, or copper weight.
+Rejected as a new land: Premo-Flex FFC jumpers. Rejected: inventing pads, layer count, or copper weight.
 
 ## What stays UNVERIFIED
 
-The B19 flex is still a custom electrode plus V-dock. Stack-up, pad geometry, copper weight, and how P09-P12 sit on that flex stay UNVERIFIED.
+The B19 flex assembly. Stack-up. Pad geometry. How P09-P12 sit on that flex. How the 8-pos target mates the V-dock.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B37.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B37.md
@@ -1,0 +1,36 @@
+# B37 hunt
+
+- balloon_id: B37
+- BOM: internal camera FPC, exact assembly. UNVERIFIED length/orientation.
+- Class: UNVERIFIED
+- verdict: candidate Arducam CB023. 15-pin Pi cables rejected.
+
+## Queries actually run
+
+1. 22 pin 0.5mm CSI FPC cable length pin count Arducam Particle
+2. 22 pin 0.5mm to 22 pin CSI FPC cable 150mm Arducam
+3. Arducam CB023 150mm 22pin to 22pin camera cable product SKU 0.5mm
+
+## Sources opened
+
+| source | URL | what printed |
+| --- | --- | --- |
+| welectron product | https://www.welectron.com/Arducam-CB023-150mm-22pin-to-22pin-camera-cable-05mm-Pitch-interface | HAN: CB023. Title: Arducam CB023 150mm 22pin to 22pin camera cable 0.5mm Pitch interface. Shop price 0,90 € incl. 19% MwSt (0,76 € exkl.). Artnr. AC2-00230. That is a shop listing, not a checkout quote. |
+| Arducam docs | https://docs.arducam.com/Raspberry-Pi-Camera/raspberry-pi-camera-pinout/ | 22-22pin FPC used when both camera and platform are 22-pin. Also documents 15-22 adapter cables. |
+| Adafruit 5820 | https://www.adafruit.com/product/5820 | Raspberry Pi 5 FPC, 22-pin 0.5mm to 15-pin 1mm, 500mm. Rejected: 15-pin Pi camera end. |
+
+A later curl of https://www.arducam.com/product/150mm-22pin-to-22pin-camera-cable-0-5mm-pitch-interface/ returned HTTP 403. I did not treat that 403 as a hit.
+
+## Candidate vs rejected
+
+Candidate: Arducam CB023. The welectron page I opened prints length 150 mm and pin count 22 to 22 at 0.5 mm pitch. That meets the "page prints length AND pin count" bar. It is not a 15-pin Pi cable.
+
+Rejected: Adafruit 5820 and other 22-to-15 Pi 5 adapter cables. BOM wants the internal camera FPC, not a Pi camera adapter.
+
+## Pinout
+
+Not printed on the welectron CB023 page. Particle CSI1 22p 0.5 mm pinout lives in sourced-interfaces from a Tachyon photo. I did not copy a pinout onto CB023.
+
+## What stays UNVERIFIED
+
+Orientation, which side the contacts face, exact length needed inside B29/B34, and whether CB023 matches the Particle-supported IMX519 module (B36 still has no module SKU). Assembly is not selected.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B37.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B37.md
@@ -3,34 +3,49 @@
 - balloon_id: B37
 - BOM: internal camera FPC, exact assembly. UNVERIFIED length/orientation.
 - Class: UNVERIFIED
-- verdict: candidate Arducam CB023. 15-pin Pi cables rejected.
+- verdict: already queued to procurementbot. Do not re-land as a new SKU. Exact length and orientation stay UNVERIFIED.
+
+## Already queued. Do not re-land
+
+Record only:
+
+- Candidates Adafruit 6034 / 6035 / 6036 (22-pin 0.5 mm, 50 / 100 / 200 mm).
+- Exact length and orientation UNVERIFIED.
+- 22-to-15 rejected.
+
+This run did not pick one length. It did not treat a 22-to-15 Pi adapter as B37.
 
 ## Queries actually run
 
 1. 22 pin 0.5mm CSI FPC cable length pin count Arducam Particle
-2. 22 pin 0.5mm to 22 pin CSI FPC cable 150mm Arducam
-3. Arducam CB023 150mm 22pin to 22pin camera cable product SKU 0.5mm
+2. Adafruit 6034 / 6035 / 6036 22-pin 0.5 mm FPC
+3. Adafruit 5820 22-pin to 15-pin (reject check)
 
 ## Sources opened
 
 | source | URL | what printed |
 | --- | --- | --- |
-| welectron product | https://www.welectron.com/Arducam-CB023-150mm-22pin-to-22pin-camera-cable-05mm-Pitch-interface | HAN: CB023. Title: Arducam CB023 150mm 22pin to 22pin camera cable 0.5mm Pitch interface. Shop price 0,90 € incl. 19% MwSt (0,76 € exkl.). Artnr. AC2-00230. That is a shop listing, not a checkout quote. |
-| Arducam docs | https://docs.arducam.com/Raspberry-Pi-Camera/raspberry-pi-camera-pinout/ | 22-22pin FPC used when both camera and platform are 22-pin. Also documents 15-22 adapter cables. |
-| Adafruit 5820 | https://www.adafruit.com/product/5820 | Raspberry Pi 5 FPC, 22-pin 0.5mm to 15-pin 1mm, 500mm. Rejected: 15-pin Pi camera end. |
+| Adafruit 6034 | https://www.adafruit.com/product/6034 | Product ID 6034. Title 22-pin 0.5mm pitch FPC Flex Cable for DSI CSI or HSTX - 5cm. Body: 5 cm long, A-B style. Options list 5cm / 10cm / 20cm. Shop prices on that page are not a checkout quote. |
+| Adafruit 6035 | https://www.adafruit.com/product/6035 | Product ID 6035. 22-pin 0.5mm. 10 cm long. Same 5cm / 10cm / 20cm option list. |
+| Adafruit 6036 | https://www.adafruit.com/product/6036 | Product ID 6036. 22-pin 0.5mm. 20 cm long. Same option list. |
+| Adafruit 5820 | https://www.adafruit.com/product/5820 | Raspberry Pi 5 FPC, 22-pin 0.5mm to 15-pin 1mm. Rejected: 15-pin end. |
+| welectron Arducam CB023 | https://www.welectron.com/Arducam-CB023-150mm-22pin-to-22pin-camera-cable-05mm-Pitch-interface | Earlier open printed CB023, 150 mm, 22pin to 22pin, 0.5 mm. Not re-landed. The queued record is Adafruit 6034/6035/6036. |
+| Arducam product | https://www.arducam.com/product/150mm-22pin-to-22pin-camera-cable-0-5mm-pitch-interface/ | HTTP 403. Not a hit. |
 
-A later curl of https://www.arducam.com/product/150mm-22pin-to-22pin-camera-cable-0-5mm-pitch-interface/ returned HTTP 403. I did not treat that 403 as a hit.
+5 cm, 10 cm, and 20 cm on those Adafruit pages are 50 mm, 100 mm, and 200 mm. I did not invent a fourth length.
 
 ## Candidate vs rejected
 
-Candidate: Arducam CB023. The welectron page I opened prints length 150 mm and pin count 22 to 22 at 0.5 mm pitch. That meets the "page prints length AND pin count" bar. It is not a 15-pin Pi cable.
+Already-queued candidates: Adafruit 6034, 6035, 6036. Each page prints 22-pin and 0.5 mm. Lengths printed as 5 cm / 10 cm / 20 cm. Which length fits B29/B34 is UNVERIFIED. Contact-face orientation is UNVERIFIED.
 
-Rejected: Adafruit 5820 and other 22-to-15 Pi 5 adapter cables. BOM wants the internal camera FPC, not a Pi camera adapter.
+Rejected: Adafruit 5820 and any other 22-to-15 Pi camera adapter. BOM wants the internal camera FPC, not a Pi 15-pin adapter.
+
+Not re-landed: Arducam CB023. Shop listing exists. It is not the queued triple.
 
 ## Pinout
 
-Not printed on the welectron CB023 page. Particle CSI1 22p 0.5 mm pinout lives in sourced-interfaces from a Tachyon photo. I did not copy a pinout onto CB023.
+Not printed on the Adafruit 6034/6035/6036 pages. I did not copy a Particle CSI1 pinout onto these cables.
 
 ## What stays UNVERIFIED
 
-Orientation, which side the contacts face, exact length needed inside B29/B34, and whether CB023 matches the Particle-supported IMX519 module (B36 still has no module SKU). Assembly is not selected.
+Exact length. Orientation. Whether 22-pin 0.5 mm A-B matches the Particle-supported IMX519 module (B36 still has no module SKU). Assembly is not selected.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B44.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B44.md
@@ -25,8 +25,10 @@ Already queued: 0154002.DR as a 2 A candidate from an Octopart search line. $1.4
 | Newark | https://www.newark.com/littelfuse/0154002-dr/fuse-very-fast-acting-2a-125v/dp/67K1545 | Fetch timed out |
 | TME | https://www.tme.eu/en/details/0154002.dr/smd-fuses-with-holder-ultra-fast/littelfuse/ | Cloudflare "security verification". Body did not print the SKU. |
 | Third-party PDF | https://www.components-store.cz/datasheets/c2/0154002.DRTL.pdf | Fetch timed out |
+| Littelfuse 154 series datasheet | https://www.littelfuse.com/assetdocs/littelfuse-fuse-154-series-data-sheet?assetguid=a8a8a462-7295-481b-a91b-d770dabf005b | Catalog number 154002.0, Ampere Rating 2, Amp Code 2.0, fuse furnished 453002.0. Numbering example printed 015401.5DR for a 1.5 A fast-acting part. Packaging code DR = tape and reel. Holder note: 155900 rated 125V, 10A. The exact string 0154002.DR is not in the PDF body I received. No DC voltage covering 12 V is printed next to that 2 A line. I did not concatenate 0154 + 002.0 + DR into an MPN. |
+| guessed Omni-Blok path | https://www.littelfuse.com/products/fuses-overcurrent-protection/fuses/surface-mount-fuses/omni-blok-fuse-and-holder-system/0154002dr | HTTP 404. |
 
-Search snippets for TME and aggregator pages printed 0154002.DR, 2 A, and 125 V DC. Those snippets are not the opened DETAIL body. Per the hunt rule I do not record a walled snippet as a hit.
+Search snippets for TME and aggregator pages printed 0154002.DR, 2 A, and 125 V DC. Those snippets are not the opened DETAIL body. Per the hunt rule I do not record a walled snippet as a hit. The Littelfuse product URL timed out, then previously 403. Search snippets of that product URL are also not a DETAIL body I received.
 
 ## Candidate vs rejected
 

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B44.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B44.md
@@ -1,0 +1,39 @@
+# B44 hunt
+
+- balloon_id: B44
+- BOM: fused rail power tap. 2 A TARGET. Final budget UNVERIFIED.
+- Class: UNVERIFIED
+- verdict: DETAIL pages I opened did not print 0154002.DR with 2 A in the body I got. STOP. No 2.5 A neighbor.
+
+Already queued: 0154002.DR as a 2 A candidate from an Octopart search line. $1.411 snapshot, not a quote. 0685T2500-01 and any 2.5 A neighbor rejected.
+
+## Queries actually run
+
+1. 0154002.DR Littelfuse 2A fuse datasheet
+2. Littelfuse 0154002.DR OMNI-BLOK official product
+3. site:tme.eu 0154002.DR 2A 125V DC
+4. Direct opens of Littelfuse, DigiKey, Mouser, LCSC, Newark, TME, and a third-party PDF
+
+## Sources opened
+
+| source | URL | what I got |
+| --- | --- | --- |
+| Littelfuse product | https://www.littelfuse.com/products/fuses-overcurrent-protection/fuse-holders-fuse-blocks-accessories/fuse-blocks/pcb-mount-fuse-blocks/154/154002-dr | HTTP 403 |
+| DigiKey | https://www.digikey.com/en/products/detail/littelfuse-inc/0154002.DR/776351 | HTTP 403 |
+| Mouser | https://www.mouser.com/ProductDetail/Littelfuse/0154002.DR | HTTP/2 stream closed |
+| LCSC (guessed path) | https://www.lcsc.com/product-detail/Fuses_Littelfuse-0154002-DR_C14258.html | Wrong part. Page printed Shun Xiang Nuo SM5845-4R7MT inductor. Not a fuse hit. |
+| Newark | https://www.newark.com/littelfuse/0154002-dr/fuse-very-fast-acting-2a-125v/dp/67K1545 | Fetch timed out |
+| TME | https://www.tme.eu/en/details/0154002.dr/smd-fuses-with-holder-ultra-fast/littelfuse/ | Cloudflare "security verification". Body did not print the SKU. |
+| Third-party PDF | https://www.components-store.cz/datasheets/c2/0154002.DRTL.pdf | Fetch timed out |
+
+Search snippets for TME and aggregator pages printed 0154002.DR, 2 A, and 125 V DC. Those snippets are not the opened DETAIL body. Per the hunt rule I do not record a walled snippet as a hit.
+
+## Candidate vs rejected
+
+No new selection. 0154002.DR stays the already-queued Octopart-line candidate until a DETAIL page that I can actually read prints 0154002.DR and 2 A plus a DC voltage covering ~12 V.
+
+Rejected: 0685T2500-01 and any 2.5 A neighbor. I did not pick one.
+
+## What stays UNVERIFIED
+
+Fuse MPN on a live DETAIL page, DC voltage covering 12 V on that same page, load budget, coordination with Q1.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B47.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B47.md
@@ -1,0 +1,34 @@
+# B47 hunt
+
+- balloon_id: B47
+- BOM: four 100 ohm V-dock point-to-point flex/STP channels. SI stack UNVERIFIED.
+- Class: UNVERIFIED
+- verdict: family-level 100 ohm printed. No orderable SKU whose opened page prints both an MPN and 100 ohm without a 90-or-100 hedge. STOP on impedance. Do not invent it.
+
+## Queries actually run
+
+1. GMSL 100 ohm STP cable Rosenberger HSD 100 Ω differential
+2. Molex Premo-Flex 100 ohm differential impedance FFC
+3. Molex 15021 Premo-Flex 100 Ohm LVDS FFC 15 circuit part number
+
+## Sources opened
+
+| source | URL | what printed |
+| --- | --- | --- |
+| Rosenberger HSD product | https://www.rosenberger.com/product/rosenberger-hsd/ | "this 100 Ohm fully shielded interconnect system". "Impedance 100 Ohm". Series codes D4 / 99 / D2. GMSL listed under protocols. No orderable connector or cable MPN on that page. |
+| Rosenberger HSD catalog PDF | https://osi.rosenberger.com/fileadmin/content/headquarter/Downloads/Differential-Data-Connectors/AUTO_HSD_Catalog_2020.pdf | Impedance 100 Ω. Cable group table with example cable types. Still a family catalog, not a picked SKU. |
+| Molex Premo-Flex family | https://www.molex.com/en-us/products/cable-assemblies/flat-flexible-cables-ffc | "FFCs with 90-Ohm and 100-Ohm impedance for USB and HDMI". Family, not one SKU. |
+| Molex Premo-Flex jumper PDF | https://www.content.molex.com/dxdam/literature/987651-3802.pdf | Series 15021. "Controlled impedance: 90 or 100 Ohm". 15, 24 or 33 circuits. Ambiguous on a single MPN. |
+| Third-party Molex part PDF | https://xonstorage.z8.web.core.windows.net/pdf/molex_150211015_apr22_xonlink.pdf | Part Number 0150211015. 0.50 mm Premo-Flex LVDS jumper, 254.00 mm, gold, 15 circuits. That sheet does not print 100 ohm. |
+
+A fetch of https://www.molex.com/en-us/products/part-detail/150210215 timed out. Not a hit.
+
+## Candidate vs rejected
+
+Not selected. Rosenberger HSD is a 100 ohm family with no SKU on the page I opened. Molex 0150211015 is an LVDS jumper whose part sheet does not print 100 ohm. Series literature that says "90 or 100 Ohm" is not a printed 100 ohm on that MPN.
+
+I did not invent impedance, a flex stack, or a GMSL launch on a catalog FFC.
+
+## What stays UNVERIFIED
+
+The four V-dock 100 ohm channels. SI stack, routing, and any orderable flex/STP SKU.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B47.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B47.md
@@ -3,32 +3,37 @@
 - balloon_id: B47
 - BOM: four 100 ohm V-dock point-to-point flex/STP channels. SI stack UNVERIFIED.
 - Class: UNVERIFIED
-- verdict: family-level 100 ohm printed. No orderable SKU whose opened page prints both an MPN and 100 ohm without a 90-or-100 hedge. STOP on impedance. Do not invent it.
+- verdict: already queued to procurementbot. Do not re-land as a new SKU. One 100 ohm pair is recorded. Four-channel V-dock SI stays UNVERIFIED.
+
+## Already queued. Do not re-land
+
+Record only:
+
+- C28S-11.00-SPS8-SPS8 one 100 ohm pair.
+- Four-channel V-dock SI UNVERIFIED.
+
+This run did not invent three more cables, a GMSL launch, or a flex stack.
 
 ## Queries actually run
 
 1. GMSL 100 ohm STP cable Rosenberger HSD 100 Ω differential
-2. Molex Premo-Flex 100 ohm differential impedance FFC
-3. Molex 15021 Premo-Flex 100 Ohm LVDS FFC 15 circuit part number
+2. Samtec C28S-11.00-SPS8-SPS8 100 ohm twinax
+3. Molex Premo-Flex 100 ohm differential impedance FFC
 
 ## Sources opened
 
 | source | URL | what printed |
 | --- | --- | --- |
-| Rosenberger HSD product | https://www.rosenberger.com/product/rosenberger-hsd/ | "this 100 Ohm fully shielded interconnect system". "Impedance 100 Ohm". Series codes D4 / 99 / D2. GMSL listed under protocols. No orderable connector or cable MPN on that page. |
-| Rosenberger HSD catalog PDF | https://osi.rosenberger.com/fileadmin/content/headquarter/Downloads/Differential-Data-Connectors/AUTO_HSD_Catalog_2020.pdf | Impedance 100 Ω. Cable group table with example cable types. Still a family catalog, not a picked SKU. |
-| Molex Premo-Flex family | https://www.molex.com/en-us/products/cable-assemblies/flat-flexible-cables-ffc | "FFCs with 90-Ohm and 100-Ohm impedance for USB and HDMI". Family, not one SKU. |
-| Molex Premo-Flex jumper PDF | https://www.content.molex.com/dxdam/literature/987651-3802.pdf | Series 15021. "Controlled impedance: 90 or 100 Ohm". 15, 24 or 33 circuits. Ambiguous on a single MPN. |
-| Third-party Molex part PDF | https://xonstorage.z8.web.core.windows.net/pdf/molex_150211015_apr22_xonlink.pdf | Part Number 0150211015. 0.50 mm Premo-Flex LVDS jumper, 254.00 mm, gold, 15 circuits. That sheet does not print 100 ohm. |
-
-A fetch of https://www.molex.com/en-us/products/part-detail/150210215 timed out. Not a hit.
+| Samtec C28S-11.00-SPS8-SPS8 | https://www.samtec.com/products/c28s-11.00-sps8-sps8 | Heading C28S-11.00-SPS8-SPS8. Feature line: 100 ohm differential pair signal routing. 28 AWG shielded twisted pair cable. Online pricing not available on that page. Tech library line: 100 Ohm, 28 AWG, Shielded Twisted Pair Cable (TPS-28100-RF). |
+| Rosenberger HSD product | https://www.rosenberger.com/product/rosenberger-hsd/ | Family 100 Ohm. No orderable cable MPN on that page. |
+| Molex Premo-Flex family | https://www.molex.com/en-us/products/cable-assemblies/flat-flexible-cables-ffc | 90-Ohm and 100-Ohm family hedge. Not one SKU. |
 
 ## Candidate vs rejected
 
-Not selected. Rosenberger HSD is a 100 ohm family with no SKU on the page I opened. Molex 0150211015 is an LVDS jumper whose part sheet does not print 100 ohm. Series literature that says "90 or 100 Ohm" is not a printed 100 ohm on that MPN.
+Already-queued: Samtec C28S-11.00-SPS8-SPS8. The product page I opened prints that MPN and 100 ohm differential pair. That is one pair, not four V-dock channels.
 
-I did not invent impedance, a flex stack, or a GMSL launch on a catalog FFC.
+Rejected as a new land: Rosenberger HSD family with no SKU. Rejected: Premo-Flex literature that says 90 or 100 Ohm. Rejected: inventing impedance onto a jumper whose sheet does not print 100 ohm.
 
 ## What stays UNVERIFIED
 
-The four V-dock 100 ohm channels. SI stack, routing, and any orderable flex/STP SKU.
+The other three 100 ohm channels. V-dock SI stack. Routing. Whether C28S-11.00-SPS8-SPS8 even belongs on the carriage-to-binder path. Four-channel SI is not closed by one twinax SKU.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B48.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B48.md
@@ -1,0 +1,50 @@
+# B48 leftover hunt
+
+- balloon_id: B48 leftover
+- BOM leftover after queued S1/S2 D2FS-F-N and Q1 TPS259830LNRGER: 12 V supervisor, discharge, bus isolation, AND/dual-enable for S1 AND S2.
+- Class: UNVERIFIED
+- verdict: catalog IC candidates on TI pages. No resistor values. No discrete AND. Timing still open.
+
+Already queued, not re-landed: S1/S2 D2FS-F-N, Q1 TPS259830LNRGER.
+
+## Queries actually run
+
+1. TPS3700 12V window supervisor datasheet site:ti.com
+2. TPS25983 output discharge dual enable datasheet site:ti.com
+3. CD4081B 18V AND gate dual input TI datasheet
+4. TPS22810 12V output discharge load switch (after TPS22965 showed 5.7 V max)
+
+## Sources opened
+
+| source | URL | what printed |
+| --- | --- | --- |
+| TI TPS3700 | https://www.ti.com/product/TPS3700 | "High-voltage (18-V) window voltage detector". "Wide supply voltage range: 1.8 V to 18 V". "the monitored voltage can be set with the use of external resistors". Packages SOT-23-THN (DDC) and WSON (DSE). |
+| TI TPS25983 | https://www.ti.com/product/TPS25983 | 2.7 V to 26 V eFuse. Features listed do not include output discharge. This is the queued Q1 family, not a leftover close. |
+| TI TPS25983 datasheet | https://www.ti.com/lit/ds/symlink/tps25983.pdf | EN/UVLO, ILIM equations. I did not compute a resistor. |
+| TI CD4081B | https://www.ti.com/product/CD4081B | "4-ch 2-input 3-V to 18-V AND gate". "CD4081B Quad 2-Input AND Gate". 5-V, 10-V, and 15-V parametric ratings. |
+| TI TPS22810 | https://www.ti.com/product/TPS22810 | "18-V, 3-A, 79-mΩ load switch with adj. rise time and adj. output discharge". "Input Voltage Range: 2.7 V to 18 V". "RON = 79 mΩ (typical) at VIN = 12 V". "Adjustable Quick Output Discharge (QOD)". |
+| TI TPS22810DBVR | https://www.ti.com/product/TPS22810/part-details/TPS22810DBVR | Orderable TPS22810DBVR. SOT-23 (DBV) 6. Package qty 3,000 LARGE T&R. Prices on that page were blank dashes. Inventory out of stock on that view. |
+| TI CD4066B | https://www.ti.com/product/CD4066B | "20V, 1:1 (SPST), 4-channel, analog switch". "Power supply voltage - single (V) 3.3, 5, 12, 16, 20". "Wide operating supply of 3V to 18V". |
+| TI TPS22965 | https://www.ti.com/product/TPS22965 | 0.8 V to 5.7 V. Rejected as a 12 V discharge stand-in. |
+
+A fetch of https://www.ti.com/product/TPS3700/part-details/TPS3700DDCR returned 404. No TPS3700 tape-reel suffix from that URL.
+
+## Candidate vs rejected
+
+Candidate, supervisor: TPS3700. The product page prints 1.8 V to 18 V, which covers 12 V rail VIN. Thresholds use external resistors. I did not invent those resistors. Full orderable suffix UNVERIFIED (DDC/DSE packages printed, tape-reel 404).
+
+Candidate, AND: CD4081B. Catalog 2-input AND, 3 V to 18 V. This is not a discrete transistor AND. I did not wire S1/S2 to it. Logic levels vs the D2FS-F-N switches stay UNVERIFIED.
+
+Candidate, discharge: TPS22810DBVR. Page prints 12 V RON and adjustable QOD. This is a load switch with discharge, not a replacement for queued Q1 TPS259830LNRGER. QOD resistor unselected. I did not invent it.
+
+Candidate, signal isolation only: CD4066B. Page prints 12 V among single-supply voltages. Quad SPST analog switch. That is not galvanic isolation of the 12 V bus. Power-bus isolation still open.
+
+Rejected: TPS22965 as 12 V discharge (5.7 V max). Rejected: inventing a discrete AND. Rejected: using a 3.3 V-class supervisor as a 12 V stand-in.
+
+## Pinout
+
+Not copied. TI pages have pin tables in datasheets. I did not transcribe them into a B48 net map.
+
+## What stays UNVERIFIED
+
+Mate order, timeout, polarity, S1 AND S2 timing, Q1 enable wiring, discharge R, and any isolation of VIN-A/VIN-B. P08 is still not safety authority.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B48.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B48.md
@@ -13,6 +13,8 @@ Already queued, not re-landed: S1/S2 D2FS-F-N, Q1 TPS259830LNRGER.
 2. TPS25983 output discharge dual enable datasheet site:ti.com
 3. CD4081B 18V AND gate dual input TI datasheet
 4. TPS22810 12V output discharge load switch (after TPS22965 showed 5.7 V max)
+5. TPS4811-Q1 12V high-side bus isolation
+6. LM74700-Q1 12V reverse current blocking
 
 ## Sources opened
 
@@ -26,8 +28,10 @@ Already queued, not re-landed: S1/S2 D2FS-F-N, Q1 TPS259830LNRGER.
 | TI TPS22810DBVR | https://www.ti.com/product/TPS22810/part-details/TPS22810DBVR | Orderable TPS22810DBVR. SOT-23 (DBV) 6. Package qty 3,000 LARGE T&R. Prices on that page were blank dashes. Inventory out of stock on that view. |
 | TI CD4066B | https://www.ti.com/product/CD4066B | "20V, 1:1 (SPST), 4-channel, analog switch". "Power supply voltage - single (V) 3.3, 5, 12, 16, 20". "Wide operating supply of 3V to 18V". |
 | TI TPS22965 | https://www.ti.com/product/TPS22965 | 0.8 V to 5.7 V. Rejected as a 12 V discharge stand-in. |
+| TI TPS4811-Q1 | https://www.ti.com/product/TPS4811-Q1 | Fetch timed out. Not a hit from a body I received. |
+| TI LM74700-Q1 | https://www.ti.com/product/LM74700-Q1 | 3.2-V to 65-V ideal diode controller. Page prints 12-V, 24-V and 48-V automotive battery systems. Reverse current blocking. External N-channel MOSFET. FET not selected. This is reverse-polarity / reverse-current control, not galvanic isolation of VIN-A/VIN-B. |
 
-A fetch of https://www.ti.com/product/TPS3700/part-details/TPS3700DDCR returned 404. No TPS3700 tape-reel suffix from that URL.
+A fetch of https://www.ti.com/product/TPS3700/part-details/TPS3700DDCR returned 404. No TPS3700 tape-reel suffix from that URL. TPS3700 datasheet PDF fetch timed out this pass. The product page still prints 1.8 V to 18 V.
 
 ## Candidate vs rejected
 
@@ -38,6 +42,8 @@ Candidate, AND: CD4081B. Catalog 2-input AND, 3 V to 18 V. This is not a discret
 Candidate, discharge: TPS22810DBVR. Page prints 12 V RON and adjustable QOD. This is a load switch with discharge, not a replacement for queued Q1 TPS259830LNRGER. QOD resistor unselected. I did not invent it.
 
 Candidate, signal isolation only: CD4066B. Page prints 12 V among single-supply voltages. Quad SPST analog switch. That is not galvanic isolation of the 12 V bus. Power-bus isolation still open.
+
+Leftover, not a close: LM74700-Q1. Page prints 12-V systems and reverse current blocking. External FET unselected. Reverse blocking is not bus isolation.
 
 Rejected: TPS22965 as 12 V discharge (5.7 V max). Rejected: inventing a discrete AND. Rejected: using a 3.3 V-class supervisor as a 12 V stand-in.
 

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B50.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B50.md
@@ -1,0 +1,38 @@
+# B50 hunt
+
+- balloon_id: B50
+- BOM: separate keyed 12-net carriage-to-binder connector. C01-C12 mirror required. Series UNVERIFIED.
+- Class: UNVERIFIED
+- verdict: candidate TE 776437-1 housing. Molex 1053081212 stays rejected. C01-C12 not invented.
+
+## Queries actually run
+
+1. Molex keyed 12 position connector housing keying
+2. Molex Nano-Fit 12 circuit keyed housing 1053081212 alternative keyed
+3. Molex Mini-Fit 12 circuit keyed housing 39-01-2120 keying
+4. TE AMPSEAL 16 776437-1 12 position keyed housing product page
+
+## Sources opened
+
+| source | URL | what printed |
+| --- | --- | --- |
+| TE 776437-1 | https://www.te.com/en/product-776437-1.html | Active. "12 V / 24 V / 240 V, 12 Position, Automotive Plug". TE Internal #: 776437-1. Description: AS16,PLUG ASSY,ST,12P,N SEAL,CODE A. Alias: AS16-ST-06-12SA-N. Number of Positions: 12. Nominal Voltage Architecture includes 12. |
+| Conrad Molex PDF (already-rejected housing) | https://asset.conrad.com/media10/add/160267/c1/-/en/002446873DS00/tehnicni-podatki-2446873-molex-ohisje-kabelske-vticnice-skupno-stevilo-polov-12-osnovna-mreza-25-mm-1053081212-1-kos-bag.pdf | 1053081212. 12 Circuits. "Keying to Mating Part Yes". This hunt does not re-admit it. Prior quest rejected it as not keyed / no C01-C12. I am not reversing that. |
+| Heilind Mini-Fit 39-01-2120 | https://www.heilind.eu/mol39-01-2120.html | 12 Circuits. "Polarized to Mate: Yes". Polarized is not the same as keyed. Not taken. |
+| RS Mini-Fit 39-01-2120 | https://uk.rs-online.com/web/p/wire-housings-plugs/1891455 | Fetch timed out. Not a hit from that open. |
+
+## Candidate vs rejected
+
+Candidate: TE 776437-1 AMPSEAL 16 plug housing. The opened TE page prints 12 Position and CODE A. CODE A is keying, not latch-only. Voltage architecture list includes 12 V.
+
+Rejected: Molex 1053081212 (already rejected, not re-landed). Rejected: Mini-Fit 39-01-2120 on a page that printed polarized, not keyed.
+
+I did not invent C01-C12. The TE page does not print a C01-C12 net map, mate order, or a controlled-impedance launch.
+
+## Pinout
+
+Not printed as C01-C12. Not invented.
+
+## What stays UNVERIFIED
+
+Mating cap/header SKU, key code pair, pin geometry vs the 12 required nets, GMSL launch on C09-C12, current, hot-unplug, durability. B50 is still not a released pinout.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B50.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/B50.md
@@ -11,6 +11,7 @@
 2. Molex Nano-Fit 12 circuit keyed housing 1053081212 alternative keyed
 3. Molex Mini-Fit 12 circuit keyed housing 39-01-2120 keying
 4. TE AMPSEAL 16 776437-1 12 position keyed housing product page
+5. TE AMPSEAL 16 catalog PDF 776437 12 position keys
 
 ## Sources opened
 
@@ -20,10 +21,12 @@
 | Conrad Molex PDF (already-rejected housing) | https://asset.conrad.com/media10/add/160267/c1/-/en/002446873DS00/tehnicni-podatki-2446873-molex-ohisje-kabelske-vticnice-skupno-stevilo-polov-12-osnovna-mreza-25-mm-1053081212-1-kos-bag.pdf | 1053081212. 12 Circuits. "Keying to Mating Part Yes". This hunt does not re-admit it. Prior quest rejected it as not keyed / no C01-C12. I am not reversing that. |
 | Heilind Mini-Fit 39-01-2120 | https://www.heilind.eu/mol39-01-2120.html | 12 Circuits. "Polarized to Mate: Yes". Polarized is not the same as keyed. Not taken. |
 | RS Mini-Fit 39-01-2120 | https://uk.rs-online.com/web/p/wire-housings-plugs/1891455 | Fetch timed out. Not a hit from that open. |
+| TE customer drawing 776437 | https://www.te.com/commerce/DocumentDelivery/DDEController?Action=srchrtrv&DocNm=776437&DocType=Customer+Drawing&DocLang=English | Title line: PLUG ASSEMBLY, 12 POSITION, DUAL ROW, AMPSEAL 16. TPA COLOR PART NUMBER table: RED 776437-1. Drawing does not print the word keyed. |
+| TE AMPSEAL 16 catalog PDF | https://www.te.com/content/dam/te-com/documents/industrial-and-commercial-transportation/global/ict-ampseal-16-cat-a4-7-1773982-8-en-2010.pdf | "4 keys available for 8 & 12 position." "-1 = A key (red TPA)". Table row 776437-1 / AS16-ST-06-12SA-N. Nearby heading 12 Pos. "Plug housing and cap housing TPA colors are mechanically keyed to mate only with identical colors." "A, B, C & D keys". |
 
 ## Candidate vs rejected
 
-Candidate: TE 776437-1 AMPSEAL 16 plug housing. The opened TE page prints 12 Position and CODE A. CODE A is keying, not latch-only. Voltage architecture list includes 12 V.
+Candidate: TE 776437-1 AMPSEAL 16 plug housing. The opened TE product page prints 12 Position and CODE A. The catalog PDF I opened prints 776437-1, 12 position, and key / keyed language on the same document. CODE A / A key is keying, not latch-only. Voltage architecture list includes 12 V.
 
 Rejected: Molex 1053081212 (already rejected, not re-landed). Rejected: Mini-Fit 39-01-2120 on a page that printed polarized, not keyed.
 

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/HITS.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/HITS.md
@@ -1,0 +1,24 @@
+# Hunt roll-up
+
+Class is UNVERIFIED on every row. No procurement write. No board edit. No merge.
+
+| balloon | MPN or UNVERIFIED | source URL | note |
+| --- | --- | --- | --- |
+| B19 | UNVERIFIED STOP | https://www.molex.com/en-us/products/cable-assemblies/flat-flexible-cables-ffc | Family search described FFC jumpers, not V-dock electrodes. DETAIL timed out. No stack invented. |
+| B37 | Arducam CB023 candidate | https://www.welectron.com/Arducam-CB023-150mm-22pin-to-22pin-camera-cable-05mm-Pitch-interface | Page printed 150 mm and 22pin to 22pin, 0.5 mm. Not a 15-pin Pi cable. Orientation UNVERIFIED. |
+| B47 | UNVERIFIED STOP | https://www.rosenberger.com/product/rosenberger-hsd/ | Family page printed 100 Ohm. No orderable SKU on that page. Impedance not invented onto a jumper. |
+| B48 leftover supervisor | TPS3700 candidate | https://www.ti.com/product/TPS3700 | 1.8 V to 18 V printed. Resistors not invented. Suffix UNVERIFIED. |
+| B48 leftover AND | CD4081B candidate | https://www.ti.com/product/CD4081B | 3 V to 18 V 2-input AND. Not a discrete AND. Timing UNVERIFIED. |
+| B48 leftover discharge | TPS22810DBVR candidate | https://www.ti.com/product/TPS22810/part-details/TPS22810DBVR | 12 V RON and QOD printed. Not a replacement for queued Q1. QOD R unselected. |
+| B48 leftover isolation | CD4066B candidate (signals only) | https://www.ti.com/product/CD4066B | 12 V listed on analog-switch supplies. Power-bus isolation still open. |
+| B50 | TE 776437-1 candidate | https://www.te.com/en/product-776437-1.html | Page printed 12 Position and CODE A. C01-C12 not invented. 1053081212 stays rejected. |
+| B44 | UNVERIFIED STOP (0154002.DR still queued from Octopart line) | https://www.tme.eu/en/details/0154002.dr/smd-fuses-with-holder-ultra-fast/littelfuse/ | Cloudflare walled. Littelfuse/DigiKey 403. No DETAIL body printed 2 A for me. No 2.5 A neighbor. |
+| B09 | Southco C2-32-15 candidate | https://southco.com/en_us_int/c2-32-15 | Catalog latch. Door cutout REF. |
+| B11 | UNVERIFIED STOP | https://www.ahh.biz/mesh/mesh_mosquito_netting_0_8_mm.php | Name prints 0.8 mm. No aperture table. JF 0.83 mm rejected. |
+| B15 | UNVERIFIED STOP | https://www.serpro.co.uk/37-5-x-23cm-Laboratory-Tray-Drip-Pan | TRAY18257 is 60 mm deep. Not 20-30 mm. |
+| B16 | UNVERIFIED STOP | https://www.usplastic.com/catalog/item.aspx?itemid=33412 | Plug without insect baffle. Combo not invented. |
+| B18 | UNVERIFIED STOP | (search only: Misumi 40 mm HFS5-4040, not 38 mm) | 40 mm is not 38 mm. No 38 mm DETAIL opened. |
+| B01-B04, B07, B10, B12-B14, B17, B20-B24, B28-B34, B51-B52 | UNVERIFIED STOP | (no catalog DETAIL hit) | Printed-REF. No invented print-file MPN. |
+| B26, B40, B35 | STOP kept | (no non-walled SKU this hunt) | B35 is not M1ENCLEA. |
+
+Queued, not re-landed: B42 TACH4NA / TACH8NA / TACH8ROW, B43 M1ENCLEA, B41 kit glands, B36 IMX519 family, B45 MAX96717GTJ/VY+T, B46 MAX96724GTN/VY+T, B49 TCA9548A family, B27 816-22-012-10-000101, B48 D2FS-F-N and TPS259830LNRGER, B25 LC032C08M, B38 94180A331 / 94459A130 / Adafruit 4255, B39 3506K21 / 5679K88, B05/B06 A000AN03.0L0GPCTE, B08 1588A714.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/HITS.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/HITS.md
@@ -4,15 +4,16 @@ Class is UNVERIFIED on every row. No procurement write. No board edit. No merge.
 
 | balloon | MPN or UNVERIFIED | source URL | note |
 | --- | --- | --- | --- |
-| B19 | UNVERIFIED STOP | https://www.molex.com/en-us/products/cable-assemblies/flat-flexible-cables-ffc | Family search described FFC jumpers, not V-dock electrodes. DETAIL timed out. No stack invented. |
-| B37 | Arducam CB023 candidate | https://www.welectron.com/Arducam-CB023-150mm-22pin-to-22pin-camera-cable-05mm-Pitch-interface | Page printed 150 mm and 22pin to 22pin, 0.5 mm. Not a 15-pin Pi cable. Orientation UNVERIFIED. |
-| B47 | UNVERIFIED STOP | https://www.rosenberger.com/product/rosenberger-hsd/ | Family page printed 100 Ohm. No orderable SKU on that page. Impedance not invented onto a jumper. |
+| B19 | already queued: 319-10-108-00-001000 (8-pos Mill-Max target). Assembly+stack UNVERIFIED. Pyralux AP materials only. No stack. | https://www.morrishk.net/products/01111856/319-10-108-00-001000.html | Do not re-land as a new SKU. Morris page printed Mating Target and 8 contacts. DuPont Pyralux AP page lists AP*R constructions. No stack selected. |
+| B37 | already queued: Adafruit 6034/6035/6036. Exact length/orientation UNVERIFIED. 22-to-15 rejected. | https://www.adafruit.com/product/6034 | Do not re-land as a new SKU. Pages print 22-pin 0.5 mm and 5/10/20 cm. Adafruit 5820 22-to-15 rejected. CB023 not re-landed. |
+| B47 | already queued: C28S-11.00-SPS8-SPS8 one 100 ohm pair. Four-channel V-dock SI UNVERIFIED. | https://www.samtec.com/products/c28s-11.00-sps8-sps8 | Do not re-land as a new SKU. Samtec page prints that MPN and 100 ohm differential pair. One pair, not four channels. |
 | B48 leftover supervisor | TPS3700 candidate | https://www.ti.com/product/TPS3700 | 1.8 V to 18 V printed. Resistors not invented. Suffix UNVERIFIED. |
 | B48 leftover AND | CD4081B candidate | https://www.ti.com/product/CD4081B | 3 V to 18 V 2-input AND. Not a discrete AND. Timing UNVERIFIED. |
 | B48 leftover discharge | TPS22810DBVR candidate | https://www.ti.com/product/TPS22810/part-details/TPS22810DBVR | 12 V RON and QOD printed. Not a replacement for queued Q1. QOD R unselected. |
 | B48 leftover isolation | CD4066B candidate (signals only) | https://www.ti.com/product/CD4066B | 12 V listed on analog-switch supplies. Power-bus isolation still open. |
-| B50 | TE 776437-1 candidate | https://www.te.com/en/product-776437-1.html | Page printed 12 Position and CODE A. C01-C12 not invented. 1053081212 stays rejected. |
-| B44 | UNVERIFIED STOP (0154002.DR still queued from Octopart line) | https://www.tme.eu/en/details/0154002.dr/smd-fuses-with-holder-ultra-fast/littelfuse/ | Cloudflare walled. Littelfuse/DigiKey 403. No DETAIL body printed 2 A for me. No 2.5 A neighbor. |
+| B48 leftover reverse-block | LM74700-Q1 leftover, not a close | https://www.ti.com/product/LM74700-Q1 | Page prints 12-V systems and reverse current blocking. External FET unselected. Not galvanic isolation of VIN-A/VIN-B. |
+| B50 | TE 776437-1 candidate | https://www.te.com/en/product-776437-1.html | Product page printed 12 Position and CODE A. Catalog PDF prints 776437-1, 12 Pos, and keyed/key language. C01-C12 not invented. 1053081212 stays rejected. |
+| B44 | UNVERIFIED STOP (0154002.DR still queued from Octopart line) | https://www.littelfuse.com/assetdocs/littelfuse-fuse-154-series-data-sheet?assetguid=a8a8a462-7295-481b-a91b-d770dabf005b | Official 154 series datasheet prints catalog 154002.0 at 2 A and numbering example 015401.5DR. Exact string 0154002.DR not in that PDF body. No DC covering 12 V next to that SKU. Product DETAIL timed out / 403. No 2.5 A neighbor. |
 | B09 | Southco C2-32-15 candidate | https://southco.com/en_us_int/c2-32-15 | Catalog latch. Door cutout REF. |
 | B11 | UNVERIFIED STOP | https://www.ahh.biz/mesh/mesh_mosquito_netting_0_8_mm.php | Name prints 0.8 mm. No aperture table. JF 0.83 mm rejected. |
 | B15 | UNVERIFIED STOP | https://www.serpro.co.uk/37-5-x-23cm-Laboratory-Tray-Drip-Pan | TRAY18257 is 60 mm deep. Not 20-30 mm. |
@@ -21,4 +22,4 @@ Class is UNVERIFIED on every row. No procurement write. No board edit. No merge.
 | B01-B04, B07, B10, B12-B14, B17, B20-B24, B28-B34, B51-B52 | UNVERIFIED STOP | (no catalog DETAIL hit) | Printed-REF. No invented print-file MPN. |
 | B26, B40, B35 | STOP kept | (no non-walled SKU this hunt) | B35 is not M1ENCLEA. |
 
-Queued, not re-landed: B42 TACH4NA / TACH8NA / TACH8ROW, B43 M1ENCLEA, B41 kit glands, B36 IMX519 family, B45 MAX96717GTJ/VY+T, B46 MAX96724GTN/VY+T, B49 TCA9548A family, B27 816-22-012-10-000101, B48 D2FS-F-N and TPS259830LNRGER, B25 LC032C08M, B38 94180A331 / 94459A130 / Adafruit 4255, B39 3506K21 / 5679K88, B05/B06 A000AN03.0L0GPCTE, B08 1588A714.
+Queued, not re-landed: B42 TACH4NA / TACH8NA / TACH8ROW, B43 M1ENCLEA, B41 kit glands, B36 IMX519 family, B45 MAX96717GTJ/VY+T, B46 MAX96724GTN/VY+T, B49 TCA9548A family, B27 816-22-012-10-000101, B48 D2FS-F-N and TPS259830LNRGER, B25 LC032C08M, B38 94180A331 / 94459A130 / Adafruit 4255, B39 3506K21 / 5679K88, B05/B06 A000AN03.0L0GPCTE, B08 1588A714, B19 319-10-108-00-001000, B37 Adafruit 6034/6035/6036, B47 C28S-11.00-SPS8-SPS8.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/QUEUED.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/QUEUED.md
@@ -21,3 +21,6 @@ Copied from the hunt brief. This run did not re-select them.
 - B05/B06 Sheet Haus A000AN03.0L0GPCTE (3 mm). Cuts REF. ePlastics 0.118" is not 3.00 mm LOCK.
 - B08 McMaster 1588A714 family. Door REF.
 - STOP already: B26 rollers, B35 brick mount, B40 gasket, B11 screen (no printed aperture).
+- B19 assembly+stack UNVERIFIED. Candidate 319-10-108-00-001000 (8-pos Mill-Max target). Pyralux AP materials only. No stack.
+- B37 candidates Adafruit 6034/6035/6036 (22-pin 0.5 mm, 50/100/200 mm). Exact length/orientation UNVERIFIED. 22-to-15 rejected.
+- B47 C28S-11.00-SPS8-SPS8 one 100 ohm pair. Four-channel V-dock SI UNVERIFIED.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/QUEUED.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/QUEUED.md
@@ -1,0 +1,23 @@
+# Already queued. Do not re-land as new SKUs
+
+Class: UNVERIFIED
+
+Copied from the hunt brief. This run did not re-select them.
+
+- B42 Particle Tachyon family TACH4NA / TACH8NA / TACH8ROW. Do not invent TACH4ROW.
+- B43 M1ENCLEA $70 in stock (Particle store).
+- B41 kit-only (M1 glands/plugs). No standalone gland MPN.
+- B36 IMX519 family, no module SKU. Legacy B0371 not selected.
+- B45 MAX96717GTJ/VY+T LCSC. Device only, no carrier.
+- B46 MAX96724GTN/VY+T LCSC. Device only, no carrier. Keep CAD future-product mark on MAX96724GTN/VY+.
+- B49 TCA9548A family. No suffix selected. No carrier.
+- B27 816-22-012-10-000101 Mill-Max candidate. CAD hold: no pogo accepted against the wet/animal volume; B20 holds. HSD cell UNVERIFIED.
+- B44 0154002.DR is a 2 A candidate from an Octopart search line; $1.411 is a snapshot, not a quote. 0685T2500-01 and any 2.5 A neighbor are rejected.
+- B48 S1/S2 D2FS-F-N; B48 Q1 TPS259830LNRGER. Supervisor / discharge / isolation / AND timing still open.
+- B50 Molex 1053081212 housing rejected (not keyed, no C01-C12).
+- B25 LC032C08M Lee Spring candidate; pocket UNVERIFIED.
+- B38 inserts 94180A331 / 94459A130 / Adafruit 4255; screw example R91292A113; pocket UNVERIFIED.
+- B39 3506K21 / 5679K88 family; size unselected; never a latch.
+- B05/B06 Sheet Haus A000AN03.0L0GPCTE (3 mm). Cuts REF. ePlastics 0.118" is not 3.00 mm LOCK.
+- B08 McMaster 1588A714 family. Door REF.
+- STOP already: B26 rollers, B35 brick mount, B40 gasket, B11 screen (no printed aperture).

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/README.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/README.md
@@ -1,0 +1,9 @@
+# Terrarium parts-quest hunt notes
+
+Writer lane. Not the procurement book. Not the tscircuit board.
+Class stays **UNVERIFIED**. No order. No PO. No merge.
+
+Opened pages only. If a page was JS/login/Cloudflare walled and did not print the SKU in the body I got, that is a miss, not a hit.
+
+`HITS.md` is the roll-up. One note per balloon or group under this folder.
+Already-queued SKUs live in `QUEUED.md`. They are not new selections.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/README.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/README.md
@@ -6,4 +6,4 @@ Class stays **UNVERIFIED**. No order. No PO. No merge.
 Opened pages only. If a page was JS/login/Cloudflare walled and did not print the SKU in the body I got, that is a miss, not a hit.
 
 `HITS.md` is the roll-up. One note per balloon or group under this folder.
-Already-queued SKUs live in `QUEUED.md`. They are not new selections.
+Already-queued SKUs live in `QUEUED.md`. They are not new selections. B19, B37, and B47 are already queued. This folder records them. It does not re-land them as new SKUs.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/REF-remaining.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/REF-remaining.md
@@ -34,6 +34,8 @@ Miss. UNVERIFIED STOP. No catalog SKU on a page I opened.
 | Serpro | https://www.serpro.co.uk/37-5-x-23cm-Laboratory-Tray-Drip-Pan | Model TRAY18257. External 37.5 x 23 x 6 cm. 6 cm is 60 mm, outside 20-30 mm. Rejected. |
 | United Scientific LTRAY1 | https://www.unitedsci.com/laboratory-supplies/general-labware/laboratory-trays-flat-pp.html | 15 in x 11.5 in flat PP tray. Depth not printed as 20-30 mm. Not taken. |
 
+This pass also opened ENPAC 5248-YE. That page prints 3.25 in height (about 83 mm), outside 20-30 mm. Rejected.
+
 Miss on 20-30 mm. UNVERIFIED STOP.
 
 ## B16 drain plug plus insect baffle
@@ -50,7 +52,9 @@ Miss on the combined item. UNVERIFIED STOP. I did not stitch a plug SKU to a str
 
 Search returned Misumi HFS5-4040 as 40 mm x 40 mm. Direct DETAIL fetches of Misumi US pages were JS shells with no SKU body. 40 mm is not the 38 mm REF envelope.
 
-Miss. UNVERIFIED STOP. I did not substitute 40 mm for 38 mm.
+This pass also opened a factory 38-series listing (Shanghai Minjian / mjaluprofile) that describes 38 mm x 38 mm T-slot as a product family. No distributor orderable MPN on that page. Not taken.
+
+Miss. UNVERIFIED STOP. I did not substitute 40 mm for 38 mm. I did not invent a factory-listing SKU.
 
 ## B20, B21, B22, B23, B24, B28, B29, B30, B31, B32, B33, B34
 

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/REF-remaining.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/REF-remaining.md
@@ -1,0 +1,71 @@
+# Remaining REF balloons
+
+Printed-REF is not a skip. Hunt catalog SKUs if a live page prints a match. Miss = UNVERIFIED STOP. Do not invent print-file MPNs.
+
+Class: UNVERIFIED for every row.
+
+## Queries actually run
+
+1. Misumi HFS5-3840 38mm aluminum extrusion 38 mm width
+2. McMaster polypropylene drip tray 1 inch deep laboratory catalog
+3. 3/8 NPT nylon plug insect screen bulkhead
+4. McMaster bulkhead drain pipe fittings
+5. Laboratory tray drip pan 20-30 mm
+
+## B01, B02, B03, B04, B07
+
+PETG/ASA corner, 250 mm edge, splice block, cassette retainer, printed door labyrinth.
+
+Opened: none that printed a catalog MPN matching these printed solids.
+
+Miss. UNVERIFIED STOP. These stay in-house REF prints. I did not invent a Bambu/STL SKU.
+
+## B10, B12, B13, B14, B17
+
+Ceiling mesh frame, vent cassettes, perforated false bottom, perch socket.
+
+Miss. UNVERIFIED STOP. No catalog SKU on a page I opened.
+
+## B15 20-30 mm drain tray
+
+| source | URL | what printed |
+| --- | --- | --- |
+| McMaster drip trays index | https://www.mcmaster.com/products/drip-trays/ | Filter chrome. No SKU in the body I got. |
+| Serpro | https://www.serpro.co.uk/37-5-x-23cm-Laboratory-Tray-Drip-Pan | Model TRAY18257. External 37.5 x 23 x 6 cm. 6 cm is 60 mm, outside 20-30 mm. Rejected. |
+| United Scientific LTRAY1 | https://www.unitedsci.com/laboratory-supplies/general-labware/laboratory-trays-flat-pp.html | 15 in x 11.5 in flat PP tray. Depth not printed as 20-30 mm. Not taken. |
+
+Miss on 20-30 mm. UNVERIFIED STOP.
+
+## B16 drain plug plus insect baffle
+
+| source | URL | what printed |
+| --- | --- | --- |
+| U.S. Plastic | https://www.usplastic.com/catalog/item.aspx?itemid=33412 | 3/8 in NPT black nylon threaded plug. No insect baffle on that page. |
+| McMaster bulkheads | https://www.mcmaster.com/products/bulkhead-drain-pipe-fittings/ | Through-wall fittings. SKUs in a table (example 8671T21 nylon). No insect baffle combo. |
+| Premium Aquatics collection | https://premiumaquatics.com/collections/bulkheads-strainers-1 | Bulkheads and strainers as a category. I did not open a single SKU DETAIL that printed both drain plug and insect baffle. |
+
+Miss on the combined item. UNVERIFIED STOP. I did not stitch a plug SKU to a strainer SKU and call it B16.
+
+## B18 external 38 mm hybrid rail channel
+
+Search returned Misumi HFS5-4040 as 40 mm x 40 mm. Direct DETAIL fetches of Misumi US pages were JS shells with no SKU body. 40 mm is not the 38 mm REF envelope.
+
+Miss. UNVERIFIED STOP. I did not substitute 40 mm for 38 mm.
+
+## B20, B21, B22, B23, B24, B28, B29, B30, B31, B32, B33, B34
+
+Structural rail wall, junctions, carriage shell, pinch levers, contact carrier, latch shoe, binder housings, FPC clamp.
+
+Custom. No catalog SKU on a page I opened.
+
+Miss. UNVERIFIED STOP.
+
+## B51, B52
+
+Captive rail end stop with M3 service removal. External access-slot guard / labyrinth wiper.
+
+Miss. UNVERIFIED STOP. No fastener PN. No wiper SKU.
+
+## B09
+
+See `B09.md`. Catalog candidate Southco C2-32-15. Door fit REF.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/RETRY-B26-B40-B35.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/RETRY-B26-B40-B35.md
@@ -1,0 +1,19 @@
+# Retry B26 / B40 / B35
+
+Prior STOP. Retry only if a non-walled page prints a real SKU. B35 is not M1ENCLEA and not a random STL.
+
+Class: UNVERIFIED
+
+## Queries actually run
+
+No separate non-walled DETAIL page this hunt printed a roller SKU, a gasket-stock SKU with compression, or a Tachyon/M1 brick-mount SKU.
+
+B11 retry is in `B11.md`.
+
+## Verdict
+
+Keep STOP.
+
+- B26 polymer roller and axle: no SKU printed on a page I opened.
+- B40 gasket stock: no material/compression SKU printed.
+- B35 external Tachyon/M1 brick mount: not M1ENCLEA. No mount SKU. No STL invented.

--- a/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/RETRY-B26-B40-B35.md
+++ b/projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/RETRY-B26-B40-B35.md
@@ -6,7 +6,7 @@ Class: UNVERIFIED
 
 ## Queries actually run
 
-No separate non-walled DETAIL page this hunt printed a roller SKU, a gasket-stock SKU with compression, or a Tachyon/M1 brick-mount SKU.
+No separate non-walled DETAIL page this hunt printed a roller SKU, a gasket-stock SKU with compression, or a Tachyon/M1 brick-mount SKU. This pass did not open a new non-walled SKU for those three either.
 
 B11 retry is in `B11.md`.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Writer lane only. Hunt notes under `projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/parts-quest/**`. No procurement book. No tscircuit board. No orders. No PO. Class stays UNVERIFIED. Hold merge.

Already queued SKUs are named in `QUEUED.md` and were not re-landed.

## Roll-up

| balloon | MPN or UNVERIFIED | source URL |
| --- | --- | --- |
| B19 | UNVERIFIED STOP | https://www.molex.com/en-us/products/cable-assemblies/flat-flexible-cables-ffc |
| B37 | Arducam CB023 candidate | https://www.welectron.com/Arducam-CB023-150mm-22pin-to-22pin-camera-cable-05mm-Pitch-interface |
| B47 | UNVERIFIED STOP | https://www.rosenberger.com/product/rosenberger-hsd/ |
| B48 leftover supervisor | TPS3700 candidate | https://www.ti.com/product/TPS3700 |
| B48 leftover AND | CD4081B candidate | https://www.ti.com/product/CD4081B |
| B48 leftover discharge | TPS22810DBVR candidate | https://www.ti.com/product/TPS22810/part-details/TPS22810DBVR |
| B48 leftover isolation | CD4066B candidate (signals only) | https://www.ti.com/product/CD4066B |
| B50 | TE 776437-1 candidate | https://www.te.com/en/product-776437-1.html |
| B44 | UNVERIFIED STOP (0154002.DR still queued from Octopart line) | https://www.tme.eu/en/details/0154002.dr/smd-fuses-with-holder-ultra-fast/littelfuse/ |
| B09 | Southco C2-32-15 candidate | https://southco.com/en_us_int/c2-32-15 |
| B11 | UNVERIFIED STOP | https://www.ahh.biz/mesh/mesh_mosquito_netting_0_8_mm.php |
| B15 | UNVERIFIED STOP | https://www.serpro.co.uk/37-5-x-23cm-Laboratory-Tray-Drip-Pan |
| B16 | UNVERIFIED STOP | https://www.usplastic.com/catalog/item.aspx?itemid=33412 |
| B18 | UNVERIFIED STOP | search only: 40 mm is not 38 mm |
| B01-B04, B07, B10, B12-B14, B17, B20-B24, B28-B34, B51-B52 | UNVERIFIED STOP | no catalog DETAIL hit |
| B26, B40, B35 | STOP kept | no non-walled SKU this hunt |

Write-set did not grow outside `ee/tscircuit/parts-quest/**`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c2a61bb-737d-4cf1-acb3-01c26c382bb8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c2a61bb-737d-4cf1-acb3-01c26c382bb8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

