### PR TITLE
ci(mantis): run terrarium and procurement checks on lab-branch PRs

### DIFF
--- a/.github/workflows/mantis-procurement-ci.yml
+++ b/.github/workflows/mantis-procurement-ci.yml
@@ -1,0 +1,36 @@
+name: mantis-procurement-ci
+
+on:
+  pull_request:
+    paths:
+      - "projects/biomemetics/labs/mantis/procurement/**"
+      - ".github/workflows/mantis-procurement-ci.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: mantis-procurement-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  procurement:
+    name: procurement
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install, typecheck, and test
+        run: |
+          set -euo pipefail
+          dir="projects/biomemetics/labs/mantis/procurement"
+          if [ ! -f "$dir/package.json" ]; then
+            echo "$dir/package.json is not on this ref; skip"
+            exit 0
+          fi
+          cd "$dir"
+          npm install
+          npm run typecheck
+          npm test

--- a/.github/workflows/mantis-terrarium-ci.yml
+++ b/.github/workflows/mantis-terrarium-ci.yml
@@ -1,0 +1,60 @@
+name: mantis-terrarium-ci
+
+on:
+  pull_request:
+    paths:
+      - "projects/biomemetics/labs/mantis/terrarium/cad/jscad/**"
+      - "projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/**"
+      - ".github/workflows/mantis-terrarium-ci.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: mantis-terrarium-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  jscad:
+    name: jscad
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install, typecheck, and test
+        run: |
+          set -euo pipefail
+          dir="projects/biomemetics/labs/mantis/terrarium/cad/jscad"
+          if [ ! -f "$dir/package.json" ]; then
+            echo "$dir/package.json is not on this ref; skip"
+            exit 0
+          fi
+          cd "$dir"
+          npm install
+          npm run typecheck
+          npm test
+
+  tscircuit:
+    name: tscircuit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install, typecheck, and test
+        run: |
+          set -euo pipefail
+          dir="projects/biomemetics/labs/mantis/terrarium/ee/tscircuit"
+          if [ ! -f "$dir/package.json" ]; then
+            echo "$dir/package.json is not on this ref; skip"
+            exit 0
+          fi
+          cd "$dir"
+          npm install
+          npm run typecheck
+          npm test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Lab-branch drafts such as solids-coupon-generate (PR 112) and parts-book-hits (PR 108) target `feat/mantis-biomemetics-lab`. Existing specimendb CI only fires on `pull_request` to `master`/`main` when `packages/specimendb/**` changes, so those drafts show no checks.

These workflows copy the `mantis-lab.yml` trigger shape. `pull_request` uses path filters and has no `branches: [master]` gate. `workflow_dispatch` is also present. GitHub can run the jobs on PRs to the lab branch once this lands.

## Scope

Adds two files under `.github/workflows/` only.

- `mantis-terrarium-ci.yml` matches `projects/biomemetics/labs/mantis/terrarium/cad/jscad/**` and `projects/biomemetics/labs/mantis/terrarium/ee/tscircuit/**`. Jobs `jscad` and `tscircuit` run Node 22, `npm install`, `npm run typecheck`, and `npm test`. Does not run `generate` or `tsci build`.
- `mantis-procurement-ci.yml` matches `projects/biomemetics/labs/mantis/procurement/**`. Job `procurement` runs the same install / typecheck / test sequence from that `package.json`.

Each job skips with exit 0 when `package.json` is missing. Those trees are not on this starting ref. The YAML stays valid.

Does not edit terrarium CAD, tscircuit, or procurement source. Does not change PR 112. Does not deploy k3d.

## Tradeoffs

Jobs skip when the package is absent so this workflow-only PR does not fail `working-directory` on a missing tree. After merge, PR 112 and PR 108 merge commits include the packages, so the jobs run for real.

`npm install` is used as specified, not `npm ci`.

## Blast Radius

Reviewers of lab-branch PRs that touch those paths get a GitHub check. Other packages and `master`-gated workflows stay unchanged. Hold merge.

## Verification

- Parsed both workflow files with PyYAML. `pull_request` has path filters and no `branches` key. `workflow_dispatch` is present.
- Confirmed skip path locally. `package.json` is absent for jscad, tscircuit, and procurement on this ref.
- Read scripts from PR 112 HEAD `4c70d05791` (`typecheck`, `test`) and PR 108 (`typecheck`, `test`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2f53d7d-af90-4776-aa2d-3f255f9f95f1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2f53d7d-af90-4776-aa2d-3f255f9f95f1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

