### PR TITLE
ci(mantis): install bun before tscircuit tests

### DIFF
--- a/.github/workflows/mantis-terrarium-ci.yml
+++ b/.github/workflows/mantis-terrarium-ci.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           node-version: 22
 
+      - uses: oven-sh/setup-bun@v2
+
       - name: Install, typecheck, and test
         run: |
           set -euo pipefail


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`npx tsci build` in `tsci-build.test.ts` looks up bun with `/usr/bin/env`. The tscircuit job on `feat/mantis-biomemetics-lab` only ran `actions/setup-node@v4`, so GitHub Actions run [32868212732](https://github.com/creatifcoding/gbg/actions/runs/32868212732/job/97868617706) failed with `/usr/bin/env: 'bun': No such file or directory` and exit 127. Seven other tests and typecheck passed. jscad passed.

This PR puts bun on PATH in that job only. Merge stays held.

## Scope

`.github/workflows/mantis-terrarium-ci.yml` only.

In the `tscircuit` job, `oven-sh/setup-bun@v2` runs after `actions/setup-node@v4` and before the Install, typecheck, and test step. No `bun-version` pin. The action default is latest when `package.json` has no bun field.

The `jscad` job is unchanged. Procurement, CAD, and EE source are unchanged. PR 112 and PR 108 are untouched.

## Tradeoffs

Latest bun, not a numbered release. The action documents that default. Pinning a bun version here would be a guess.

## Blast Radius

Reviewers of this workflow, and later tscircuit CI on lab-branch PRs once this merges. Until then PR 112 stays red on that test. This PR's own Actions run skips tscircuit tests because `ee/tscircuit/package.json` is not on this ref.

## Verification

Failed repro is run 32868212732, job 97868617706, test `tsci build writes Circuit JSON without a selected MPN`.

YAML parse on this branch. tscircuit steps are checkout, setup-node, `oven-sh/setup-bun@v2`, then npm install, typecheck, and test. jscad steps have no setup-bun. Diff is two lines in one file.

I did not re-run PR 112.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07cec8bd-acdf-4fd9-8749-1e587cfab88f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07cec8bd-acdf-4fd9-8749-1e587cfab88f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

